### PR TITLE
fix: remove unused cryptography dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "cachetools>=6.2.0",
     "requests>=2.32.0",
     "aiofiles>=25.1.0",
-    "cryptography>=46.0.0",
     "fastapi>=0.128.0",
     "uvicorn>=0.40.0",
     "sse-starlette>=3.1.0",
@@ -172,4 +171,3 @@ dev = [
 
 [tool.hatch.build.sources]
 "src" = ""
-


### PR DESCRIPTION
Closes #40

## Changes
- removed direct runtime dependency on cryptography>=46.0.0 from pyproject.toml
- left lockfile unchanged to avoid unrelated dependency churn

## Test plan
- uv run ruff check pyproject.toml src tests
- uv run pytest tests/unit/test_broker_base.py -k token_expired -q (fails in current env due pytest-async plugin/config mismatch)
- uv run mypy src/open_stocks_mcp (fails with existing import/type baseline issues unrelated to this change)
