### PR TITLE
fix: guard missing http transport singletons

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -19,6 +19,22 @@ from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 from open_stocks_mcp.tools.session_manager import get_session_manager
 
 
+def _require_session_manager() -> Any:
+    """Return session manager or raise 503 when unavailable."""
+    session_manager = get_session_manager()
+    if session_manager is None:
+        raise HTTPException(status_code=503, detail="Session manager unavailable")
+    return session_manager
+
+
+def _require_metrics_collector() -> Any:
+    """Return metrics collector or raise 503 when unavailable."""
+    metrics_collector = get_metrics_collector()
+    if metrics_collector is None:
+        raise HTTPException(status_code=503, detail="Metrics collector unavailable")
+    return metrics_collector
+
+
 class TimeoutMiddleware(BaseHTTPMiddleware):
     """Middleware to handle request timeouts"""
 
@@ -96,7 +112,8 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
         logger.info("Shutting down HTTP MCP server")
         # Cleanup session manager
         session_manager = get_session_manager()
-        await session_manager.logout()
+        if session_manager is not None:
+            await session_manager.logout()
 
     app = FastAPI(
         title="Open Stocks MCP Server",
@@ -122,10 +139,10 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
     async def health_check() -> dict[str, Any]:
         """Health check endpoint"""
         try:
-            metrics_collector = get_metrics_collector()
+            metrics_collector = _require_metrics_collector()
             health_status = await metrics_collector.get_health_status()
 
-            session_manager = get_session_manager()
+            session_manager = _require_session_manager()
             session_info = session_manager.get_session_info()
 
             return {
@@ -139,6 +156,8 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
                 },
                 "health": health_status,
             }
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Health check failed: {e}")
             raise HTTPException(status_code=503, detail="Service unhealthy") from e
@@ -147,13 +166,13 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
     async def server_status() -> dict[str, Any]:
         """Detailed server status endpoint"""
         try:
-            metrics_collector = get_metrics_collector()
+            metrics_collector = _require_metrics_collector()
             metrics = await metrics_collector.get_metrics()
 
             rate_limiter = get_rate_limiter()
             rate_stats = rate_limiter.get_stats()
 
-            session_manager = get_session_manager()
+            session_manager = _require_session_manager()
             session_info = session_manager.get_session_info()
 
             return {
@@ -167,6 +186,8 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
                 "rate_limiting": rate_stats,
                 "metrics": metrics,
             }
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Status check failed: {e}")
             raise HTTPException(status_code=500, detail="Status check failed") from e
@@ -197,7 +218,7 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
     async def refresh_session() -> dict[str, Any]:
         """Refresh authentication session"""
         try:
-            session_manager = get_session_manager()
+            session_manager = _require_session_manager()
             success = await session_manager.ensure_authenticated()
 
             if success:
@@ -205,6 +226,8 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
                 return {"status": "success", "session": session_info}
             else:
                 raise HTTPException(status_code=401, detail="Authentication failed")
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Session refresh failed: {e}")
             raise HTTPException(status_code=500, detail="Session refresh failed") from e

--- a/tests/http_transport/test_http_error_handling.py
+++ b/tests/http_transport/test_http_error_handling.py
@@ -128,6 +128,39 @@ class TestHTTPErrorHandling:
         data = response.json()
         assert "detail" in data
 
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
+    async def test_health_returns_503_when_session_manager_unavailable(
+        self, mock_get_session_manager: Mock, http_client: httpx.AsyncClient
+    ) -> None:
+        """Health check should return 503 when session manager singleton is unavailable."""
+        mock_get_session_manager.return_value = None
+
+        response = await http_client.get("/health")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Session manager unavailable"
+
+    @patch("open_stocks_mcp.server.http_transport.get_metrics_collector")
+    async def test_status_returns_503_when_metrics_collector_unavailable(
+        self, mock_get_metrics_collector: Mock, http_client: httpx.AsyncClient
+    ) -> None:
+        """Status should return 503 when metrics collector singleton is unavailable."""
+        mock_get_metrics_collector.return_value = None
+
+        response = await http_client.get("/status")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Metrics collector unavailable"
+
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
+    async def test_refresh_returns_503_when_session_manager_unavailable(
+        self, mock_get_session_manager: Mock, http_client: httpx.AsyncClient
+    ) -> None:
+        """Session refresh should return 503 when session manager singleton is unavailable."""
+        mock_get_session_manager.return_value = None
+
+        response = await http_client.post("/session/refresh")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Session manager unavailable"
+
 
 @pytest.mark.integration
 @pytest.mark.journey_system


### PR DESCRIPTION
Closes #17

## Changes
- Added explicit singleton guards in `http_transport.py` for missing session manager and metrics collector
- Return `503 Service Unavailable` with specific details when singleton dependencies are unavailable
- Preserved intentional `HTTPException` responses in `/health`, `/status`, and `/session/refresh` by re-raising them
- Added targeted regression tests for unavailable singleton scenarios
- Hardened lifespan shutdown to avoid dereferencing a missing session manager during logout

## Test plan
- `uv run --extra dev pytest -q tests/http_transport/test_http_error_handling.py -k "session_manager_unavailable or metrics_collector_unavailable"`
- `uv run --extra dev ruff check src/open_stocks_mcp/server/http_transport.py tests/http_transport/test_http_error_handling.py`

## Notes
- Existing unrelated tests in `tests/http_transport/test_http_auth.py` currently fail due stale version assertion (`0.6.4` vs `0.6.5`) and patch target mismatches for imported getters.
