### PR TITLE
feat: add cross-broker portfolio aggregation tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -20,6 +20,9 @@ from open_stocks_mcp.server.tool_helpers import (
     get_rate_limit_status_data,
     get_session_status_data,
 )
+
+# Cross-Broker Tools
+from open_stocks_mcp.tools.cross_broker_tools import get_aggregated_portfolio
 from open_stocks_mcp.tools.robinhood_account_features_tools import (
     get_account_features,
     get_latest_notification,
@@ -1033,6 +1036,22 @@ async def schwab_account_balances(account_hash: str) -> dict[str, Any]:
         account_hash: Account hash from schwab_account_numbers
     """
     return await get_schwab_account_balances(account_hash)
+
+
+# Cross-Broker Tools
+@mcp.tool()
+async def aggregated_portfolio() -> dict[str, Any]:
+    """Get a unified portfolio view aggregated across all registered brokers.
+
+    Combines positions and summary values from Robinhood and Schwab into a single
+    normalized response. Brokers that are not authenticated contribute a degraded
+    (status=unavailable) entry so partial information is always returned.
+
+    Returns:
+        Dict with aggregated totals, per-broker rollups, positions list,
+        partial_failure flag, and unavailable_brokers list.
+    """
+    return await get_aggregated_portfolio()
 
 
 # Schwab Market Data Tools

--- a/src/open_stocks_mcp/tools/cross_broker_tools.py
+++ b/src/open_stocks_mcp/tools/cross_broker_tools.py
@@ -1,0 +1,203 @@
+"""Cross-broker portfolio aggregation tools."""
+
+from typing import Any
+
+from open_stocks_mcp.brokers.registry import get_broker_registry
+from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.responses import create_success_response
+from open_stocks_mcp.tools.robinhood_account_tools import get_portfolio, get_positions
+from open_stocks_mcp.tools.schwab_account_tools import get_schwab_accounts
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    """Convert value to float, returning default on failure."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+async def _collect_robinhood_data(
+    broker_name: str,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Collect portfolio summary and positions from Robinhood.
+
+    Returns:
+        Tuple of (summary dict, positions list)
+    """
+    summary: dict[str, Any] = {}
+    positions: list[dict[str, Any]] = []
+
+    portfolio_result = await get_portfolio()
+    portfolio_data = portfolio_result.get("result", {})
+    if "error" not in portfolio_data:
+        summary["market_value"] = _safe_float(portfolio_data.get("market_value"))
+        summary["equity"] = _safe_float(portfolio_data.get("equity"))
+        summary["buying_power"] = _safe_float(portfolio_data.get("buying_power"))
+
+    positions_result = await get_positions()
+    positions_data = positions_result.get("result", {})
+    if "error" not in positions_data:
+        for pos in positions_data.get("positions", []):
+            positions.append(
+                {
+                    "symbol": pos.get("symbol"),
+                    "quantity": _safe_float(pos.get("quantity")),
+                    "average_buy_price": _safe_float(pos.get("average_buy_price")),
+                    "market_value": None,
+                    "broker": broker_name,
+                }
+            )
+
+    return summary, positions
+
+
+async def _collect_schwab_data(
+    broker_name: str,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Collect portfolio summary and positions from Schwab.
+
+    Returns:
+        Tuple of (summary dict, positions list)
+    """
+    summary: dict[str, Any] = {"market_value": 0.0, "equity": 0.0, "buying_power": 0.0}
+    positions: list[dict[str, Any]] = []
+
+    accounts_result = await get_schwab_accounts(include_positions=True)
+    accounts_data = accounts_result.get("result", {})
+    if "error" in accounts_data:
+        return summary, positions
+
+    total_market_value = 0.0
+    total_buying_power = 0.0
+
+    for account in accounts_data.get("accounts", []):
+        sec_account = account.get("securitiesAccount", {})
+        balances = sec_account.get("currentBalances", {})
+        total_market_value += _safe_float(balances.get("liquidationValue"))
+        total_buying_power += _safe_float(balances.get("buyingPower"))
+
+        for pos in sec_account.get("positions", []):
+            instrument = pos.get("instrument", {})
+            quantity = _safe_float(pos.get("longQuantity")) + _safe_float(
+                pos.get("shortQuantity")
+            )
+            positions.append(
+                {
+                    "symbol": instrument.get("symbol"),
+                    "quantity": quantity,
+                    "average_buy_price": _safe_float(pos.get("averagePrice")),
+                    "market_value": _safe_float(pos.get("marketValue")),
+                    "broker": broker_name,
+                }
+            )
+
+    summary["market_value"] = total_market_value
+    summary["equity"] = total_market_value
+    summary["buying_power"] = total_buying_power
+
+    return summary, positions
+
+
+async def get_aggregated_portfolio() -> dict[str, Any]:
+    """Aggregate portfolio data across all registered brokers.
+
+    Returns a normalized portfolio view combining positions and summary values
+    from all available brokers. Brokers that are not authenticated contribute
+    a degraded (status=unavailable) entry rather than failing the whole call.
+
+    Returns:
+        Dict with result containing:
+        - aggregated: combined totals and merged positions list
+        - brokers: per-broker rollup with status, summary, and positions
+        - partial_failure: True if any broker was unavailable
+        - unavailable_brokers: list of broker names that could not contribute
+    """
+    registry = await get_broker_registry()
+    broker_names = registry.list_brokers()
+
+    brokers_out: dict[str, Any] = {}
+    unavailable: list[str] = []
+    all_positions: list[dict[str, Any]] = []
+    total_market_value = 0.0
+    total_equity = 0.0
+    total_buying_power = 0.0
+
+    for name in broker_names:
+        broker = registry.get_broker(name)
+        if broker is None or not broker.is_available():
+            error_msg = None
+            if broker is not None:
+                error_msg = (
+                    broker.auth_info.error_message or broker.auth_info.status.value
+                )
+            brokers_out[name] = {
+                "status": "unavailable",
+                "error": error_msg,
+                "market_value": 0.0,
+                "equity": 0.0,
+                "buying_power": 0.0,
+                "positions": [],
+                "position_count": 0,
+            }
+            unavailable.append(name)
+            logger.warning(f"Broker {name} unavailable for aggregation: {error_msg}")
+            continue
+
+        try:
+            if name == "robinhood":
+                summary, positions = await _collect_robinhood_data(name)
+            elif name == "schwab":
+                summary, positions = await _collect_schwab_data(name)
+            else:
+                logger.warning(f"No aggregation collector for broker: {name}")
+                summary, positions = {}, []
+
+            market_value = summary.get("market_value", 0.0)
+            equity = summary.get("equity", 0.0)
+            buying_power = summary.get("buying_power", 0.0)
+
+            brokers_out[name] = {
+                "status": "available",
+                "error": None,
+                "market_value": market_value,
+                "equity": equity,
+                "buying_power": buying_power,
+                "positions": positions,
+                "position_count": len(positions),
+            }
+            all_positions.extend(positions)
+            total_market_value += market_value
+            total_equity += equity
+            total_buying_power += buying_power
+
+        except Exception as exc:
+            logger.error(
+                f"Error collecting data from broker {name}: {exc}", exc_info=True
+            )
+            brokers_out[name] = {
+                "status": "error",
+                "error": str(exc),
+                "market_value": 0.0,
+                "equity": 0.0,
+                "buying_power": 0.0,
+                "positions": [],
+                "position_count": 0,
+            }
+            unavailable.append(name)
+
+    return create_success_response(
+        {
+            "aggregated": {
+                "total_market_value": total_market_value,
+                "total_equity": total_equity,
+                "total_buying_power": total_buying_power,
+                "positions": all_positions,
+                "position_count": len(all_positions),
+            },
+            "brokers": brokers_out,
+            "partial_failure": len(unavailable) > 0,
+            "unavailable_brokers": unavailable,
+            "registered_brokers": broker_names,
+        }
+    )

--- a/tests/unit/test_cross_broker_tools.py
+++ b/tests/unit/test_cross_broker_tools.py
@@ -1,0 +1,536 @@
+"""Unit tests for cross-broker portfolio aggregation."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
+from open_stocks_mcp.tools.cross_broker_tools import get_aggregated_portfolio
+
+
+class MockBroker(BaseBroker):
+    """Mock broker for testing."""
+
+    def __init__(self, name: str, authenticated: bool = True):
+        super().__init__(name)
+        if authenticated:
+            self._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+        else:
+            self._auth_info.status = BrokerAuthStatus.AUTH_FAILED
+            self._auth_info.error_message = "Mock auth failed"
+
+    async def authenticate(self) -> bool:
+        return self._auth_info.status == BrokerAuthStatus.AUTHENTICATED
+
+    async def is_authenticated(self) -> bool:
+        return self._auth_info.status == BrokerAuthStatus.AUTHENTICATED
+
+    async def logout(self) -> None:
+        self._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
+
+    async def get_account_info(self):
+        return {"result": {"mock": "account"}}
+
+    async def get_portfolio(self):
+        return {"result": {"mock": "portfolio"}}
+
+    async def get_positions(self):
+        return {"result": {"mock": "positions"}}
+
+    async def get_stock_quote(self, symbol: str):
+        return {"result": {"price": 100}}
+
+    async def get_stock_price(self, symbol: str):
+        return {"result": {"price": 100}}
+
+    async def order_buy_market(self, symbol: str, quantity: float):
+        return {"result": {"order": "buy"}}
+
+    async def order_sell_market(self, symbol: str, quantity: float):
+        return {"result": {"order": "sell"}}
+
+
+class TestGetAggregatedPortfolio:
+    """Tests for cross-broker portfolio aggregation."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_both_brokers_available(self):
+        """Aggregation includes data from both brokers when both are authenticated."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+
+        rh_broker = MockBroker("robinhood", authenticated=True)
+        schwab_broker = MockBroker("schwab", authenticated=True)
+        mock_registry.get_broker.side_effect = lambda name: (
+            rh_broker if name == "robinhood" else schwab_broker
+        )
+
+        rh_portfolio = AsyncMock(
+            return_value={
+                "result": {
+                    "market_value": "10000.00",
+                    "equity": "9500.00",
+                    "buying_power": "3000.00",
+                    "status": "success",
+                }
+            }
+        )
+        rh_positions = AsyncMock(
+            return_value={
+                "result": {
+                    "positions": [
+                        {
+                            "symbol": "AAPL",
+                            "quantity": "10",
+                            "average_buy_price": "150.00",
+                        }
+                    ],
+                    "count": 1,
+                    "status": "success",
+                }
+            }
+        )
+        schwab_accounts = AsyncMock(
+            return_value={
+                "result": {
+                    "accounts": [
+                        {
+                            "securitiesAccount": {
+                                "currentBalances": {
+                                    "liquidationValue": 5000.0,
+                                    "buyingPower": 2000.0,
+                                },
+                                "positions": [
+                                    {
+                                        "instrument": {"symbol": "MSFT"},
+                                        "longQuantity": 5,
+                                        "averagePrice": 300.0,
+                                        "marketValue": 1750.0,
+                                    }
+                                ],
+                            }
+                        }
+                    ],
+                    "count": 1,
+                    "status": "success",
+                }
+            }
+        )
+
+        with (
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+                return_value=mock_registry,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
+                rh_portfolio,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
+                rh_positions,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
+                schwab_accounts,
+            ),
+        ):
+            result = await get_aggregated_portfolio()
+
+        assert "result" in result
+        data = result["result"]
+        assert data["status"] == "success"
+        assert "brokers" in data
+        assert "aggregated" in data
+        assert "robinhood" in data["brokers"]
+        assert "schwab" in data["brokers"]
+        assert data["brokers"]["robinhood"]["status"] == "available"
+        assert data["brokers"]["schwab"]["status"] == "available"
+        assert data["partial_failure"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_schwab_unavailable_returns_degraded_response(self):
+        """Aggregation returns degraded response when Schwab is not authenticated."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+
+        rh_broker = MockBroker("robinhood", authenticated=True)
+        schwab_broker = MockBroker("schwab", authenticated=False)
+        mock_registry.get_broker.side_effect = lambda name: (
+            rh_broker if name == "robinhood" else schwab_broker
+        )
+
+        rh_portfolio = AsyncMock(
+            return_value={
+                "result": {
+                    "market_value": "10000.00",
+                    "equity": "9500.00",
+                    "buying_power": "3000.00",
+                    "status": "success",
+                }
+            }
+        )
+        rh_positions = AsyncMock(
+            return_value={
+                "result": {
+                    "positions": [
+                        {
+                            "symbol": "AAPL",
+                            "quantity": "10",
+                            "average_buy_price": "150.00",
+                        }
+                    ],
+                    "count": 1,
+                    "status": "success",
+                }
+            }
+        )
+
+        with (
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+                return_value=mock_registry,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
+                rh_portfolio,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
+                rh_positions,
+            ),
+        ):
+            result = await get_aggregated_portfolio()
+
+        assert "result" in result
+        data = result["result"]
+        assert data["status"] == "success"
+        assert data["partial_failure"] is True
+        assert "schwab" in data["unavailable_brokers"]
+        assert data["brokers"]["robinhood"]["status"] == "available"
+        assert data["brokers"]["schwab"]["status"] == "unavailable"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_robinhood_unavailable_returns_degraded_response(self):
+        """Aggregation returns degraded response when Robinhood is not authenticated."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+
+        rh_broker = MockBroker("robinhood", authenticated=False)
+        schwab_broker = MockBroker("schwab", authenticated=True)
+        mock_registry.get_broker.side_effect = lambda name: (
+            rh_broker if name == "robinhood" else schwab_broker
+        )
+
+        schwab_accounts = AsyncMock(
+            return_value={
+                "result": {
+                    "accounts": [
+                        {
+                            "securitiesAccount": {
+                                "currentBalances": {
+                                    "liquidationValue": 5000.0,
+                                    "buyingPower": 2000.0,
+                                },
+                                "positions": [],
+                            }
+                        }
+                    ],
+                    "count": 1,
+                    "status": "success",
+                }
+            }
+        )
+
+        with (
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+                return_value=mock_registry,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
+                schwab_accounts,
+            ),
+        ):
+            result = await get_aggregated_portfolio()
+
+        assert "result" in result
+        data = result["result"]
+        assert data["status"] == "success"
+        assert data["partial_failure"] is True
+        assert "robinhood" in data["unavailable_brokers"]
+        assert data["brokers"]["robinhood"]["status"] == "unavailable"
+        assert data["brokers"]["schwab"]["status"] == "available"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_both_brokers_unavailable(self):
+        """Aggregation returns degraded response when all brokers are unavailable."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+
+        rh_broker = MockBroker("robinhood", authenticated=False)
+        schwab_broker = MockBroker("schwab", authenticated=False)
+        mock_registry.get_broker.side_effect = lambda name: (
+            rh_broker if name == "robinhood" else schwab_broker
+        )
+
+        with patch(
+            "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+            return_value=mock_registry,
+        ):
+            result = await get_aggregated_portfolio()
+
+        assert "result" in result
+        data = result["result"]
+        assert data["status"] == "success"
+        assert data["partial_failure"] is True
+        assert set(data["unavailable_brokers"]) == {"robinhood", "schwab"}
+        assert data["brokers"]["robinhood"]["status"] == "unavailable"
+        assert data["brokers"]["schwab"]["status"] == "unavailable"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_aggregated_totals_sum_both_brokers(self):
+        """Aggregated totals correctly sum values from both brokers."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+
+        rh_broker = MockBroker("robinhood", authenticated=True)
+        schwab_broker = MockBroker("schwab", authenticated=True)
+        mock_registry.get_broker.side_effect = lambda name: (
+            rh_broker if name == "robinhood" else schwab_broker
+        )
+
+        rh_portfolio = AsyncMock(
+            return_value={
+                "result": {
+                    "market_value": "10000.00",
+                    "equity": "9500.00",
+                    "buying_power": "3000.00",
+                    "status": "success",
+                }
+            }
+        )
+        rh_positions = AsyncMock(
+            return_value={"result": {"positions": [], "count": 0, "status": "success"}}
+        )
+        schwab_accounts = AsyncMock(
+            return_value={
+                "result": {
+                    "accounts": [
+                        {
+                            "securitiesAccount": {
+                                "currentBalances": {
+                                    "liquidationValue": 5000.0,
+                                    "buyingPower": 2000.0,
+                                },
+                                "positions": [],
+                            }
+                        }
+                    ],
+                    "count": 1,
+                    "status": "success",
+                }
+            }
+        )
+
+        with (
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+                return_value=mock_registry,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
+                rh_portfolio,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
+                rh_positions,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
+                schwab_accounts,
+            ),
+        ):
+            result = await get_aggregated_portfolio()
+
+        data = result["result"]
+        aggregated = data["aggregated"]
+
+        # RH: market_value=10000, buying_power=3000; Schwab: market_value=5000, buying_power=2000
+        assert aggregated["total_market_value"] == pytest.approx(15000.0)
+        assert aggregated["total_buying_power"] == pytest.approx(5000.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_positions_merged_from_both_brokers(self):
+        """Aggregated positions list includes entries from both brokers."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+
+        rh_broker = MockBroker("robinhood", authenticated=True)
+        schwab_broker = MockBroker("schwab", authenticated=True)
+        mock_registry.get_broker.side_effect = lambda name: (
+            rh_broker if name == "robinhood" else schwab_broker
+        )
+
+        rh_portfolio = AsyncMock(
+            return_value={
+                "result": {
+                    "market_value": "10000.00",
+                    "equity": "9500.00",
+                    "buying_power": "3000.00",
+                    "status": "success",
+                }
+            }
+        )
+        rh_positions = AsyncMock(
+            return_value={
+                "result": {
+                    "positions": [
+                        {
+                            "symbol": "AAPL",
+                            "quantity": "10",
+                            "average_buy_price": "150.00",
+                        }
+                    ],
+                    "count": 1,
+                    "status": "success",
+                }
+            }
+        )
+        schwab_accounts = AsyncMock(
+            return_value={
+                "result": {
+                    "accounts": [
+                        {
+                            "securitiesAccount": {
+                                "currentBalances": {
+                                    "liquidationValue": 5000.0,
+                                    "buyingPower": 2000.0,
+                                },
+                                "positions": [
+                                    {
+                                        "instrument": {"symbol": "MSFT"},
+                                        "longQuantity": 5,
+                                        "averagePrice": 300.0,
+                                        "marketValue": 1750.0,
+                                    }
+                                ],
+                            }
+                        }
+                    ],
+                    "count": 1,
+                    "status": "success",
+                }
+            }
+        )
+
+        with (
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+                return_value=mock_registry,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
+                rh_portfolio,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
+                rh_positions,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
+                schwab_accounts,
+            ),
+        ):
+            result = await get_aggregated_portfolio()
+
+        data = result["result"]
+        symbols = {p["symbol"] for p in data["aggregated"]["positions"]}
+        assert "AAPL" in symbols
+        assert "MSFT" in symbols
+
+        # Each position tagged with source broker
+        for pos in data["aggregated"]["positions"]:
+            assert "broker" in pos
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_broker_status_includes_auth_error_message(self):
+        """Unavailable broker entry includes the auth error reason."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+
+        rh_broker = MockBroker("robinhood", authenticated=True)
+        schwab_broker = MockBroker("schwab", authenticated=False)
+        mock_registry.get_broker.side_effect = lambda name: (
+            rh_broker if name == "robinhood" else schwab_broker
+        )
+
+        rh_portfolio = AsyncMock(
+            return_value={
+                "result": {
+                    "market_value": "10000.00",
+                    "equity": "9500.00",
+                    "buying_power": "3000.00",
+                    "status": "success",
+                }
+            }
+        )
+        rh_positions = AsyncMock(
+            return_value={"result": {"positions": [], "count": 0, "status": "success"}}
+        )
+
+        with (
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+                return_value=mock_registry,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
+                rh_portfolio,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
+                rh_positions,
+            ),
+        ):
+            result = await get_aggregated_portfolio()
+
+        schwab_entry = result["result"]["brokers"]["schwab"]
+        assert "error" in schwab_entry
+        assert schwab_entry["error"] is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_no_brokers_registered(self):
+        """Empty registry returns empty aggregation without error."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = []
+
+        with patch(
+            "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+            return_value=mock_registry,
+        ):
+            result = await get_aggregated_portfolio()
+
+        assert "result" in result
+        data = result["result"]
+        assert data["status"] == "success"
+        assert data["aggregated"]["total_market_value"] == 0.0
+        assert data["aggregated"]["positions"] == []
+        assert data["partial_failure"] is False


### PR DESCRIPTION
Closes #114

## Changes
- Add `src/open_stocks_mcp/tools/cross_broker_tools.py` with `get_aggregated_portfolio()` — collects portfolio summary (market value, equity, buying power) and positions from Robinhood and Schwab, merges them into a normalized response
- Register `aggregated_portfolio` MCP tool in `src/open_stocks_mcp/server/app.py`
- Add 8 unit tests in `tests/unit/test_cross_broker_tools.py` covering: both brokers available, each broker individually unavailable, both unavailable, aggregated totals summation, position merging with broker tagging, auth error surface, and empty registry

## Partial-failure behaviour
Brokers that are not authenticated contribute an `"unavailable"` entry with an error reason rather than failing the whole call. `partial_failure: true` and `unavailable_brokers` list are always present in the response for downstream consumers.

## Test plan
- `uv run pytest tests/unit/test_cross_broker_tools.py -v` — 8 passed
- `uv run mypy src/open_stocks_mcp/tools/cross_broker_tools.py --ignore-missing-imports` — no issues
- `uv run ruff check src/open_stocks_mcp/tools/cross_broker_tools.py` — no issues