### PR TITLE
refactor: use RegistryNotInitializedError instead of RuntimeError in registry

### DIFF
--- a/src/open_stocks_mcp/brokers/registry.py
+++ b/src/open_stocks_mcp/brokers/registry.py
@@ -7,6 +7,11 @@ from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
 from open_stocks_mcp.logging_config import logger
 
 
+class RegistryNotInitializedError(LookupError):
+    """Raised when broker registry is accessed before initialization."""
+    pass
+
+
 class BrokerRegistry:
     """Manages multiple broker instances and their authentication status.
 
@@ -297,10 +302,10 @@ def get_broker_registry_sync() -> BrokerRegistry:
         Global BrokerRegistry instance
 
     Raises:
-        RuntimeError: If registry not initialized
+        RegistryNotInitializedError: If registry not initialized
     """
     if _registry is None:
-        raise RuntimeError(
+        raise RegistryNotInitializedError(
             "Broker registry not initialized. Call get_broker_registry() first."
         )
     return _registry

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1485,12 +1485,15 @@ def main(
     except KeyboardInterrupt:
         logger.info("\nServer stopped by user")
         # Logout all brokers
-        from open_stocks_mcp.brokers.registry import get_broker_registry_sync
+        from open_stocks_mcp.brokers.registry import (
+            RegistryNotInitializedError,
+            get_broker_registry_sync,
+        )
 
         try:
             registry = get_broker_registry_sync()
             asyncio.run(registry.logout_all())
-        except RuntimeError:
+        except RegistryNotInitializedError:
             # Registry not initialized - no brokers to logout
             pass
         return 0

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -5,7 +5,12 @@ from datetime import datetime
 import pytest
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
-from open_stocks_mcp.brokers.registry import BrokerRegistry, get_broker_registry
+from open_stocks_mcp.brokers.registry import (
+    BrokerRegistry,
+    RegistryNotInitializedError,
+    get_broker_registry,
+    get_broker_registry_sync,
+)
 
 
 class MockBroker(BaseBroker):
@@ -365,19 +370,18 @@ class TestBrokerRegistrySingleton:
         registry2 = await get_broker_registry()
         assert "persistent" in registry2.list_brokers()
         assert registry2.get_broker("persistent") is broker
+
     def test_get_broker_registry_sync_uninitialized(self):
         """Test get_broker_registry_sync raises RegistryNotInitializedError when uninitialized."""
-        from open_stocks_mcp.brokers.registry import get_broker_registry_sync, RegistryNotInitializedError, _registry
         import open_stocks_mcp.brokers.registry as registry_mod
-        
+
         # Ensure it's uninitialized for this test
         original_registry = registry_mod._registry
         registry_mod._registry = None
-        
+
         try:
             with pytest.raises(RegistryNotInitializedError):
                 get_broker_registry_sync()
         finally:
             # Restore original state
             registry_mod._registry = original_registry
-

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -365,3 +365,19 @@ class TestBrokerRegistrySingleton:
         registry2 = await get_broker_registry()
         assert "persistent" in registry2.list_brokers()
         assert registry2.get_broker("persistent") is broker
+    def test_get_broker_registry_sync_uninitialized(self):
+        """Test get_broker_registry_sync raises RegistryNotInitializedError when uninitialized."""
+        from open_stocks_mcp.brokers.registry import get_broker_registry_sync, RegistryNotInitializedError, _registry
+        import open_stocks_mcp.brokers.registry as registry_mod
+        
+        # Ensure it's uninitialized for this test
+        original_registry = registry_mod._registry
+        registry_mod._registry = None
+        
+        try:
+            with pytest.raises(RegistryNotInitializedError):
+                get_broker_registry_sync()
+        finally:
+            # Restore original state
+            registry_mod._registry = original_registry
+


### PR DESCRIPTION
Closes #19

## Changes
- Added `RegistryNotInitializedError` (inheriting from `LookupError`) to `src/open_stocks_mcp/brokers/registry.py`.
- Updated `get_broker_registry_sync()` to raise `RegistryNotInitializedError` instead of `RuntimeError`.
- Added unit test to verify the new exception is raised when accessed before initialization.

## Test plan
- Run `pytest tests/unit/test_broker_registry.py` to verify all tests pass, including the new `test_get_broker_registry_sync_uninitialized`.