### PR TITLE
fix: propagate logout exceptions

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -116,7 +116,12 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
         # Cleanup session manager
         session_manager = get_session_manager()
         if session_manager is not None:
-            await session_manager.logout()
+            try:
+                await session_manager.logout()
+            except Exception:
+                logger.warning(
+                    "Logout failed during shutdown; session state already cleared"
+                )
 
     app = FastAPI(
         title="Open Stocks MCP Server",

--- a/src/open_stocks_mcp/tools/session_manager.py
+++ b/src/open_stocks_mcp/tools/session_manager.py
@@ -405,7 +405,12 @@ class SessionManager:
         return info
 
     async def logout(self) -> None:
-        """Logout and clear session."""
+        """Logout and clear session.
+
+        Robin Stocks logout failures are logged and re-raised so callers can
+        choose whether logout is best-effort or fail-hard. Local session state is
+        always cleared before this method returns or raises.
+        """
         async with self._lock:
             try:
                 loop = asyncio.get_event_loop()

--- a/src/open_stocks_mcp/tools/session_manager.py
+++ b/src/open_stocks_mcp/tools/session_manager.py
@@ -413,6 +413,7 @@ class SessionManager:
                 logger.info("Successfully logged out")
             except Exception as e:
                 logger.error(f"Error during logout: {e}")
+                raise
             finally:
                 self._is_authenticated = False
                 self.login_time = None

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
@@ -213,3 +214,22 @@ class TestSessionManagement:
         response = await http_client.post("/session/refresh")
         # Should either succeed or fail with auth error, not crash
         assert response.status_code in [200, 401, 500]
+
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
+    def test_lifespan_shutdown_suppresses_logout_failure(
+        self, mock_get_session_manager: Mock, mcp_server: FastMCP
+    ) -> None:
+        """Shutdown should remain best-effort when Robin Stocks logout fails."""
+        mock_session_manager = AsyncMock()
+        mock_session_manager.logout.side_effect = RuntimeError("logout failed")
+        mock_get_session_manager.return_value = mock_session_manager
+
+        app = create_http_server(mcp_server)
+
+        async def run_lifespan() -> None:
+            async with app.router.lifespan_context(app):
+                pass
+
+        asyncio.run(run_lifespan())
+
+        mock_session_manager.logout.assert_awaited_once()

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -1,0 +1,46 @@
+"""Unit tests for session manager behavior."""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from open_stocks_mcp.tools.session_manager import SessionManager
+
+
+def test_logout_clears_session_state() -> None:
+    """Logout should clear authentication state and timestamps."""
+    manager = SessionManager()
+    manager._is_authenticated = True
+    manager.login_time = datetime.now()
+    manager.last_successful_call = datetime.now()
+    manager._failed_login_attempts = 2
+
+    with patch("open_stocks_mcp.tools.session_manager.rh.logout"):
+        asyncio.run(manager.logout())
+
+    assert manager._is_authenticated is False
+    assert manager.login_time is None
+    assert manager.last_successful_call is None
+    assert manager._failed_login_attempts == 0
+
+
+def test_logout_reraises_exception_and_still_clears_state() -> None:
+    """Logout failures should propagate to callers while still clearing local state."""
+    manager = SessionManager()
+    manager._is_authenticated = True
+    manager.login_time = datetime.now()
+    manager.last_successful_call = datetime.now()
+    manager._failed_login_attempts = 1
+
+    with patch(
+        "open_stocks_mcp.tools.session_manager.rh.logout",
+        side_effect=RuntimeError("logout failure"),
+    ), pytest.raises(RuntimeError, match="logout failure"):
+        asyncio.run(manager.logout())
+
+    assert manager._is_authenticated is False
+    assert manager.login_time is None
+    assert manager.last_successful_call is None
+    assert manager._failed_login_attempts == 0


### PR DESCRIPTION
Closes #15

## Changes
- make SessionManager.logout() re-raise exceptions after logging
- preserve existing session-state cleanup in the finally block
- add unit tests covering normal logout and exception propagation paths

## Test plan
- uv run pytest tests/unit/test_session_manager.py -q
- uv run ruff check src/open_stocks_mcp/tools/session_manager.py tests/unit/test_session_manager.py
