### PR TITLE
refactor: remove FastMCP type leak from tools layer

### DIFF
--- a/src/open_stocks_mcp/tools/robinhood_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_tools.py
@@ -2,17 +2,15 @@
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
-
 from open_stocks_mcp.logging_config import logger
 
 
-async def list_available_tools(mcp: FastMCP) -> dict[str, Any]:
+async def list_available_tools(mcp: Any) -> dict[str, Any]:
     """
     Provides a list of available tools and their descriptions.
 
     Args:
-        mcp: The FastMCP server instance.
+        mcp: The MCP server instance (must expose a list_tools() coroutine).
 
     Returns:
         A JSON object containing the list of tools in the result field.


### PR DESCRIPTION
Closes #12

## Changes
- Remove `from mcp.server.fastmcp import FastMCP` import from `tools/robinhood_tools.py`
- Replace `mcp: FastMCP` parameter annotation with `mcp: Any` in `list_available_tools`
- Update docstring to reflect protocol-style expectation rather than concrete type

## Test plan
- `mypy src/` passes with zero errors (type safety maintained)
- `ruff check` and `ruff format --check` pass (no lint regressions)
- `pytest tests/unit/test_stock_market_tools.py::TestStockMarketTools::test_list_available_tools_success` passes
- Full unit suite unaffected (pure type annotation change, no runtime behaviour change)