### PR TITLE
fix: validate Schwab token_path boundary

### DIFF
--- a/src/open_stocks_mcp/brokers/schwab.py
+++ b/src/open_stocks_mcp/brokers/schwab.py
@@ -44,15 +44,18 @@ class SchwabBroker(BaseBroker):
         self.app_secret = app_secret
         self.callback_url = callback_url
 
+        token_dir = Path.home() / ".tokens"
+        token_dir.mkdir(parents=True, exist_ok=True)
+
         # Default token path
         if token_path is None:
-            token_dir = Path.home() / ".tokens"
-            token_dir.mkdir(exist_ok=True)
             self.token_path = str(token_dir / "schwab_token.json")
         else:
-            self.token_path = token_path
+            self.token_path = str(
+                self._validate_token_path(token_path=token_path, allowed_root=token_dir)
+            )
             # Ensure token directory exists
-            Path(token_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(self.token_path).parent.mkdir(parents=True, exist_ok=True)
 
         self.client = None
 
@@ -66,6 +69,21 @@ class SchwabBroker(BaseBroker):
             self._auth_info.requires_setup = True
         else:
             self._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
+
+    @staticmethod
+    def _validate_token_path(token_path: str, allowed_root: Path) -> Path:
+        """Validate token path is constrained to the allowed token root."""
+        resolved_token_path = Path(token_path).expanduser().resolve()
+        resolved_allowed_root = allowed_root.expanduser().resolve()
+
+        try:
+            resolved_token_path.relative_to(resolved_allowed_root)
+        except ValueError as exc:
+            raise ValueError(
+                f"token_path must be under {resolved_allowed_root}"
+            ) from exc
+
+        return resolved_token_path
 
     async def authenticate(self) -> bool:
         """Authenticate with Schwab using OAuth 2.0.

--- a/tests/unit/test_schwab_broker.py
+++ b/tests/unit/test_schwab_broker.py
@@ -15,11 +15,12 @@ class TestSchwabBroker:
     @pytest.fixture
     def schwab_broker(self) -> SchwabBroker:
         """Create a Schwab broker instance for testing."""
+        token_path = str(Path.home() / ".tokens" / "test_schwab_token.json")
         return SchwabBroker(
             api_key="test_api_key",
             app_secret="test_app_secret",
             callback_url="https://127.0.0.1:8182/",
-            token_path="/tmp/test_schwab_token.json",
+            token_path=token_path,
         )
 
     def test_broker_name(self, schwab_broker: SchwabBroker) -> None:
@@ -125,6 +126,25 @@ class TestSchwabBroker:
             Path(broker.token_path).expanduser().exists()
             or not Path(broker.token_path).expanduser().exists()
         )
+
+    def test_rejects_token_path_outside_tokens_dir(self, tmp_path: Path) -> None:
+        """Token path must remain inside ~/.tokens."""
+        with pytest.raises(ValueError, match="token_path must be under"):
+            SchwabBroker(
+                api_key="test",
+                app_secret="test",
+                token_path=str(tmp_path / "outside.json"),
+            )
+
+    def test_accepts_token_path_inside_tokens_dir(self) -> None:
+        """Token path under ~/.tokens is accepted."""
+        token_path = str(Path.home() / ".tokens" / "nested" / "token.json")
+        broker = SchwabBroker(
+            api_key="test",
+            app_secret="test",
+            token_path=token_path,
+        )
+        assert broker.token_path == token_path
 
     @pytest.mark.asyncio
     async def test_missing_credentials(self) -> None:


### PR DESCRIPTION
Closes #37

## Changes
- enforce that `SchwabBroker.token_path` resolves under `~/.tokens`
- raise `ValueError` for token paths outside the allowed root
- add unit coverage for accepted and rejected token path cases
- adjust existing Schwab broker fixture to use an allowed token path

## Test plan
- uv run pytest tests/unit/test_schwab_broker.py -k 'token_path or rejects_token_path or accepts_token_path' -q
- uv run ruff check src/open_stocks_mcp/brokers/schwab.py tests/unit/test_schwab_broker.py