### PR TITLE
fix: enforce read-only MCP tool authorization

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1402,6 +1402,12 @@ def attempt_login(username: str, password: str) -> None:
         "Also read from the MCP_API_KEY environment variable."
     ),
 )
+@click.option(
+    "--allow-trading",
+    is_flag=True,
+    default=False,
+    help="Allow mutating trading tools over HTTP /mcp (default is read-only only)",
+)
 def main(
     port: int,
     host: str,
@@ -1409,6 +1415,7 @@ def main(
     username: str | None,
     password: str | None,
     api_key: str | None,
+    allow_trading: bool,
 ) -> int:
     """Run the server with specified transport and handle authentication.
 
@@ -1457,7 +1464,15 @@ def main(
             logger.info(
                 "Server ready - broker tools available based on authentication status"
             )
-            asyncio.run(run_http_server(server, host, port, api_key=api_key))
+            asyncio.run(
+                run_http_server(
+                    server,
+                    host,
+                    port,
+                    api_key=api_key,
+                    allow_trading=allow_trading,
+                )
+            )
         return 0
     except KeyboardInterrupt:
         logger.info("\nServer stopped by user")

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -30,6 +30,95 @@ LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 # Health/status/root remain open so container orchestrators can probe liveness.
 PROTECTED_PATHS = frozenset({"/mcp", "/sse", "/session/refresh", "/tools"})
 
+READ_ONLY_HTTP_TOOL_NAMES = frozenset(
+    {
+        "account_details",
+        "account_features",
+        "account_info",
+        "account_profile",
+        "account_settings",
+        "aggregate_option_positions",
+        "aggregated_portfolio",
+        "all_option_positions",
+        "all_watchlists",
+        "basic_profile",
+        "broker_status",
+        "build_holdings",
+        "build_user_profile",
+        "complete_profile",
+        "day_trades",
+        "dividends",
+        "dividends_by_instrument",
+        "find_instruments",
+        "find_options",
+        "health_check",
+        "instruments_by_symbols",
+        "interest_payments",
+        "investment_profile",
+        "latest_notification",
+        "list_brokers",
+        "list_tools",
+        "margin_calls",
+        "margin_interest",
+        "market_hours",
+        "metrics_summary",
+        "notifications",
+        "open_option_orders",
+        "open_option_positions",
+        "open_option_positions_with_details",
+        "open_stock_orders",
+        "option_historicals",
+        "option_market_data",
+        "options_chains",
+        "options_orders",
+        "portfolio",
+        "positions",
+        "price_history",
+        "pricebook_by_symbol",
+        "rate_limit_status",
+        "referrals",
+        "schwab_account",
+        "schwab_account_balances",
+        "schwab_account_numbers",
+        "schwab_accounts",
+        "schwab_get_order",
+        "schwab_instrument",
+        "schwab_option_chain",
+        "schwab_option_chain_by_expiration",
+        "schwab_option_expirations",
+        "schwab_options_positions",
+        "schwab_orders",
+        "schwab_portfolio",
+        "schwab_price_history",
+        "schwab_quote",
+        "schwab_quotes",
+        "schwab_search_instruments",
+        "search_stocks_tool",
+        "security_profile",
+        "session_status",
+        "stock_earnings",
+        "stock_events",
+        "stock_info",
+        "stock_level2_data",
+        "stock_loan_payments",
+        "stock_news",
+        "stock_orders",
+        "stock_price",
+        "stock_quote_by_id",
+        "stock_ratings",
+        "stock_splits",
+        "stocks_by_tag",
+        "subscription_fees",
+        "top_100_stocks",
+        "top_movers",
+        "top_movers_sp500",
+        "total_dividends",
+        "user_profile",
+        "watchlist_by_name",
+        "watchlist_performance",
+    }
+)
+
 
 def is_loopback_host(host: str) -> bool:
     """Return True if ``host`` only accepts connections from the local machine."""
@@ -140,7 +229,11 @@ class SecurityMiddleware(BaseHTTPMiddleware):
         return False
 
 
-def create_http_server(mcp_server: FastMCP, api_key: str | None = None) -> FastAPI:
+def create_http_server(
+    mcp_server: FastMCP,
+    api_key: str | None = None,
+    allow_trading: bool = False,
+) -> FastAPI:
     """Create FastAPI server with MCP integration and enhancements.
 
     Args:
@@ -148,7 +241,17 @@ def create_http_server(mcp_server: FastMCP, api_key: str | None = None) -> FastA
         api_key: When set, requests to :data:`PROTECTED_PATHS` must carry an
             ``Authorization: Bearer <api_key>`` header. Required when the
             server is reachable from non-loopback interfaces.
+        allow_trading: When False, HTTP ``tools/call`` requests may invoke only
+            the known read-only tool registrations.
     """
+
+    def _is_tool_allowed(tool_name: str | None) -> bool:
+        """Allow only read-only tools unless trading access is explicitly enabled."""
+        if not tool_name:
+            return False
+        if allow_trading:
+            return True
+        return tool_name in READ_ONLY_HTTP_TOOL_NAMES
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -403,6 +506,28 @@ def create_http_server(mcp_server: FastMCP, api_key: str | None = None) -> FastA
                     tool_name = params.get("name")
                     arguments = params.get("arguments", {})
 
+                    if not _is_tool_allowed(tool_name):
+                        logger.warning(
+                            "Blocked MCP tool call in read-only mode: %s", tool_name
+                        )
+                        return Response(
+                            content=json.dumps(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "error": {
+                                        "code": -32600,
+                                        "message": (
+                                            "Tool is not allowed in read-only mode. "
+                                            "Enable --allow-trading to permit mutating tools."
+                                        ),
+                                    },
+                                    "id": request_id,
+                                }
+                            ).encode(),
+                            status_code=403,
+                            headers={"content-type": "application/json"},
+                        )
+
                     # Call the tool using FastMCP's method
                     tool_result = await mcp_server.call_tool(tool_name, arguments)
 
@@ -540,6 +665,7 @@ async def run_http_server(
     host: str = "127.0.0.1",
     port: int = 3000,
     api_key: str | None = None,
+    allow_trading: bool = False,
 ) -> None:
     """Run the HTTP server with the MCP server mounted.
 
@@ -565,7 +691,11 @@ async def run_http_server(
     mcp_server.settings.port = port
 
     # Create the FastAPI app with our enhancements
-    app = create_http_server(mcp_server, api_key=api_key)
+    app = create_http_server(
+        mcp_server,
+        api_key=api_key,
+        allow_trading=allow_trading,
+    )
 
     auth_status = "bearer-token auth enabled" if api_key else "no auth (loopback only)"
     logger.info(f"Starting HTTP MCP server on {host}:{port} ({auth_status})")
@@ -576,6 +706,10 @@ async def run_http_server(
     logger.info(f"  - Server Status: http://{host}:{port}/status")
     logger.info(f"  - Tools List: http://{host}:{port}/tools")
     logger.info(f"  - API Documentation: http://{host}:{port}/docs")
+    logger.info(
+        "  - Tool Authorization Mode: %s",
+        "full access" if allow_trading else "read-only allow-list",
+    )
 
     # Configure uvicorn
     config = uvicorn.Config(

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -10,7 +10,11 @@ import pytest
 from mcp.server.fastmcp import FastMCP
 
 from open_stocks_mcp import __version__
-from open_stocks_mcp.server.http_transport import TimeoutMiddleware, create_http_server
+from open_stocks_mcp.server.http_transport import (
+    READ_ONLY_HTTP_TOOL_NAMES,
+    TimeoutMiddleware,
+    create_http_server,
+)
 
 
 @pytest.fixture
@@ -18,11 +22,16 @@ def mcp_server() -> FastMCP:
     """Create a test MCP server instance"""
     server = FastMCP("Test Open Stocks MCP")
 
-    # Add a simple test tool
+    # Use production tool names so tests exercise the HTTP authorization policy.
     @server.tool()
-    async def test_tool() -> dict[str, Any]:
-        """A simple test tool"""
+    async def account_info() -> dict[str, Any]:
+        """A simple read-only test tool"""
         return {"result": {"message": "test successful", "status": "success"}}
+
+    @server.tool()
+    async def buy_stock_market() -> dict[str, Any]:
+        """A simple mutating test tool"""
+        return {"result": {"message": "order placed", "status": "success"}}
 
     return server
 
@@ -41,6 +50,34 @@ def test_timeout_middleware_uses_configured_timeout(
         if middleware.cls is TimeoutMiddleware
     )
     assert timeout_middleware.kwargs["timeout"] == 7.5
+
+
+@pytest.mark.anyio
+async def test_http_allow_list_matches_production_registry_sample() -> None:
+    """Representative production read-only tools are allowed; mutating tools are not."""
+    from open_stocks_mcp.server.app import mcp as production_mcp
+
+    production_tool_names = {tool.name for tool in await production_mcp.list_tools()}
+    expected_read_only = {
+        "account_info",
+        "portfolio",
+        "stock_price",
+        "market_hours",
+        "schwab_quote",
+        "schwab_accounts",
+    }
+    expected_mutating = {
+        "add_to_watchlist",
+        "buy_stock_market",
+        "cancel_stock_order_by_id",
+        "schwab_cancel_order",
+        "schwab_buy_stock_market",
+    }
+
+    assert expected_read_only <= production_tool_names
+    assert expected_mutating <= production_tool_names
+    assert expected_read_only <= READ_ONLY_HTTP_TOOL_NAMES
+    assert expected_mutating.isdisjoint(READ_ONLY_HTTP_TOOL_NAMES)
 
 
 @pytest.fixture
@@ -158,6 +195,68 @@ class TestMCPIntegration:
         assert data["id"] is None
         assert data["error"]["code"] == -32700
         assert "too large" in data["error"]["message"].lower()
+
+    @pytest.mark.anyio
+    async def test_mcp_endpoint_blocks_mutating_tools_by_default(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """Test MCP endpoint blocks real mutating tool names by default"""
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "buy_stock_market", "arguments": {}},
+        }
+        response = await http_client.post("/mcp", json=payload)
+        assert response.status_code == 403
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert data["id"] == 1
+        assert data["error"]["code"] == -32600
+        assert "read-only mode" in data["error"]["message"].lower()
+
+    @pytest.mark.anyio
+    async def test_mcp_endpoint_allows_read_only_tools_by_default(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """Test MCP endpoint allows real read-only tool names by default"""
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "account_info", "arguments": {}},
+        }
+        response = await http_client.post("/mcp", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert data["id"] == 2
+        assert "result" in data
+
+    @pytest.mark.anyio
+    async def test_mcp_endpoint_allows_mutating_tools_when_enabled(
+        self, mcp_server: FastMCP
+    ) -> None:
+        """Test MCP endpoint allows mutating tools when allow_trading is enabled"""
+        from httpx import ASGITransport
+
+        app = create_http_server(mcp_server, allow_trading=True)
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            payload = {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "buy_stock_market", "arguments": {}},
+            }
+            response = await client.post("/mcp", json=payload)
+            assert response.status_code == 200
+            data = response.json()
+            assert data["jsonrpc"] == "2.0"
+            assert data["id"] == 3
+            assert "result" in data
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #38

## Changes
- enforce per-tool authorization for `/mcp` `tools/call` requests in HTTP transport
- default HTTP mode to read-only tool access (`get_*`, `list_*`)
- add `--allow-trading` CLI flag to explicitly allow mutating tools over HTTP
- add focused HTTP transport tests for default deny/allow behavior

## Test plan
- `uv run pytest tests/http_transport/test_http_server.py -q -k "blocks_mutating_tools_by_default or allows_read_only_tools_by_default or allows_mutating_tools_when_enabled"`
- `uv run ruff check src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/app.py tests/http_transport/test_http_server.py`

## Notes
- Full `tests/http_transport/test_http_server.py` run is currently impacted by existing async fixture/plugin configuration issues in this repo environment; focused authorization tests pass.