### PR TITLE
fix: validate list_available_tools response before returning to HTTP clients

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -220,7 +220,12 @@ def create_http_server(mcp_server: FastMCP) -> FastAPI:
             from open_stocks_mcp.tools.robinhood_tools import list_available_tools
 
             tools = await list_available_tools(mcp_server)
+            if not isinstance(tools, dict) or "error" in tools or "result" not in tools:
+                logger.error("list_available_tools returned an unexpected or error response")
+                raise HTTPException(status_code=500, detail="Failed to list tools")
             return tools
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Failed to list tools: {e}")
             raise HTTPException(status_code=500, detail="Failed to list tools") from e

--- a/tests/http_transport/test_http_error_handling.py
+++ b/tests/http_transport/test_http_error_handling.py
@@ -309,6 +309,54 @@ class TestSecurityErrorHandling:
 
 @pytest.mark.integration
 @pytest.mark.journey_system
+class TestListToolsErrorHandling:
+    """Test /tools endpoint validates list_available_tools responses before returning to clients."""
+
+    @patch("open_stocks_mcp.tools.robinhood_tools.list_available_tools")
+    async def test_error_dict_not_passed_through(
+        self, mock_list_tools: AsyncMock, http_client: httpx.AsyncClient
+    ) -> None:
+        """Error dicts from list_available_tools must not be returned to HTTP clients."""
+        mock_list_tools.return_value = {
+            "error": "internal DB connection string: postgres://user:pass@host/db",
+            "status": "error",
+        }
+        response = await http_client.get("/tools")
+        assert response.status_code == 500
+        data = response.json()
+        assert "detail" in data
+        # Must not expose any internal error details to the client
+        assert "DB connection" not in data["detail"]
+        assert "postgres" not in data["detail"]
+
+    @patch("open_stocks_mcp.tools.robinhood_tools.list_available_tools")
+    async def test_missing_result_key_rejected(
+        self, mock_list_tools: AsyncMock, http_client: httpx.AsyncClient
+    ) -> None:
+        """Responses without expected 'result' key must be rejected."""
+        mock_list_tools.return_value = {"unexpected_key": []}
+        response = await http_client.get("/tools")
+        assert response.status_code == 500
+        data = response.json()
+        assert "detail" in data
+
+    @patch("open_stocks_mcp.tools.robinhood_tools.list_available_tools")
+    async def test_valid_response_returned(
+        self, mock_list_tools: AsyncMock, http_client: httpx.AsyncClient
+    ) -> None:
+        """Valid list_available_tools responses are returned as-is."""
+        mock_list_tools.return_value = {
+            "result": {"tools": [{"name": "get_stock_quote", "description": "Get quote"}], "count": 1}
+        }
+        response = await http_client.get("/tools")
+        assert response.status_code == 200
+        data = response.json()
+        assert "result" in data
+        assert data["result"]["count"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.journey_system
 class TestRecoveryMechanisms:
     """Test error recovery mechanisms"""
 


### PR DESCRIPTION
Closes #18

## Changes
- Added shape validation in the `/tools` endpoint after calling `list_available_tools`
- If the returned dict contains an `"error"` key or is missing the expected `"result"` key, the endpoint now raises `HTTPException(500, "Failed to list tools")` instead of passing the raw error structure to the client
- Added `except HTTPException: raise` guard so the validation path doesn't get swallowed by the outer exception handler
- Added 3 tests covering: error dict blocked, missing `result` key blocked, and valid response passed through

## Test plan
- `test_error_dict_not_passed_through`: mocks `list_available_tools` to return an error dict with internal detail; asserts HTTP 500 with no internal info in response
- `test_missing_result_key_rejected`: mocks return of a dict without `result` key; asserts HTTP 500
- `test_valid_response_returned`: mocks a well-formed response; asserts HTTP 200 and correct body

🤖 Generated with [Claude Code](https://claude.com/claude-code)