### PR TITLE
fix: block auth retry on persistent cache-clear failures

### DIFF
--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -70,6 +70,13 @@ async def execute_with_retry(
                 )
 
             if isinstance(classified_error, AuthenticationError) and handle_auth_errors:
+                if session_manager.should_block_auth_retries():
+                    logger.critical(
+                        "Blocking authentication retry due to persistent session cache clear failures"
+                    )
+                    raise AuthenticationError(
+                        "Session cache clear failures prevent safe authentication retry"
+                    ) from e
                 if auth_retry_count < max_auth_retries:
                     logger.warning(
                         f"Authentication error detected, attempting re-authentication: {e}"

--- a/src/open_stocks_mcp/tools/session_manager.py
+++ b/src/open_stocks_mcp/tools/session_manager.py
@@ -30,6 +30,8 @@ class SessionManager:
         self._lock = asyncio.Lock()
         self._is_authenticated = False
         self._failed_login_attempts = 0
+        self._consecutive_pickle_clear_failures = 0
+        self._max_pickle_clear_failures = 3
 
     def set_credentials(self, username: str, password: str) -> None:
         """Store credentials for re-authentication.
@@ -97,13 +99,27 @@ class SessionManager:
             if pickle_path.exists():
                 pickle_path.unlink()
                 logger.info(f"Cleared pickle file: {pickle_path}")
+                self._consecutive_pickle_clear_failures = 0
                 return True
             else:
                 logger.debug(f"Pickle file does not exist: {pickle_path}")
+                self._consecutive_pickle_clear_failures = 0
                 return True
         except Exception as e:
+            self._consecutive_pickle_clear_failures += 1
             logger.error(f"Failed to clear pickle file: {e}")
+            if self._consecutive_pickle_clear_failures >= self._max_pickle_clear_failures:
+                logger.critical(
+                    "Session cache clear failed %s consecutive times; authentication retries will be blocked until cache clear succeeds",
+                    self._consecutive_pickle_clear_failures,
+                )
             return False
+
+    def should_block_auth_retries(self) -> bool:
+        """Return True when persistent pickle clear failures make auth retries unsafe."""
+        return (
+            self._consecutive_pickle_clear_failures >= self._max_pickle_clear_failures
+        )
 
     def _increment_failed_attempts(self) -> None:
         """Increment failed login attempts and clear pickle if threshold reached."""
@@ -433,6 +449,7 @@ class SessionManager:
                 self.last_successful_call = None
                 # Reset failed attempts on logout
                 self._failed_login_attempts = 0
+                self._consecutive_pickle_clear_failures = 0
 
     def clear_session_cache(self) -> bool:
         """Manually clear the Robin Stocks session cache (pickle file).

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,13 +1,17 @@
-"""Tests for configurable retry behavior."""
+"""Tests for configurable retry behavior and authentication error handling."""
 
 from collections.abc import Callable
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from open_stocks_mcp.tools import rate_limiter, retry
 from open_stocks_mcp.tools import session_manager as session_manager_module
-from open_stocks_mcp.tools.error_handling import NetworkError, execute_with_retry
+from open_stocks_mcp.tools.error_handling import (
+    AuthenticationError,
+    NetworkError,
+    execute_with_retry,
+)
 
 
 def _patch_retry_dependencies(
@@ -16,6 +20,7 @@ def _patch_retry_dependencies(
     session_manager = Mock()
     session_manager.update_last_successful_call = Mock()
     session_manager.refresh_session = Mock()
+    session_manager.should_block_auth_retries = Mock(return_value=False)
     monkeypatch.setattr(
         session_manager_module, "get_session_manager", lambda: session_manager
     )
@@ -90,3 +95,51 @@ async def test_execute_with_retry_explicit_arguments_override_config(
 
     assert len(attempts) == 1
     assert sleep_calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_blocks_auth_retry_when_pickle_clear_failures_persist() -> None:
+    """Auth retries should short-circuit when session cache clear keeps failing."""
+
+    def auth_fail() -> None:
+        raise Exception("authentication token expired")
+
+    mock_session_manager = MagicMock()
+    mock_session_manager.should_block_auth_retries.return_value = True
+    mock_session_manager.refresh_session = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.get_session_manager",
+            return_value=mock_session_manager,
+        ),
+        patch("open_stocks_mcp.tools.rate_limiter.get_rate_limiter", return_value=None),
+        pytest.raises(AuthenticationError, match="Session cache clear failures"),
+    ):
+        await execute_with_retry(auth_fail, max_retries=0)
+
+    mock_session_manager.refresh_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_attempts_reauth_when_not_blocked() -> None:
+    """Auth retries should still attempt reauth when not blocked."""
+
+    def auth_fail() -> None:
+        raise Exception("authentication token expired")
+
+    mock_session_manager = MagicMock()
+    mock_session_manager.should_block_auth_retries.return_value = False
+    mock_session_manager.refresh_session = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.get_session_manager",
+            return_value=mock_session_manager,
+        ),
+        patch("open_stocks_mcp.tools.rate_limiter.get_rate_limiter", return_value=None),
+        pytest.raises(AuthenticationError),
+    ):
+        await execute_with_retry(auth_fail, max_retries=0)
+
+    mock_session_manager.refresh_session.assert_awaited_once()


### PR DESCRIPTION
Closes #16

## Changes
- track consecutive Robinhood pickle-clear failures in `SessionManager` and emit `CRITICAL` once threshold is exceeded
- add `should_block_auth_retries()` guard to prevent unsafe re-auth loops when cache clear is persistently failing
- short-circuit `execute_with_retry` auth-retry path with structured `AuthenticationError` when blocker is active
- add focused unit coverage for blocked auth-retry and normal auth-refresh path

## Test plan
- uv run pytest -q tests/unit/test_error_handling.py
- uv run ruff check src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/session_manager.py tests/unit/test_error_handling.py
- uv run mypy src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/session_manager.py