### PR TITLE
fix: cap /mcp request body size

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -1,6 +1,7 @@
 """HTTP transport enhancements for the MCP server"""
 
 import asyncio
+import json
 import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -17,6 +18,8 @@ from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.monitoring import get_metrics_collector
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 from open_stocks_mcp.tools.session_manager import get_session_manager
+
+MAX_MCP_REQUEST_BODY_SIZE = 1024 * 1024  # 1 MiB
 
 
 class TimeoutMiddleware(BaseHTTPMiddleware):
@@ -234,9 +237,20 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
             # Get the request body
             body = await request.body()
 
-            # Parse the JSON-RPC request
-            import json
+            if len(body) > MAX_MCP_REQUEST_BODY_SIZE:
+                return Response(
+                    content=json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "error": {"code": -32700, "message": "Request body too large"},
+                            "id": None,
+                        }
+                    ).encode(),
+                    status_code=413,
+                    headers={"content-type": "application/json"},
+                )
 
+            # Parse the JSON-RPC request
             try:
                 json_request = json.loads(body.decode())
             except json.JSONDecodeError:
@@ -373,8 +387,6 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
 
         except Exception as e:
             logger.error(f"MCP endpoint error: {e}")
-            import json
-
             error_response = {
                 "jsonrpc": "2.0",
                 "error": {"code": -32603, "message": f"Internal error: {e!s}"},

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -123,6 +123,24 @@ class TestMCPIntegration:
         # Should get a method not allowed or proper response, not 404
         assert response.status_code != 404
 
+    @pytest.mark.anyio
+    async def test_mcp_endpoint_rejects_oversized_body(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """Test MCP endpoint rejects request bodies over the configured limit"""
+        oversized_payload = b"x" * ((1024 * 1024) + 1)
+        response = await http_client.post(
+            "/mcp",
+            content=oversized_payload,
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 413
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert data["id"] is None
+        assert data["error"]["code"] == -32700
+        assert "too large" in data["error"]["message"].lower()
+
 
 @pytest.mark.integration
 @pytest.mark.journey_system


### PR DESCRIPTION
Closes #3

## Changes
- add a 1 MiB request-body limit for POST /mcp
- return JSON-RPC error payload with HTTP 413 when the body exceeds the limit
- add an integration test that verifies oversized bodies are rejected

## Test plan
- uv run pytest tests/http_transport/test_http_server.py -k oversized_body -q
- uv run ruff check src/open_stocks_mcp/server/http_transport.py tests/http_transport/test_http_server.py