### PR TITLE
feat: add test marker taxonomy and default exclusion filter

### DIFF
--- a/docs/TEST_MARKERS.md
+++ b/docs/TEST_MARKERS.md
@@ -1,0 +1,121 @@
+# Test Marker Taxonomy
+
+Pytest markers used in this project to categorize and filter tests.
+
+## Marker Definitions
+
+### Exclusion Categories (excluded by default)
+
+| Marker | Purpose | When to use |
+|--------|---------|-------------|
+| `rate_limited` | Tests that call live broker APIs and may trigger rate limiting | Any test making real API calls to Robinhood or Schwab |
+| `live_market` | Tests that require an active market connection or real-time data | Tests verifying live quote feeds, streaming data, or market-hours-sensitive logic |
+| `performance` | Benchmark and throughput tests | Tests measuring latency, throughput, or resource usage |
+
+These three markers are excluded from the **default** `pytest` invocation via `addopts` in `pyproject.toml`. Running `pytest` without arguments will never collect tests with these markers.
+
+### Opt-In Categories
+
+| Marker | Purpose |
+|--------|---------|
+| `auth_required` | Tests that require valid broker credentials in env vars |
+| `integration` | Tests that exercise multiple real components together |
+| `slow` | Tests that take more than ~5 seconds |
+| `exception_test` | Error/edge-case paths, often verbose |
+| `login_flow` | Full credential-round-trip tests |
+| `agent_evaluation` | ADK agent evaluation harness tests |
+
+### Unit / Journey Categories
+
+| Marker | Purpose |
+|--------|---------|
+| `unit` | Fast, isolated, no network |
+| `journey_account` | Account management flows |
+| `journey_portfolio` | Portfolio and positions |
+| `journey_market_data` | Stock quotes and market info |
+| `journey_research` | Earnings, ratings, news |
+| `journey_watchlists` | Watchlist CRUD |
+| `journey_options` | Options chains and positions |
+| `journey_notifications` | Alerts and margin calls |
+| `journey_system` | Health checks and metrics |
+| `journey_advanced_data` | Level II and premium data |
+| `journey_market_intelligence` | Movers and trending stocks |
+| `journey_trading` | Buy/sell order workflows |
+
+---
+
+## Default Behavior
+
+Running `pytest` with no arguments applies:
+
+```
+not rate_limited and not live_market and not performance
+```
+
+This ensures the default test suite is safe for CI and local development without broker credentials.
+
+---
+
+## CI-Safe Invocation Paths
+
+### Local development — fast feedback loop
+```bash
+pytest                             # default: excludes rate_limited, live_market, performance
+pytest -m unit                     # only unit tests
+pytest tests/unit/                 # all unit tests by directory
+pytest -m "not slow and not exception_test"  # skip slow/noisy tests
+```
+
+### CI pipeline — safe default
+```bash
+uv run pytest -m 'not rate_limited and not live_market and not performance'
+uv run ruff check src tests
+```
+
+### Full suite — requires credentials
+```bash
+# Set ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD first
+pytest -m ""                       # override addopts, run everything
+pytest -m "rate_limited"           # only rate-limited tests
+pytest -m "live_market"            # only live-market tests
+pytest -m "auth_required"          # only auth-required tests
+```
+
+### Journey-based runs (no credentials needed)
+```bash
+pytest -m "journey_account or journey_portfolio"
+pytest -m "journey_market_data or journey_research"
+pytest -m "journey_account or journey_portfolio or journey_market_data or journey_research or journey_notifications or journey_system"  # read-only journeys
+```
+
+---
+
+## Applying Markers to New Tests
+
+```python
+import pytest
+
+@pytest.mark.rate_limited
+def test_my_api_call():
+    """Hits live broker API — excluded from default runs."""
+    ...
+
+@pytest.mark.live_market
+def test_live_quote():
+    """Requires active market feed."""
+    ...
+
+@pytest.mark.performance
+def test_throughput():
+    """Measures request throughput — run manually."""
+    ...
+```
+
+Multiple markers can be stacked:
+
+```python
+@pytest.mark.rate_limited
+@pytest.mark.auth_required
+def test_live_order():
+    ...
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,8 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "--verbose",
+    "-m",
+    "not rate_limited and not live_market and not performance",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -1,7 +1,7 @@
 """Robinhood broker implementation using existing robin-stocks integration."""
 
 from datetime import datetime
-from typing import Any, cast
+from typing import Any
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
 from open_stocks_mcp.logging_config import logger

--- a/tests/unit/test_marker_infrastructure.py
+++ b/tests/unit/test_marker_infrastructure.py
@@ -1,0 +1,135 @@
+"""Validation tests for Phase 8 test marker infrastructure."""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+PYPROJECT = Path(__file__).parent.parent.parent / "pyproject.toml"
+REQUIRED_MARKERS = {"rate_limited", "live_market", "performance", "auth_required"}
+DEFAULT_EXCLUDED = {"rate_limited", "live_market", "performance"}
+
+
+def _load_pytest_config() -> dict:
+    with open(PYPROJECT, "rb") as fh:
+        return tomllib.load(fh)["tool"]["pytest"]["ini_options"]
+
+
+# ---------------------------------------------------------------------------
+# Marker registration
+# ---------------------------------------------------------------------------
+
+
+def test_required_markers_registered():
+    cfg = _load_pytest_config()
+    registered = {m.split(":")[0].strip() for m in cfg["markers"]}
+    missing = REQUIRED_MARKERS - registered
+    assert not missing, f"Markers not registered in pyproject.toml: {missing}"
+
+
+def test_rate_limited_marker_description():
+    cfg = _load_pytest_config()
+    rate_limited = next(m for m in cfg["markers"] if m.startswith("rate_limited"))
+    assert "rate limit" in rate_limited.lower()
+
+
+def test_live_market_marker_description():
+    cfg = _load_pytest_config()
+    live_market = next(m for m in cfg["markers"] if m.startswith("live_market"))
+    assert "live" in live_market.lower() or "market" in live_market.lower()
+
+
+def test_performance_marker_description():
+    cfg = _load_pytest_config()
+    perf = next(m for m in cfg["markers"] if m.startswith("performance"))
+    assert "performance" in perf.lower() or "benchmark" in perf.lower()
+
+
+def test_auth_required_marker_description():
+    cfg = _load_pytest_config()
+    auth = next(m for m in cfg["markers"] if m.startswith("auth_required"))
+    assert "auth" in auth.lower()
+
+
+# ---------------------------------------------------------------------------
+# Default addopts exclusions
+# ---------------------------------------------------------------------------
+
+
+def test_addopts_excludes_rate_limited():
+    cfg = _load_pytest_config()
+    addopts = cfg.get("addopts", [])
+    addopts_str = " ".join(addopts) if isinstance(addopts, list) else str(addopts)
+    assert "not rate_limited" in addopts_str, (
+        "addopts must exclude rate_limited tests by default"
+    )
+
+
+def test_addopts_excludes_live_market():
+    cfg = _load_pytest_config()
+    addopts = cfg.get("addopts", [])
+    addopts_str = " ".join(addopts) if isinstance(addopts, list) else str(addopts)
+    assert "not live_market" in addopts_str, (
+        "addopts must exclude live_market tests by default"
+    )
+
+
+def test_addopts_excludes_performance():
+    cfg = _load_pytest_config()
+    addopts = cfg.get("addopts", [])
+    addopts_str = " ".join(addopts) if isinstance(addopts, list) else str(addopts)
+    assert "not performance" in addopts_str, (
+        "addopts must exclude performance tests by default"
+    )
+
+
+def test_addopts_has_strict_markers():
+    cfg = _load_pytest_config()
+    addopts = cfg.get("addopts", [])
+    addopts_str = " ".join(addopts) if isinstance(addopts, list) else str(addopts)
+    assert "--strict-markers" in addopts_str
+
+
+# ---------------------------------------------------------------------------
+# Marker taxonomy completeness
+# ---------------------------------------------------------------------------
+
+
+def test_all_default_excluded_markers_have_descriptions():
+    cfg = _load_pytest_config()
+    registered = {m.split(":")[0].strip(): m for m in cfg["markers"]}
+    for marker in DEFAULT_EXCLUDED:
+        assert marker in registered, f"Marker '{marker}' missing from registry"
+        assert ":" in registered[marker], (
+            f"Marker '{marker}' must have a description (use 'name: description' format)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sample tests demonstrating marker behaviour
+# (These will be collected only when explicitly requested)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.rate_limited
+def test_rate_limited_sample_excluded_by_default():
+    """Would call a live broker API — excluded from default pytest runs."""
+    assert True
+
+
+@pytest.mark.live_market
+def test_live_market_sample_excluded_by_default():
+    """Would require an active market connection — excluded from default pytest runs."""
+    assert True
+
+
+@pytest.mark.performance
+def test_performance_sample_excluded_by_default():
+    """Would run a benchmark — excluded from default pytest runs."""
+    assert True
+
+
+@pytest.mark.auth_required
+def test_auth_required_sample():
+    """Would require ROBINHOOD_USERNAME/PASSWORD in env — opt-in only."""
+    assert True


### PR DESCRIPTION
Closes #146

## Changes
- Add `-m 'not rate_limited and not live_market and not performance'` to pytest `addopts` in `pyproject.toml` so the default `pytest` invocation never runs rate-limited, live-market, or performance tests
- Create `docs/TEST_MARKERS.md` documenting the full marker taxonomy and CI-safe invocation paths
- Add `tests/unit/test_marker_infrastructure.py` with 11 validation tests proving marker registration and default filtering work correctly (3 sample tests with excluded markers are intentionally deselected)
- Fix pre-existing unused `cast` import in `src/open_stocks_mcp/brokers/robinhood.py`

## Test plan
- `uv run pytest tests/unit/test_marker_infrastructure.py -v` → 11 passed, 3 deselected
- `uv run pytest -m 'not rate_limited and not live_market and not performance' tests/unit/test_marker_infrastructure.py` → same result
- `uv run ruff check src tests` → all checks passed