### PR TITLE
docs: add api docs generator and notebook examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Add to your MCP settings (`~/Library/Application Support/Claude/claude_desktop_c
 
 ## Available Tools
 
+Reference docs and runnable examples:
+- [API docs and notebook guide](docs/api/README.md)
+
 ### 🏦 Multi-Broker Support
 
 **Robinhood Tools (80 tools)**:

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,35 @@
+# API Docs and Notebook Examples
+
+This directory provides generated tool documentation and notebook walkthroughs.
+
+## Prerequisites
+
+Set credentials before using live broker-backed examples:
+
+- `ROBINHOOD_USERNAME`
+- `ROBINHOOD_PASSWORD`
+
+## Safety Notes
+
+Trading tools can place real orders with real money. Review every cell before running it.
+
+## Regenerate Tool Reference
+
+```bash
+uv run python scripts/generate_api_docs.py
+```
+
+The command rewrites [tools.md](tools.md) from the server's current MCP tool registry.
+
+## Open Notebook Examples
+
+```bash
+uv run jupyter lab examples/notebooks/
+```
+
+- `01_market_data_quickstart.ipynb` focuses on read-only workflows.
+- `02_trading_safe_dry_run.ipynb` demonstrates dry-run payload construction.
+
+## CI Scope
+
+Notebook execution is intentionally not run in CI for this issue. CI workflow changes are out of scope.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1,0 +1,739 @@
+# Open Stocks MCP - Tool Reference
+
+104 tools registered
+
+### account_details
+
+Gets comprehensive account details including buying power and cash balances.
+
+### account_features
+
+Gets comprehensive account features and settings.
+
+### account_info
+
+Gets basic Robinhood account information.
+
+### account_profile
+
+Gets trading account profile and configuration.
+
+### account_settings
+
+Gets account settings and preferences.
+
+### add_to_watchlist
+
+Adds symbols to a watchlist.
+
+    Args:
+        watchlist_name: Name of the watchlist
+        symbols: List of stock symbols to add
+    
+
+### aggregate_option_positions
+
+Gets aggregated option positions collapsed by underlying stock.
+
+### aggregated_portfolio
+
+Get a unified portfolio view aggregated across all registered brokers.
+
+    Combines positions and summary values from Robinhood and Schwab into a single
+    normalized response. Brokers that are not authenticated contribute a degraded
+    (status=unavailable) entry so partial information is always returned.
+
+    Returns:
+        Dict with aggregated totals, per-broker rollups, positions list,
+        partial_failure flag, and unavailable_brokers list.
+    
+
+### all_option_positions
+
+Gets all option positions ever held.
+
+### all_watchlists
+
+Gets all user-created watchlists.
+
+### basic_profile
+
+Gets basic user profile information.
+
+### broker_status
+
+Gets authentication status for all configured brokers.
+
+    Returns information about which brokers are available, authenticated,
+    or experiencing issues. Use this to troubleshoot authentication problems.
+
+    Returns:
+        Dictionary with broker authentication status for each broker
+    
+
+### build_holdings
+
+Builds comprehensive holdings with dividend information and performance metrics.
+
+    Returns detailed holdings data including cost basis, equity, dividends, and performance.
+    
+
+### build_user_profile
+
+Builds comprehensive user profile with equity, cash, and dividend totals.
+
+    Returns complete financial profile including total equity, cash balances, and dividend totals.
+    
+
+### buy_option_limit
+
+Places a limit buy order for an option.
+
+    Args:
+        instrument_id: The option instrument ID
+        quantity: The number of option contracts to buy
+        limit_price: The maximum price per contract
+    
+
+### buy_stock_limit
+
+Places a limit buy order for a stock.
+
+    Args:
+        symbol: The stock symbol to buy (e.g., "AAPL")
+        quantity: The number of shares to buy
+        limit_price: The maximum price per share
+    
+
+### buy_stock_market
+
+Places a market buy order for a stock.
+
+    Args:
+        symbol: The stock symbol to buy (e.g., "AAPL")
+        quantity: The number of shares to buy
+    
+
+### cancel_all_option_orders_tool
+
+Cancels all open option orders.
+
+### cancel_all_stock_orders_tool
+
+Cancels all open stock orders.
+
+### cancel_option_order_by_id
+
+Cancels a specific option order.
+
+    Args:
+        order_id: The ID of the order to cancel
+    
+
+### cancel_stock_order_by_id
+
+Cancels a specific stock order.
+
+    Args:
+        order_id: The ID of the order to cancel
+    
+
+### complete_profile
+
+Gets complete user profile combining all profile types.
+
+### day_trades
+
+Gets pattern day trading information and tracking.
+
+    Returns day trade count, remaining day trades, PDT status, and buying power information.
+    
+
+### dividends
+
+Gets all dividend payment history for the account.
+
+### dividends_by_instrument
+
+Gets dividend history for a specific stock symbol.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### find_instruments
+
+Searches for instrument information by various criteria.
+
+    Args:
+        query: Search query string (can be symbol, company name, or other criteria)
+    
+
+### find_options
+
+Finds tradable options with optional filtering.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+        expiration_date: Optional expiration date in YYYY-MM-DD format
+        option_type: Optional option type ("call" or "put")
+    
+
+### health_check
+
+Gets health status of the MCP server.
+
+### instruments_by_symbols
+
+Gets detailed instrument metadata for multiple symbols.
+
+    Args:
+        symbols: List of stock ticker symbols (e.g., ["AAPL", "GOOGL", "MSFT"])
+    
+
+### interest_payments
+
+Gets interest payment history from cash management.
+
+### investment_profile
+
+Gets investment profile and risk assessment.
+
+### latest_notification
+
+Gets the most recent notification.
+
+### list_brokers
+
+Lists all registered brokers and their availability.
+
+    Returns:
+        List of broker names and their authentication status
+    
+
+### list_tools
+
+Provides a list of available tools and their descriptions.
+
+### margin_calls
+
+Gets margin call information.
+
+### margin_interest
+
+Gets margin interest charges and rates.
+
+### market_hours
+
+Gets current market hours and status.
+
+### metrics_summary
+
+Gets comprehensive metrics summary for monitoring.
+
+### notifications
+
+Gets account notifications and alerts.
+
+    Args:
+        count: Number of notifications to retrieve (default: 20)
+    
+
+### open_option_orders
+
+Retrieves all open option orders.
+
+### open_option_positions
+
+Gets currently open option positions.
+
+### open_option_positions_with_details
+
+Gets currently open option positions with enriched details including call/put type.
+
+    This enhanced version includes complete option instrument details for each position:
+    - option_type: "call" or "put"
+    - strike_price: Strike price of the option
+    - option_symbol: OCC option symbol
+    - tradability: Trading status
+    - state: Option state (active, expired, etc.)
+    - underlying_symbol: Underlying stock symbol
+    - enrichment_success_rate: Percentage of positions successfully enriched
+
+    Use this instead of open_option_positions() when you need complete option details.
+    
+
+### open_stock_orders
+
+Retrieves all open stock orders.
+
+### option_credit_spread
+
+Places a credit spread order (sell short option, buy long option).
+
+    Args:
+        short_instrument_id: The option instrument ID to sell (short leg)
+        long_instrument_id: The option instrument ID to buy (long leg)
+        quantity: The number of spread contracts
+        credit_price: The net credit received per spread
+    
+
+### option_debit_spread
+
+Places a debit spread order (buy long option, sell short option).
+
+    Args:
+        short_instrument_id: The option instrument ID to sell (short leg)
+        long_instrument_id: The option instrument ID to buy (long leg)
+        quantity: The number of spread contracts
+        debit_price: The net debit paid per spread
+    
+
+### option_historicals
+
+Gets historical price data for an option contract.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+        expiration_date: Expiration date in YYYY-MM-DD format
+        strike_price: Strike price as string
+        option_type: Option type ("call" or "put")
+        interval: Time interval (default: "hour")
+        span: Time span (default: "week")
+    
+
+### option_market_data
+
+Gets market data for a specific option contract.
+
+    Args:
+        option_id: Unique option contract ID
+    
+
+### options_chains
+
+Gets complete option chains for a stock symbol.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### options_orders
+
+Retrieves a list of recent options order history and their statuses.
+
+### portfolio
+
+Provides a high-level overview of the portfolio.
+
+### positions
+
+Gets current stock positions with quantities and values.
+
+### price_history
+
+Gets historical price data for a stock.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+        period: Time period ("day", "week", "month", "3month", "year", "5year")
+    
+
+### pricebook_by_symbol
+
+Gets Level II order book data for a symbol (requires Gold subscription).
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### rate_limit_status
+
+Gets current rate limit usage and statistics.
+
+### referrals
+
+Gets referral program information.
+
+### remove_from_watchlist
+
+Removes symbols from a watchlist.
+
+    Args:
+        watchlist_name: Name of the watchlist
+        symbols: List of stock symbols to remove
+    
+
+### schwab_account
+
+Get Schwab account details including balances and positions.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        include_positions: Whether to include positions (default: True)
+    
+
+### schwab_account_balances
+
+Get account balances for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+    
+
+### schwab_account_numbers
+
+Get Schwab account numbers and their hashes.
+
+### schwab_accounts
+
+Get all Schwab linked accounts with balances and positions.
+
+    Args:
+        include_positions: Whether to include positions (default: True)
+    
+
+### schwab_buy_stock_limit
+
+Place a limit buy order for stock.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Stock ticker symbol
+        quantity: Number of shares to buy
+        price: Limit price
+    
+
+### schwab_buy_stock_market
+
+Place a market buy order for stock.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Stock ticker symbol
+        quantity: Number of shares to buy
+    
+
+### schwab_cancel_order
+
+Cancel a specific Schwab order.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        order_id: Order ID to cancel
+    
+
+### schwab_get_order
+
+Get details for a specific Schwab order.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        order_id: Order ID to retrieve
+    
+
+### schwab_instrument
+
+Get instrument information for a symbol.
+
+    Args:
+        symbol: Stock ticker symbol
+    
+
+### schwab_option_chain
+
+Get option chain for a symbol.
+
+    Args:
+        symbol: Stock ticker symbol
+        contract_type: Type of contracts ('CALL', 'PUT', 'ALL')
+        strike_count: Number of strikes above/below at-the-money price
+        include_underlying_quote: Whether to include underlying quote
+    
+
+### schwab_option_chain_by_expiration
+
+Get option chain filtered by expiration dates.
+
+    Args:
+        symbol: Stock ticker symbol
+        from_date: Only return expirations after this date (YYYY-MM-DD)
+        to_date: Only return expirations before this date (YYYY-MM-DD)
+        contract_type: Type of contracts ('CALL', 'PUT', 'ALL')
+    
+
+### schwab_option_expirations
+
+Get option expiration dates for a symbol.
+
+    Args:
+        symbol: Stock ticker symbol
+    
+
+### schwab_options_positions
+
+Get current options positions for an account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+    
+
+### schwab_orders
+
+Get orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        max_results: Maximum number of orders to return (default: 50)
+    
+
+### schwab_portfolio
+
+Get Schwab portfolio positions for a specific account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+    
+
+### schwab_price_history
+
+Get price history for a stock symbol.
+
+    Args:
+        symbol: Stock ticker symbol
+        period_type: Type of period ('day', 'month', 'year', 'ytd')
+        period: Number of periods
+        frequency_type: Frequency type ('minute', 'daily', 'weekly', 'monthly')
+        frequency: Frequency value
+    
+
+### schwab_quote
+
+Get current quote for a stock symbol from Schwab.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., 'AAPL', 'TSLA')
+    
+
+### schwab_quotes
+
+Get current quotes for multiple stock symbols from Schwab.
+
+    Args:
+        symbols: List of stock ticker symbols
+    
+
+### schwab_search_instruments
+
+Search for instruments by symbol or name.
+
+    Args:
+        query: Symbol or company name to search
+    
+
+### schwab_sell_stock_limit
+
+Place a limit sell order for stock.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Stock ticker symbol
+        quantity: Number of shares to sell
+        price: Limit price
+    
+
+### schwab_sell_stock_market
+
+Place a market sell order for stock.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Stock ticker symbol
+        quantity: Number of shares to sell
+    
+
+### search_stocks_tool
+
+Searches for stocks by symbol or company name.
+
+    Args:
+        query: Search query (symbol or company name)
+    
+
+### security_profile
+
+Gets security profile and settings.
+
+### sell_option_limit
+
+Places a limit sell order for an option.
+
+    Args:
+        instrument_id: The option instrument ID
+        quantity: The number of option contracts to sell
+        limit_price: The minimum price per contract
+    
+
+### sell_stock_limit
+
+Places a limit sell order for a stock.
+
+    Args:
+        symbol: The stock symbol to sell (e.g., "AAPL")
+        quantity: The number of shares to sell
+        limit_price: The minimum price per share
+    
+
+### sell_stock_market
+
+Places a market sell order for a stock.
+
+    Args:
+        symbol: The stock symbol to sell (e.g., "AAPL")
+        quantity: The number of shares to sell
+    
+
+### sell_stock_stop_loss
+
+Places a stop loss sell order for a stock.
+
+    Args:
+        symbol: The stock symbol to sell (e.g., "AAPL")
+        quantity: The number of shares to sell
+        stop_price: The stop price that triggers the order
+    
+
+### session_status
+
+Gets current session status and authentication information.
+
+### stock_earnings
+
+Gets earnings reports for a stock.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### stock_events
+
+Gets corporate events for a stock (for owned positions).
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### stock_info
+
+Gets detailed company information and fundamentals.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### stock_level2_data
+
+Gets Level II market data for a stock (Gold subscription required).
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### stock_loan_payments
+
+Gets stock loan payment history from the stock lending program.
+
+### stock_news
+
+Gets news stories for a stock.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### stock_orders
+
+Retrieves a list of recent stock order history and their statuses.
+
+### stock_price
+
+Gets current stock price and basic metrics.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### stock_quote_by_id
+
+Gets stock quote using Robinhood's internal instrument ID.
+
+    Args:
+        instrument_id: Robinhood's internal instrument ID
+    
+
+### stock_ratings
+
+Gets analyst ratings for a stock.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### stock_splits
+
+Gets stock split history for a stock.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+    
+
+### stocks_by_tag
+
+Gets stocks filtered by market category tag.
+
+    Args:
+        tag: Market category tag (e.g., 'technology', 'biopharmaceutical', 'upcoming-earnings')
+    
+
+### subscription_fees
+
+Gets Robinhood Gold subscription fees.
+
+### top_100_stocks
+
+Gets top 100 most popular stocks on Robinhood.
+
+### top_movers
+
+Gets top 20 movers on Robinhood.
+
+### top_movers_sp500
+
+Gets top S&P 500 movers for the day.
+
+    Args:
+        direction: Direction of movement, either 'up' or 'down' (default: 'up')
+    
+
+### total_dividends
+
+Gets total dividends received across all time.
+
+### user_profile
+
+Gets comprehensive user profile information.
+
+### watchlist_by_name
+
+Gets contents of a specific watchlist by name.
+
+    Args:
+        watchlist_name: Name of the watchlist to retrieve
+    
+
+### watchlist_performance
+
+Gets performance metrics for a watchlist.
+
+    Args:
+        watchlist_name: Name of the watchlist to analyze

--- a/examples/notebooks/01_market_data_quickstart.ipynb
+++ b/examples/notebooks/01_market_data_quickstart.ipynb
@@ -1,0 +1,76 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Prerequisites & Safety\\n",
+        "\\n",
+        "Required environment variables:\\n",
+        "- ROBINHOOD_USERNAME\\n",
+        "- ROBINHOOD_PASSWORD\\n",
+        "\\n",
+        "This notebook uses read-only market and portfolio tools. No order placement calls are included."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Connect to the MCP server\\n",
+        "\\n",
+        "Start the server first:\\n",
+        "```bash\\n",
+        "uv run open-stocks-mcp-server --transport http --port 3001\\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StreamableHTTPConnectionParams\\n",
+        "\\n",
+        "toolset = MCPToolset(connection_params=StreamableHTTPConnectionParams(url=\"http://localhost:3001/mcp\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Example read-only calls\\n",
+        "stock_price(\"AAPL\")\\n",
+        "market_hours()\\n",
+        "portfolio()\\n",
+        "account_info()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Next steps\\n",
+        "\\n",
+        "- Review [tools.md](../../docs/api/tools.md) for full tool coverage.\\n",
+        "- Continue with `02_trading_safe_dry_run.ipynb` for safe trading payload patterns."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/examples/notebooks/02_trading_safe_dry_run.ipynb
+++ b/examples/notebooks/02_trading_safe_dry_run.ipynb
@@ -1,0 +1,74 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# SAFETY: Trading Dry Run Only\\n",
+        "\\n",
+        "This dry run notebook demonstrates structure and validation patterns only.\\n",
+        "Do not run live trading actions unless you deliberately replace dry-run cells with production-safe order execution logic."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Prerequisites & Safety\\n",
+        "\\n",
+        "Required environment variables:\\n",
+        "- ROBINHOOD_USERNAME\\n",
+        "- ROBINHOOD_PASSWORD\\n",
+        "\\n",
+        "Running real trading cells places real orders with real money."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "tools = list_tools()\\n",
+        "trading_tools = [t for t in tools.get(\"result\", {}).get(\"tools\", []) if \"order\" in t.get(\"name\", \"\")]\\n",
+        "trading_tools[:10]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "dry_run_order = {\\n",
+        "    \"symbol\": \"AAPL\",\\n",
+        "    \"quantity\": 1,\\n",
+        "    \"type\": \"market\",\\n",
+        "    \"timeInForce\": \"gfd\"\\n",
+        "}\\n",
+        "print(\"Dry run payload:\", dry_run_order)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "To convert this dry run into real execution, explicitly swap payload preview code for intentional order calls after review.\\n",
+        "See [tools.md](../../docs/api/tools.md) for the current tool reference."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -1,0 +1,38 @@
+"""Generate API documentation from registered MCP tools."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+HEADER = "# Open Stocks MCP - Tool Reference\n"
+
+
+async def build_doc(mcp: Any) -> str:
+    """Build deterministic markdown from registered tools."""
+    tools = await mcp.list_tools()
+    tool_entries = sorted(tools, key=lambda tool: tool.name)
+
+    lines = [HEADER, f"{len(tool_entries)} tools registered\n"]
+    for tool in tool_entries:
+        description = tool.description or "No description provided."
+        lines.extend([f"### {tool.name}\n", f"{description}\n"])
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(output_path: Path | None = None) -> Path:
+    """Render docs/api/tools.md (or custom output path)."""
+    from open_stocks_mcp.server.app import mcp
+
+    target = output_path or Path("docs/api/tools.md")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    markdown = asyncio.run(build_doc(mcp))
+    target.write_text(markdown, encoding="utf-8")
+    return target
+
+
+if __name__ == "__main__":
+    path = main()
+    print(f"Generated {path}")

--- a/tests/unit/test_api_docs_generator.py
+++ b/tests/unit/test_api_docs_generator.py
@@ -1,0 +1,22 @@
+import re
+
+import pytest
+
+from scripts import generate_api_docs
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_generate_writes_tools_md(tmp_path):
+    output_path = tmp_path / "tools.md"
+
+    written_path = generate_api_docs.main(output_path=output_path)
+
+    assert written_path == output_path
+    assert output_path.exists()
+
+    content = output_path.read_text(encoding="utf-8")
+    assert "# Open Stocks MCP - Tool Reference" in content
+    assert re.search(r"\n\d+ tools registered\n", content)
+    assert "### list_tools" in content
+    assert "### account_info" in content

--- a/tests/unit/test_example_notebooks.py
+++ b/tests/unit/test_example_notebooks.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import pytest
+
+NOTEBOOK_01 = Path("examples/notebooks/01_market_data_quickstart.ipynb")
+NOTEBOOK_02 = Path("examples/notebooks/02_trading_safe_dry_run.ipynb")
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_market_data_notebook_is_valid():
+    notebook = json.loads(NOTEBOOK_01.read_text(encoding="utf-8"))
+
+    assert notebook.get("nbformat", 0) >= 4
+    first_cell = notebook["cells"][0]
+    assert first_cell["cell_type"] == "markdown"
+    first_source = "".join(first_cell.get("source", []))
+    assert "Prerequisites & Safety" in first_source
+    assert "ROBINHOOD_USERNAME" in first_source
+
+    code_sources = ["".join(cell.get("source", [])) for cell in notebook["cells"] if cell["cell_type"] == "code"]
+    assert any(
+        token in src for src in code_sources for token in ["account_info", "portfolio", "stock_price"]
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_trading_dry_run_notebook_is_safe():
+    notebook = json.loads(NOTEBOOK_02.read_text(encoding="utf-8"))
+
+    assert notebook.get("nbformat", 0) >= 4
+    first_cell = notebook["cells"][0]
+    assert first_cell["cell_type"] == "markdown"
+    first_source = "".join(first_cell.get("source", []))
+    assert "SAFETY" in first_source
+    assert "dry run" in first_source.lower()
+
+    forbidden = [
+        "rh.order_buy_market",
+        "rh.order_sell_market",
+        "rh.order_buy_limit",
+        "rh.order_sell_limit",
+        "order_buy_option_limit",
+    ]
+    for cell in notebook["cells"]:
+        if cell.get("cell_type") != "code":
+            continue
+        source = "".join(cell.get("source", []))
+        for token in forbidden:
+            assert token not in source
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_api_docs_readme_links_from_root_readme():
+    readme = Path("README.md").read_text(encoding="utf-8")
+    assert "docs/api/README.md" in readme


### PR DESCRIPTION
Closes #154

## Changes
- add `scripts/generate_api_docs.py` and `scripts/__init__.py` to generate deterministic `docs/api/tools.md` from `mcp.list_tools()`
- add committed API docs artifacts: `docs/api/tools.md` and `docs/api/README.md`
- add notebook examples: `examples/notebooks/01_market_data_quickstart.ipynb` and `examples/notebooks/02_trading_safe_dry_run.ipynb`
- add tests for docs generation and notebook safety/structure in `tests/unit/test_api_docs_generator.py` and `tests/unit/test_example_notebooks.py`
- link `docs/api/README.md` from root `README.md` under Available Tools

## Test plan
- `uv run python scripts/generate_api_docs.py` (run twice; deterministic output confirmed)
- `uv run pytest tests/unit/test_api_docs_generator.py -v`
- `uv run pytest tests/unit/test_example_notebooks.py -v`
- `uv run mypy scripts src`
- `uv run pytest tests -k 'docs or examples'`
- `uv run python -c "import json; json.load(open('examples/notebooks/01_market_data_quickstart.ipynb')); json.load(open('examples/notebooks/02_trading_safe_dry_run.ipynb'))"`

Note: `uv run ruff check src tests` reports a pre-existing unrelated failure in `tests/unit/test_cross_broker_tools.py` (`datetime` imported but unused).
