### PR TITLE
test: isolate rate limited marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ pytest -m "not slow and not exception_test"               # Fast tests (recommen
 pytest -m "unit and journey_account"                      # Quick unit feedback
 pytest tests/unit/                                        # Unit tests (fast)
 pytest tests/integration/ -m integration                  # Integration (needs auth)
+pytest -m rate_limited                                    # Live rate-limited API tests
+RUN_RATE_LIMITED=1 pytest                                 # Include rate-limited tests in full run
 
 # READ ONLY journeys (perfect for ADK evaluations)
 pytest -m "journey_account or journey_portfolio or journey_market_data or journey_research or journey_notifications or journey_system"
@@ -62,6 +64,9 @@ pytest -m "journey_account or journey_portfolio or journey_market_data or journe
 - `journey_notifications` - Alerts, margin calls, subscription fees
 - `journey_system` - Health checks, metrics, session status
 - `journey_trading` - Buy/sell orders, cancellation, order management
+- `rate_limited` - Live endpoint tests that may hit Robinhood or Schwab rate
+  limits; skipped by default unless selected with `-m rate_limited` or
+  `RUN_RATE_LIMITED=1`
 
 ### Code Quality
 ```bash

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -61,6 +61,8 @@ Thank you for your interest in contributing! We welcome contributions from every
 ### Testing
 - Add unit tests for new functionality
 - Use `@pytest.mark.integration` for tests requiring credentials
+- Use `@pytest.mark.rate_limited` for tests that hit live rate-limited endpoints
+  (Robinhood, Schwab). These tests are skipped by default; opt in deliberately.
 - Use `@pytest.mark.slow` for long-running tests
 - Mock external API calls in unit tests
 
@@ -115,6 +117,8 @@ pytest                           # All tests
 pytest tests/unit/               # Unit tests only
 pytest -m integration           # Integration tests
 pytest -m "not slow and not exception_test"  # Fast tests (recommended)
+pytest -m rate_limited           # Run rate-limited live API tests
+RUN_RATE_LIMITED=1 pytest        # Include rate-limited tests in a full run
 ```
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ addopts = [
     "--strict-config",
     "--verbose",
     "-m",
-    "not rate_limited and not live_market and not performance",
+    "not live_market and not performance",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
@@ -146,7 +146,7 @@ markers = [
     "unit: marks tests as fast unit tests",
     "performance: marks tests as performance/benchmark tests",
     "auth_required: marks tests that require authentication",
-    "rate_limited: marks tests that may hit rate limits",
+    "rate_limited: marks tests that may hit live endpoints with rate limit risk (skipped by default; opt in with '-m rate_limited' or RUN_RATE_LIMITED=1)",
     "journey_account: Account management tests (account_info, profiles, settings)",
     "journey_portfolio: Portfolio & holdings tests (portfolio, positions, build_holdings)",
     "journey_market_data: Stock quotes & market info tests (stock_price, market_hours, search)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for open-stocks-mcp tests."""
 
+import os
 import sys
 from typing import Any
 from unittest.mock import MagicMock
@@ -17,9 +18,18 @@ except ImportError:
 
 import pytest
 
+RATE_LIMITED_SKIP_REASON = (
+    "rate_limited test; set RUN_RATE_LIMITED=1 or pass '-m rate_limited' to enable"
+)
+
 
 def pytest_configure(config: Any) -> None:
     """Configure pytest with journey markers for organized testing."""
+    config.addinivalue_line(
+        "markers",
+        "rate_limited: marks tests that may hit live endpoints with rate limit risk "
+        "(skipped by default; opt in with '-m rate_limited' or RUN_RATE_LIMITED=1)",
+    )
     config.addinivalue_line(
         "markers",
         "journey_account: Account management tests (account_info, profiles, settings)",
@@ -64,6 +74,18 @@ def pytest_configure(config: Any) -> None:
         "markers",
         "journey_trading: Trading operations tests (buy/sell orders, cancellation)",
     )
+
+
+def pytest_collection_modifyitems(config: Any, items: list[Any]) -> None:
+    """Skip rate-limited tests unless the run explicitly opts into them."""
+    markexpr = config.option.markexpr or ""
+    if "rate_limited" in markexpr or os.environ.get("RUN_RATE_LIMITED"):
+        return
+
+    skip_rate_limited = pytest.mark.skip(reason=RATE_LIMITED_SKIP_REASON)
+    for item in items:
+        if list(item.iter_markers(name="rate_limited")):
+            item.add_marker(skip_rate_limited)
 
 
 @pytest.fixture

--- a/tests/integration/test_basic_api.py
+++ b/tests/integration/test_basic_api.py
@@ -39,6 +39,7 @@ def robinhood_session() -> Any:
 
 @pytest.mark.integration
 @pytest.mark.journey_account
+@pytest.mark.rate_limited
 class TestBasicIntegration:
     """Test basic API functionality that should work reliably."""
 
@@ -66,6 +67,7 @@ class TestBasicIntegration:
 
 @pytest.mark.integration
 @pytest.mark.journey_account
+@pytest.mark.rate_limited
 @pytest.mark.exception_test
 @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
 @pytest.mark.asyncio

--- a/tests/server/test_server_login_flow.py
+++ b/tests/server/test_server_login_flow.py
@@ -9,6 +9,7 @@ import pytest
 
 @pytest.mark.integration
 @pytest.mark.journey_account
+@pytest.mark.rate_limited
 class TestServerLoginFlow:
     """Test the complete server login flow with environment credentials."""
 

--- a/tests/unit/test_marker_infrastructure.py
+++ b/tests/unit/test_marker_infrastructure.py
@@ -7,7 +7,7 @@ import pytest
 
 PYPROJECT = Path(__file__).parent.parent.parent / "pyproject.toml"
 REQUIRED_MARKERS = {"rate_limited", "live_market", "performance", "auth_required"}
-DEFAULT_EXCLUDED = {"rate_limited", "live_market", "performance"}
+DEFAULT_EXCLUDED = {"live_market", "performance"}
 
 
 def _load_pytest_config() -> dict:
@@ -56,12 +56,13 @@ def test_auth_required_marker_description():
 # ---------------------------------------------------------------------------
 
 
-def test_addopts_excludes_rate_limited():
+def test_addopts_leaves_rate_limited_to_conftest_hook():
     cfg = _load_pytest_config()
     addopts = cfg.get("addopts", [])
     addopts_str = " ".join(addopts) if isinstance(addopts, list) else str(addopts)
-    assert "not rate_limited" in addopts_str, (
-        "addopts must exclude rate_limited tests by default"
+    assert "not rate_limited" not in addopts_str, (
+        "rate_limited tests are skipped by tests/conftest.py so "
+        "RUN_RATE_LIMITED=1 can include them"
     )
 
 

--- a/tests/unit/test_rate_limited_marker.py
+++ b/tests/unit/test_rate_limited_marker.py
@@ -1,0 +1,153 @@
+"""Tests for rate-limited marker isolation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import tests.conftest as shared_conftest
+
+ROOT = Path(__file__).parent.parent.parent
+
+
+class DummyItem:
+    """Small pytest item double for marker hook tests."""
+
+    def __init__(self, marker_names: set[str]) -> None:
+        self.marker_names = marker_names
+        self.added_markers: list[Any] = []
+
+    def iter_markers(self, name: str | None = None) -> list[SimpleNamespace]:
+        markers = [SimpleNamespace(name=marker) for marker in self.marker_names]
+        if name is None:
+            return markers
+        return [marker for marker in markers if marker.name == name]
+
+    def add_marker(self, marker: Any) -> None:
+        self.added_markers.append(marker)
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_rate_limited_marker_registered_by_conftest() -> None:
+    added_markers: list[tuple[str, str]] = []
+    config = SimpleNamespace(
+        addinivalue_line=lambda name, value: added_markers.append((name, value))
+    )
+
+    shared_conftest.pytest_configure(config)
+
+    assert (
+        "markers",
+        "rate_limited: marks tests that may hit live endpoints with rate limit risk "
+        "(skipped by default; opt in with '-m rate_limited' or RUN_RATE_LIMITED=1)",
+    ) in added_markers
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_rate_limited_tests_are_skipped_without_explicit_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RUN_RATE_LIMITED", raising=False)
+    config = SimpleNamespace(option=SimpleNamespace(markexpr="not slow"))
+    rate_limited_item = DummyItem({"rate_limited"})
+    unmarked_item = DummyItem(set())
+
+    shared_conftest.pytest_collection_modifyitems(
+        config, [rate_limited_item, unmarked_item]
+    )
+
+    assert len(rate_limited_item.added_markers) == 1
+    assert "rate_limited test" in rate_limited_item.added_markers[0].kwargs["reason"]
+    assert unmarked_item.added_markers == []
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+@pytest.mark.parametrize(
+    ("markexpr", "run_rate_limited"),
+    [
+        ("rate_limited", None),
+        ("not rate_limited", None),
+        ("not slow", "1"),
+    ],
+)
+def test_rate_limited_tests_are_not_skipped_when_explicitly_selected(
+    monkeypatch: pytest.MonkeyPatch, markexpr: str, run_rate_limited: str | None
+) -> None:
+    if run_rate_limited is None:
+        monkeypatch.delenv("RUN_RATE_LIMITED", raising=False)
+    else:
+        monkeypatch.setenv("RUN_RATE_LIMITED", run_rate_limited)
+    item = DummyItem({"rate_limited"})
+    config = SimpleNamespace(option=SimpleNamespace(markexpr=markexpr))
+
+    shared_conftest.pytest_collection_modifyitems(config, [item])
+
+    assert item.added_markers == []
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_rate_limited_collection_finds_live_api_tests() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "-m",
+            "rate_limited",
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "<Module test_basic_api.py>" in result.stdout
+    assert "<Module test_server_login_flow.py>" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_rate_limited_docs_are_present() -> None:
+    for relative_path in ("contributing/README.md", "CLAUDE.md"):
+        content = (ROOT / relative_path).read_text(encoding="utf-8")
+        assert "rate_limited" in content
+        assert "RUN_RATE_LIMITED=1" in content
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_run_rate_limited_env_can_include_marked_tests() -> None:
+    env = {**os.environ, "RUN_RATE_LIMITED": "1"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "tests/integration/test_basic_api.py",
+            "tests/server/test_server_login_flow.py",
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "<Class TestBasicIntegration>" in result.stdout
+    assert "<Class TestServerLoginFlow>" in result.stdout


### PR DESCRIPTION
Closes #160

## Changes
- Register `rate_limited` in `tests/conftest.py` and skip marked tests by default unless `-m rate_limited` or `RUN_RATE_LIMITED=1` opts in.
- Move the default `rate_limited` exclusion out of `pyproject.toml` addopts so explicit fast marker expressions still rely on the conftest hook.
- Mark live Robinhood/server login tests as `rate_limited` and cover the behavior with marker infrastructure tests.
- Document deliberate rate-limited test runs in `CLAUDE.md` and `contributing/README.md`.

## Test plan
- `uv run pytest tests/unit/test_rate_limited_marker.py -v` - 8 passed
- `uv run pytest tests/unit/test_marker_infrastructure.py tests/unit/test_rate_limited_marker.py -v` - 19 passed, 1 skipped, 2 deselected
- `uv run pytest --collect-only -m rate_limited -q` - 6 selected, including `test_basic_api.py` and `test_server_login_flow.py`
- `uv run pytest --collect-only -m "not rate_limited" -q` - 461 selected, 6 deselected
- `uv run pytest --collect-only -m "not slow and not rate_limited and not exception_test" -q` - 386 selected, 81 deselected
- `uv run ruff check tests/conftest.py tests/integration/test_basic_api.py tests/server/test_server_login_flow.py tests/unit/test_marker_infrastructure.py tests/unit/test_rate_limited_marker.py` - passed
- `uv run ruff format --check tests/conftest.py tests/integration/test_basic_api.py tests/server/test_server_login_flow.py tests/unit/test_marker_infrastructure.py tests/unit/test_rate_limited_marker.py` - passed
- `uv run mypy .` - passed
- `git diff --check` - passed

## Concerns
- CI workflow edits are intentionally not included because Foreman issue-pickup policy forbids `.github/workflows/**` changes.
- `uv run pytest -m "not slow and not exception_test"` exposed unrelated HTTP transport failures and then hung; it was interrupted after early failures.
- Full `uv run ruff check .` still reports an unrelated existing `F401` in `tests/unit/test_cross_broker_tools.py`.
