### PR TITLE
refactor: extract system-tool bodies from server/app.py into tool_helpers.py

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -11,8 +11,15 @@ from mcp.server.fastmcp import FastMCP
 
 from open_stocks_mcp.config import ServerConfig, load_config
 from open_stocks_mcp.logging_config import logger, setup_logging
-from open_stocks_mcp.monitoring import get_metrics_collector
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
+from open_stocks_mcp.server.tool_helpers import (
+    get_broker_status_data,
+    get_health_check_data,
+    get_list_brokers_data,
+    get_list_tools_data,
+    get_metrics_summary_data,
+    get_rate_limit_status_data,
+    get_session_status_data,
+)
 from open_stocks_mcp.tools.robinhood_account_features_tools import (
     get_account_features,
     get_latest_notification,
@@ -79,7 +86,6 @@ from open_stocks_mcp.tools.robinhood_stock_tools import (
     get_stock_quote_by_id,
     search_stocks,
 )
-from open_stocks_mcp.tools.robinhood_tools import list_available_tools
 
 # Phase 7: Trading Capabilities Tools
 from open_stocks_mcp.tools.robinhood_trading_tools import (
@@ -163,7 +169,7 @@ mcp = FastMCP("Open Stocks MCP")
 @mcp.tool()
 async def list_tools() -> dict[str, Any]:
     """Provides a list of available tools and their descriptions."""
-    return await list_available_tools(mcp)
+    return await get_list_tools_data(mcp)
 
 
 @mcp.tool()
@@ -234,10 +240,7 @@ async def day_trades() -> dict[str, Any]:
 @mcp.tool()
 async def session_status() -> dict[str, Any]:
     """Gets current session status and authentication information."""
-    session_manager = get_session_manager()
-    session_info = session_manager.get_session_info()
-
-    return {"result": {**session_info, "status": "success"}}
+    return await get_session_status_data()
 
 
 @mcp.tool()
@@ -250,30 +253,7 @@ async def broker_status() -> dict[str, Any]:
     Returns:
         Dictionary with broker authentication status for each broker
     """
-    from open_stocks_mcp.brokers.registry import get_broker_registry
-
-    try:
-        registry = await get_broker_registry()
-        auth_status = registry.get_auth_status()
-        available_brokers = registry.get_available_brokers()
-
-        return {
-            "result": {
-                "brokers": auth_status,
-                "available_brokers": available_brokers,
-                "total_configured": len(registry.list_brokers()),
-                "total_authenticated": len(available_brokers),
-                "status": "success",
-            }
-        }
-    except Exception as e:
-        logger.error(f"Error getting broker status: {e}")
-        return {
-            "result": {
-                "error": str(e),
-                "status": "error",
-            }
-        }
+    return await get_broker_status_data()
 
 
 @mcp.tool()
@@ -283,69 +263,26 @@ async def list_brokers() -> dict[str, Any]:
     Returns:
         List of broker names and their authentication status
     """
-    from open_stocks_mcp.brokers.registry import get_broker_registry
-
-    try:
-        registry = await get_broker_registry()
-        brokers = registry.list_brokers()
-        available = registry.get_available_brokers()
-
-        broker_info = []
-        for broker_name in brokers:
-            broker = registry.get_broker(broker_name)
-            if broker:
-                broker_info.append(
-                    {
-                        "name": broker_name,
-                        "available": broker_name in available,
-                        "status": broker.auth_info.status.value,
-                        "configured": broker.is_configured(),
-                    }
-                )
-
-        return {
-            "result": {
-                "brokers": broker_info,
-                "count": len(brokers),
-                "status": "success",
-            }
-        }
-    except Exception as e:
-        logger.error(f"Error listing brokers: {e}")
-        return {
-            "result": {
-                "error": str(e),
-                "status": "error",
-            }
-        }
+    return await get_list_brokers_data()
 
 
 @mcp.tool()
 async def rate_limit_status() -> dict[str, Any]:
     """Gets current rate limit usage and statistics."""
-    rate_limiter = get_rate_limiter()
-    stats = rate_limiter.get_stats()
-
-    return {"result": {**stats, "status": "success"}}
+    return await get_rate_limit_status_data()
 
 
 # Monitoring Tools
 @mcp.tool()
 async def metrics_summary() -> dict[str, Any]:
     """Gets comprehensive metrics summary for monitoring."""
-    metrics_collector = get_metrics_collector()
-    metrics = await metrics_collector.get_metrics()
-
-    return {"result": {**metrics, "status": "success"}}
+    return await get_metrics_summary_data()
 
 
 @mcp.tool()
 async def health_check() -> dict[str, Any]:
     """Gets health status of the MCP server."""
-    metrics_collector = get_metrics_collector()
-    health_status = await metrics_collector.get_health_status()
-
-    return {"result": {**health_status, "status": "success"}}
+    return await get_health_check_data()
 
 
 # Market Data Tools

--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -1,0 +1,117 @@
+"""Helper functions implementing the bodies of server-app system tools.
+
+These helpers exist so `server/app.py` can stay focused on `@mcp.tool()`
+registration. Each helper returns the same `{"result": {...}}` shape its
+corresponding `@mcp.tool()` wrapper used to return inline.
+"""
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from open_stocks_mcp.brokers.registry import get_broker_registry
+from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.monitoring import get_metrics_collector
+from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
+from open_stocks_mcp.tools.robinhood_tools import list_available_tools
+from open_stocks_mcp.tools.session_manager import get_session_manager
+
+
+async def get_list_tools_data(mcp: FastMCP) -> dict[str, Any]:
+    """Return the list of tools registered on the given FastMCP server."""
+    return await list_available_tools(mcp)
+
+
+async def get_session_status_data() -> dict[str, Any]:
+    """Return current session status and authentication information."""
+    session_manager = get_session_manager()
+    session_info = session_manager.get_session_info()
+
+    return {"result": {**session_info, "status": "success"}}
+
+
+async def get_broker_status_data() -> dict[str, Any]:
+    """Return authentication status for all configured brokers."""
+    try:
+        registry = await get_broker_registry()
+        auth_status = registry.get_auth_status()
+        available_brokers = registry.get_available_brokers()
+
+        return {
+            "result": {
+                "brokers": auth_status,
+                "available_brokers": available_brokers,
+                "total_configured": len(registry.list_brokers()),
+                "total_authenticated": len(available_brokers),
+                "status": "success",
+            }
+        }
+    except Exception as e:
+        logger.error(f"Error getting broker status: {e}")
+        return {
+            "result": {
+                "error": str(e),
+                "status": "error",
+            }
+        }
+
+
+async def get_list_brokers_data() -> dict[str, Any]:
+    """Return all registered brokers and their availability."""
+    try:
+        registry = await get_broker_registry()
+        brokers = registry.list_brokers()
+        available = registry.get_available_brokers()
+
+        broker_info = []
+        for broker_name in brokers:
+            broker = registry.get_broker(broker_name)
+            if broker:
+                broker_info.append(
+                    {
+                        "name": broker_name,
+                        "available": broker_name in available,
+                        "status": broker.auth_info.status.value,
+                        "configured": broker.is_configured(),
+                    }
+                )
+
+        return {
+            "result": {
+                "brokers": broker_info,
+                "count": len(brokers),
+                "status": "success",
+            }
+        }
+    except Exception as e:
+        logger.error(f"Error listing brokers: {e}")
+        return {
+            "result": {
+                "error": str(e),
+                "status": "error",
+            }
+        }
+
+
+async def get_rate_limit_status_data() -> dict[str, Any]:
+    """Return current rate limit usage and statistics."""
+    rate_limiter = get_rate_limiter()
+    stats = rate_limiter.get_stats()
+
+    return {"result": {**stats, "status": "success"}}
+
+
+async def get_metrics_summary_data() -> dict[str, Any]:
+    """Return a comprehensive metrics summary for monitoring."""
+    metrics_collector = get_metrics_collector()
+    metrics = await metrics_collector.get_metrics()
+
+    return {"result": {**metrics, "status": "success"}}
+
+
+async def get_health_check_data() -> dict[str, Any]:
+    """Return health status of the MCP server."""
+    metrics_collector = get_metrics_collector()
+    health_status = await metrics_collector.get_health_status()
+
+    return {"result": {**health_status, "status": "success"}}

--- a/tests/server/test_tool_helpers.py
+++ b/tests/server/test_tool_helpers.py
@@ -1,0 +1,209 @@
+"""Tests for server.tool_helpers extracted system-tool helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from open_stocks_mcp.server.tool_helpers import (
+    get_broker_status_data,
+    get_health_check_data,
+    get_list_brokers_data,
+    get_list_tools_data,
+    get_metrics_summary_data,
+    get_rate_limit_status_data,
+    get_session_status_data,
+)
+
+
+@pytest.mark.journey_system
+class TestSessionStatusHelper:
+    """Tests for get_session_status_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_result_with_session_info(self) -> None:
+        fake_session_info = {"authenticated": True, "username": "test@example.com"}
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_session_manager"
+        ) as mock_get_sm:
+            sm = MagicMock()
+            sm.get_session_info.return_value = fake_session_info
+            mock_get_sm.return_value = sm
+
+            response = await get_session_status_data()
+
+        assert "result" in response
+        assert response["result"]["status"] == "success"
+        assert response["result"]["authenticated"] is True
+        assert response["result"]["username"] == "test@example.com"
+
+
+@pytest.mark.journey_system
+class TestBrokerStatusHelper:
+    """Tests for get_broker_status_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_broker_status_on_success(self) -> None:
+        fake_registry = MagicMock()
+        fake_registry.get_auth_status.return_value = {"robinhood": "authenticated"}
+        fake_registry.get_available_brokers.return_value = ["robinhood"]
+        fake_registry.list_brokers.return_value = ["robinhood"]
+
+        async def fake_get_registry() -> MagicMock:
+            return fake_registry
+
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_broker_registry",
+            side_effect=fake_get_registry,
+        ):
+            response = await get_broker_status_data()
+
+        assert response["result"]["status"] == "success"
+        assert response["result"]["brokers"] == {"robinhood": "authenticated"}
+        assert response["result"]["total_configured"] == 1
+        assert response["result"]["total_authenticated"] == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_registry_raises(self) -> None:
+        async def fake_get_registry() -> MagicMock:
+            raise RuntimeError("boom")
+
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_broker_registry",
+            side_effect=fake_get_registry,
+        ):
+            response = await get_broker_status_data()
+
+        assert response["result"]["status"] == "error"
+        assert response["result"]["error"] == "boom"
+
+
+@pytest.mark.journey_system
+class TestListBrokersHelper:
+    """Tests for get_list_brokers_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_broker_list_on_success(self) -> None:
+        fake_broker = MagicMock()
+        fake_broker.auth_info.status.value = "authenticated"
+        fake_broker.is_configured.return_value = True
+
+        fake_registry = MagicMock()
+        fake_registry.list_brokers.return_value = ["robinhood"]
+        fake_registry.get_available_brokers.return_value = ["robinhood"]
+        fake_registry.get_broker.return_value = fake_broker
+
+        async def fake_get_registry() -> MagicMock:
+            return fake_registry
+
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_broker_registry",
+            side_effect=fake_get_registry,
+        ):
+            response = await get_list_brokers_data()
+
+        assert response["result"]["status"] == "success"
+        assert response["result"]["count"] == 1
+        assert response["result"]["brokers"][0]["name"] == "robinhood"
+        assert response["result"]["brokers"][0]["available"] is True
+        assert response["result"]["brokers"][0]["status"] == "authenticated"
+        assert response["result"]["brokers"][0]["configured"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_registry_raises(self) -> None:
+        async def fake_get_registry() -> MagicMock:
+            raise RuntimeError("kaboom")
+
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_broker_registry",
+            side_effect=fake_get_registry,
+        ):
+            response = await get_list_brokers_data()
+
+        assert response["result"]["status"] == "error"
+        assert response["result"]["error"] == "kaboom"
+
+
+@pytest.mark.journey_system
+class TestRateLimitStatusHelper:
+    """Tests for get_rate_limit_status_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_rate_limiter_stats(self) -> None:
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_rate_limiter"
+        ) as mock_get_rl:
+            rl = MagicMock()
+            rl.get_stats.return_value = {"requests_made": 5, "limit": 100}
+            mock_get_rl.return_value = rl
+
+            response = await get_rate_limit_status_data()
+
+        assert response["result"]["status"] == "success"
+        assert response["result"]["requests_made"] == 5
+        assert response["result"]["limit"] == 100
+
+
+@pytest.mark.journey_system
+class TestMetricsSummaryHelper:
+    """Tests for get_metrics_summary_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_metrics(self) -> None:
+        fake_metrics = {"uptime": 123.4, "request_count": 42}
+
+        async def fake_get_metrics() -> dict:
+            return fake_metrics
+
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_metrics_collector"
+        ) as mock_get_mc:
+            mc = MagicMock()
+            mc.get_metrics.side_effect = fake_get_metrics
+            mock_get_mc.return_value = mc
+
+            response = await get_metrics_summary_data()
+
+        assert response["result"]["status"] == "success"
+        assert response["result"]["uptime"] == 123.4
+        assert response["result"]["request_count"] == 42
+
+
+@pytest.mark.journey_system
+class TestHealthCheckHelper:
+    """Tests for get_health_check_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_health_status(self) -> None:
+        fake_health = {"healthy": True, "checks": {"db": "ok"}}
+
+        async def fake_get_health() -> dict:
+            return fake_health
+
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_metrics_collector"
+        ) as mock_get_mc:
+            mc = MagicMock()
+            mc.get_health_status.side_effect = fake_get_health
+            mock_get_mc.return_value = mc
+
+            response = await get_health_check_data()
+
+        assert response["result"]["status"] == "success"
+        assert response["result"]["healthy"] is True
+        assert response["result"]["checks"] == {"db": "ok"}
+
+
+@pytest.mark.journey_system
+class TestListToolsHelper:
+    """Tests for get_list_tools_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_tool_list_for_fresh_server(self) -> None:
+        fresh_mcp = FastMCP("test-empty")
+
+        response = await get_list_tools_data(fresh_mcp)
+
+        assert "result" in response
+        assert response["result"]["count"] == 0
+        assert response["result"]["tools"] == []

--- a/tests/unit/test_analytics_tools.py
+++ b/tests/unit/test_analytics_tools.py
@@ -479,7 +479,7 @@ class TestStockLoanPayments:
 class TestServerMetrics:
     """Test server metrics and health check functionality."""
 
-    @patch("open_stocks_mcp.server.app.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -511,7 +511,7 @@ class TestServerMetrics:
         assert result["result"]["session_refreshes"] == 1
         assert result["result"]["status"] == "success"
 
-    @patch("open_stocks_mcp.server.app.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -540,7 +540,7 @@ class TestServerMetrics:
         assert result["result"]["metrics_summary"]["error_rate_percent"] == 1.5
         assert result["result"]["metrics_summary"]["avg_response_time_ms"] == 200.0
 
-    @patch("open_stocks_mcp.server.app.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -359,7 +359,7 @@ class TestServerTools:
 
     @pytest.mark.journey_system
     @pytest.mark.unit
-    @patch("open_stocks_mcp.server.app.get_session_manager")
+    @patch("open_stocks_mcp.server.tool_helpers.get_session_manager")
     @pytest.mark.asyncio
     async def test_session_status_success(self, mock_get_session_manager: Any) -> None:
         """Test successful session status retrieval."""
@@ -386,7 +386,7 @@ class TestServerTools:
 
     @pytest.mark.journey_system
     @pytest.mark.unit
-    @patch("open_stocks_mcp.server.app.get_rate_limiter")
+    @patch("open_stocks_mcp.server.tool_helpers.get_rate_limiter")
     @pytest.mark.asyncio
     async def test_rate_limit_status_success(self, mock_get_rate_limiter: Any) -> None:
         """Test successful rate limit status retrieval."""
@@ -414,7 +414,7 @@ class TestServerTools:
 
     @pytest.mark.journey_system
     @pytest.mark.unit
-    @patch("open_stocks_mcp.server.app.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
     @pytest.mark.asyncio
     async def test_metrics_summary_success(
         self, mock_get_metrics_collector: Any
@@ -444,7 +444,7 @@ class TestServerTools:
 
     @pytest.mark.journey_system
     @pytest.mark.unit
-    @patch("open_stocks_mcp.server.app.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
     @pytest.mark.asyncio
     async def test_health_check_success(self, mock_get_metrics_collector: Any) -> None:
         """Test successful health check."""
@@ -473,7 +473,7 @@ class TestServerTools:
 
     @pytest.mark.journey_system
     @pytest.mark.unit
-    @patch("open_stocks_mcp.server.app.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
     @pytest.mark.asyncio
     async def test_health_check_degraded(self, mock_get_metrics_collector: Any) -> None:
         """Test health check with degraded status."""


### PR DESCRIPTION
Closes #14

## Changes
- Add `src/open_stocks_mcp/server/tool_helpers.py` containing seven async helpers (`get_list_tools_data`, `get_session_status_data`, `get_broker_status_data`, `get_list_brokers_data`, `get_rate_limit_status_data`, `get_metrics_summary_data`, `get_health_check_data`) that implement the bodies of the corresponding system `@mcp.tool()` wrappers.
- Shrink the wrappers in `src/open_stocks_mcp/server/app.py` to single-statement delegates (`return await get_*_data(...)`), matching the existing `account_info()` → `get_account_info()` pattern.
- Move the `from open_stocks_mcp.brokers.registry import get_broker_registry` import from inside `broker_status` / `list_brokers` to the top of `tool_helpers.py`; drop the no-longer-used `get_metrics_collector`, `get_rate_limiter`, and `list_available_tools` imports from `app.py`.
- Add `tests/server/test_tool_helpers.py` covering each helper plus the explicit error paths for `get_broker_status_data` and `get_list_brokers_data`.
- Update existing tests in `tests/unit/test_stock_market_tools.py` and `tests/unit/test_analytics_tools.py` to patch `open_stocks_mcp.server.tool_helpers.<symbol>` (where the helpers now look those symbols up), preserving the same test intent.

## Test plan
- [x] `pytest tests/server/test_tool_helpers.py -x` — 9/9 pass
- [x] `pytest tests/server/ tests/unit/test_stock_market_tools.py tests/unit/test_analytics_tools.py -m "not slow and not exception_test"` — 50/50 pass (excluding the pre-existing-on-main `TestAttemptLogin::test_attempt_login_no_user_profile` failure, which is unrelated to this PR)
- [x] `ruff check src/open_stocks_mcp/server/ tests/server/` — clean
- [x] `mypy src/open_stocks_mcp/server/` — zero errors
- [x] `wc -l src/open_stocks_mcp/server/app.py` — 1461 lines (≈63 lines of extracted bodies removed from the wrappers)