### PR TITLE
refactor: decouple schwab tools from auth coordinator

### DIFF
--- a/src/open_stocks_mcp/tools/broker_utils.py
+++ b/src/open_stocks_mcp/tools/broker_utils.py
@@ -1,0 +1,14 @@
+"""Tool-layer broker helper utilities."""
+
+from typing import Any
+
+from open_stocks_mcp.brokers.registry import get_broker_registry
+
+
+async def get_authenticated_broker_or_error(
+    broker_name: str | None = None,
+    operation: str = "operation",
+) -> tuple[Any, dict[str, Any] | None]:
+    """Get an authenticated broker or return an error response tuple."""
+    registry = await get_broker_registry()
+    return registry.get_broker_or_error(broker_name, operation)

--- a/src/open_stocks_mcp/tools/schwab_account_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_account_tools.py
@@ -3,8 +3,8 @@
 import asyncio
 from typing import Any
 
-from open_stocks_mcp.brokers.auth_coordinator import get_authenticated_broker_or_error
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.broker_utils import get_authenticated_broker_or_error
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,

--- a/src/open_stocks_mcp/tools/schwab_market_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_market_tools.py
@@ -3,8 +3,8 @@
 import asyncio
 from typing import Any
 
-from open_stocks_mcp.brokers.auth_coordinator import get_authenticated_broker_or_error
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.broker_utils import get_authenticated_broker_or_error
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -4,8 +4,8 @@ import asyncio
 from datetime import date
 from typing import Any
 
-from open_stocks_mcp.brokers.auth_coordinator import get_authenticated_broker_or_error
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.broker_utils import get_authenticated_broker_or_error
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,

--- a/src/open_stocks_mcp/tools/schwab_trading_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_trading_tools.py
@@ -3,8 +3,8 @@
 import asyncio
 from typing import Any
 
-from open_stocks_mcp.brokers.auth_coordinator import get_authenticated_broker_or_error
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.broker_utils import get_authenticated_broker_or_error
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,

--- a/tests/unit/test_schwab_tool_layering.py
+++ b/tests/unit/test_schwab_tool_layering.py
@@ -1,0 +1,28 @@
+"""Architecture tests for Schwab tool layering boundaries."""
+
+import ast
+from pathlib import Path
+
+SCHWAB_TOOL_FILES = [
+    "schwab_account_tools.py",
+    "schwab_market_tools.py",
+    "schwab_options_tools.py",
+    "schwab_trading_tools.py",
+]
+
+
+def test_schwab_tools_do_not_import_auth_coordinator() -> None:
+    """Schwab tools must not import broker auth coordinator directly."""
+    tools_dir = Path("src/open_stocks_mcp/tools")
+
+    for filename in SCHWAB_TOOL_FILES:
+        path = tools_dir / filename
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == (
+                "open_stocks_mcp.brokers.auth_coordinator"
+            ):
+                raise AssertionError(
+                    f"{filename} imports from brokers.auth_coordinator"
+                )


### PR DESCRIPTION
Closes #10

## Changes
- add neutral tool-layer helper at src/open_stocks_mcp/tools/broker_utils.py for broker lookup
- switch Schwab tool modules to import get_authenticated_broker_or_error from tool layer instead of brokers.auth_coordinator
- add architecture guard test to prevent regression (tests/unit/test_schwab_tool_layering.py)

## Test plan
- /Users/wes/Development/Open Agent Tools/open-stocks-mcp/.venv/bin/python -m pytest -q tests/unit/test_schwab_tool_layering.py
- /Users/wes/Development/Open Agent Tools/open-stocks-mcp/.venv/bin/ruff check src/open_stocks_mcp/tools/broker_utils.py src/open_stocks_mcp/tools/schwab_account_tools.py src/open_stocks_mcp/tools/schwab_market_tools.py src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/tools/schwab_trading_tools.py tests/unit/test_schwab_tool_layering.py
