### PR TITLE
feat: component-level health checks

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -86,6 +86,7 @@ class ServerConfig:
 
     name: str = "Open Stocks MCP"
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
+    monitoring_enabled: bool = True
     cache: CacheConfig = field(default_factory=CacheConfig)
     retry: RetryConfig | None = None
     timeout: TimeoutConfig | None = None
@@ -108,6 +109,7 @@ def load_config() -> ServerConfig:
     return ServerConfig(
         name=os.getenv("MCP_SERVER_NAME", "Open Stocks MCP"),
         log_level=os.getenv("LOG_LEVEL", "INFO"),
+        monitoring_enabled=os.getenv("MONITORING_ENABLED", "true").lower() == "true",
         cache=cache,
         retry=RetryConfig(
             max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", 3),

--- a/src/open_stocks_mcp/health.py
+++ b/src/open_stocks_mcp/health.py
@@ -1,0 +1,176 @@
+"""Component-level health status aggregation for the MCP server."""
+
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from open_stocks_mcp.brokers.base import BrokerAuthStatus
+from open_stocks_mcp.brokers.registry import BrokerRegistry, get_broker_registry
+from open_stocks_mcp.config import load_config
+from open_stocks_mcp.monitoring import MetricsCollector, get_metrics_collector
+from open_stocks_mcp.tools.session_manager import SessionManager, get_session_manager
+
+
+class ComponentStatus(Enum):
+    """Discrete component health states."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+
+
+@dataclass
+class ComponentHealth:
+    """Component health payload."""
+
+    name: str
+    status: ComponentStatus
+    last_checked: datetime
+    detail: str | None = None
+    error_message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize component health."""
+        payload: dict[str, Any] = {
+            "status": self.status.value,
+            "last_checked": self.last_checked.isoformat(),
+        }
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        if self.error_message is not None:
+            payload["error_message"] = self.error_message
+        return payload
+
+
+class HealthService:
+    """Aggregates server health from cached component state."""
+
+    def __init__(
+        self,
+        registry: BrokerRegistry | None = None,
+        metrics_collector: MetricsCollector | None = None,
+        session_manager: SessionManager | None = None,
+        monitoring_enabled: bool = True,
+    ) -> None:
+        self.registry = registry
+        self.metrics_collector = metrics_collector
+        self.session_manager = session_manager
+        self.monitoring_enabled = monitoring_enabled
+
+    @staticmethod
+    def _map_broker_auth_status(status: BrokerAuthStatus) -> ComponentStatus:
+        if status == BrokerAuthStatus.AUTHENTICATED:
+            return ComponentStatus.HEALTHY
+        if status in (BrokerAuthStatus.AUTHENTICATING, BrokerAuthStatus.MFA_REQUIRED):
+            return ComponentStatus.DEGRADED
+        return ComponentStatus.UNHEALTHY
+
+    @staticmethod
+    def _component_from_status_value(status: str) -> ComponentStatus:
+        if status == ComponentStatus.UNHEALTHY.value:
+            return ComponentStatus.UNHEALTHY
+        if status == ComponentStatus.DEGRADED.value:
+            return ComponentStatus.DEGRADED
+        return ComponentStatus.HEALTHY
+
+    async def _get_registry(self) -> BrokerRegistry:
+        if self.registry is None:
+            self.registry = await get_broker_registry()
+        return self.registry
+
+    def _get_session_manager(self) -> SessionManager:
+        if self.session_manager is not None:
+            return self.session_manager
+        return get_session_manager()
+
+    def _get_metrics_collector(self) -> MetricsCollector:
+        if self.metrics_collector is None:
+            self.metrics_collector = get_metrics_collector()
+        return self.metrics_collector
+
+    async def get_status(self) -> dict[str, Any]:
+        """Return aggregated health status and component details."""
+        now = datetime.now()
+        components: dict[str, dict[str, Any]] = {}
+        component_states: list[ComponentStatus] = []
+
+        if self.monitoring_enabled:
+            metrics = await self._get_metrics_collector().get_health_status()
+            metrics_state = self._component_from_status_value(
+                str(metrics.get("status", "healthy"))
+            )
+            metrics_component = ComponentHealth(
+                name="metrics",
+                status=metrics_state,
+                last_checked=now,
+                detail=", ".join(metrics.get("issues", [])) if metrics.get("issues") else None,
+            )
+        else:
+            metrics_component = ComponentHealth(
+                name="metrics",
+                status=ComponentStatus.HEALTHY,
+                last_checked=now,
+                detail="monitoring disabled",
+            )
+        components["metrics"] = metrics_component.to_dict()
+        component_states.append(metrics_component.status)
+
+        session_info = self._get_session_manager().get_session_info()
+        session_status = (
+            ComponentStatus.HEALTHY
+            if session_info.get("authenticated", False)
+            else ComponentStatus.DEGRADED
+        )
+        session_component = ComponentHealth(
+            name="session",
+            status=session_status,
+            last_checked=now,
+            detail=(
+                f"session_duration={session_info.get('session_duration')}"
+                if session_info.get("session_duration") is not None
+                else None
+            ),
+        )
+        components["session"] = session_component.to_dict()
+        component_states.append(session_component.status)
+
+        registry = await self._get_registry()
+        for broker_name in registry.list_brokers():
+            broker = registry.get_broker(broker_name)
+            if broker is None:
+                continue
+            broker_status = self._map_broker_auth_status(broker.auth_info.status)
+            broker_component = ComponentHealth(
+                name=f"broker:{broker_name}",
+                status=broker_status,
+                last_checked=now,
+                error_message=broker.auth_info.error_message,
+            )
+            components[f"broker:{broker_name}"] = broker_component.to_dict()
+            component_states.append(broker_component.status)
+
+        overall = ComponentStatus.HEALTHY
+        if any(state == ComponentStatus.UNHEALTHY for state in component_states):
+            overall = ComponentStatus.UNHEALTHY
+        elif any(state == ComponentStatus.DEGRADED for state in component_states):
+            overall = ComponentStatus.DEGRADED
+
+        return {
+            "status": overall.value,
+            "components": components,
+            "timestamp": time.time(),
+        }
+
+
+_health_service: HealthService | None = None
+
+
+def get_health_service() -> HealthService:
+    """Get process-wide health service singleton."""
+    global _health_service
+    if _health_service is None:
+        config = load_config()
+        _health_service = HealthService(monitoring_enabled=config.monitoring_enabled)
+    return _health_service

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -213,17 +213,19 @@ class MetricsCollector:
         health = "healthy"
         issues = []
 
-        if error_rate > 10:
+        if error_rate > 25:
+            health = "unhealthy"
+            issues.append(f"Critical error rate: {error_rate}%")
+        elif error_rate > 10:
             health = "degraded"
             issues.append(f"High error rate: {error_rate}%")
-        elif error_rate > 25:
-            health = "unhealthy"
 
-        if avg_response_time > 5000:  # 5 seconds
+        if avg_response_time > 10000:  # 10 seconds
+            health = "unhealthy"
+            issues.append(f"Critical response time: {avg_response_time}ms")
+        elif avg_response_time > 5000:  # 5 seconds
             health = "degraded" if health == "healthy" else health
             issues.append(f"High response time: {avg_response_time}ms")
-        elif avg_response_time > 10000:  # 10 seconds
-            health = "unhealthy"
 
         return {
             "status": health,

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -16,6 +16,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from open_stocks_mcp import __version__
 from open_stocks_mcp.config import load_config
+from open_stocks_mcp.health import get_health_service
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.monitoring import get_metrics_collector
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
@@ -200,22 +201,24 @@ def create_http_server(mcp_server: FastMCP, api_key: str | None = None) -> FastA
     async def health_check() -> dict[str, Any]:
         """Health check endpoint"""
         try:
-            metrics_collector = _require_metrics_collector()
-            health_status = await metrics_collector.get_health_status()
-
             session_manager = _require_session_manager()
             session_info = session_manager.get_session_info()
+            health_status = await get_health_service().get_status()
 
             return {
-                "status": "healthy",
-                "timestamp": time.time(),
+                "status": health_status["status"],
+                "components": health_status["components"],
+                "timestamp": health_status["timestamp"],
                 "version": __version__,
                 "transport": "http",
                 "session": {
                     "authenticated": session_info.get("authenticated", False),
                     "session_duration": session_info.get("session_duration"),
                 },
-                "health": health_status,
+                "health": {
+                    "status": health_status["status"],
+                    "components": health_status["components"],
+                },
             }
         except HTTPException:
             raise

--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -10,6 +10,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from open_stocks_mcp.brokers.registry import get_broker_registry
+from open_stocks_mcp.health import get_health_service
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.monitoring import get_metrics_collector
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
@@ -111,7 +112,5 @@ async def get_metrics_summary_data() -> dict[str, Any]:
 
 async def get_health_check_data() -> dict[str, Any]:
     """Return health status of the MCP server."""
-    metrics_collector = get_metrics_collector()
-    health_status = await metrics_collector.get_health_status()
-
-    return {"result": {**health_status, "status": "success"}}
+    health_status = await get_health_service().get_status()
+    return {"result": {**health_status, "health_status": health_status["status"], "status": "success"}}

--- a/tests/http_transport/test_http_auth.py
+++ b/tests/http_transport/test_http_auth.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 from mcp.server.fastmcp import FastMCP
 
+from open_stocks_mcp import __version__
 from open_stocks_mcp.server.http_transport import create_http_server
 
 
@@ -39,9 +40,13 @@ async def http_client(mcp_server: FastMCP) -> Any:
 class TestHTTPAuthentication:
     """Test authentication scenarios for HTTP transport"""
 
-    @patch("open_stocks_mcp.tools.session_manager.get_session_manager")
+    @patch("open_stocks_mcp.server.http_transport.get_health_service")
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
     async def test_health_check_with_authenticated_session(
-        self, mock_get_session_manager: Mock, http_client: httpx.AsyncClient
+        self,
+        mock_get_session_manager: Mock,
+        mock_get_health_service: Mock,
+        http_client: httpx.AsyncClient,
     ) -> None:
         """Test health check when session is authenticated"""
         # Mock authenticated session
@@ -52,6 +57,13 @@ class TestHTTPAuthentication:
             "username": "test_user",
         }
         mock_get_session_manager.return_value = mock_session_manager
+        mock_health_service = AsyncMock()
+        mock_health_service.get_status.return_value = {
+            "status": "healthy",
+            "components": {"session": {"status": "healthy"}},
+            "timestamp": 123.0,
+        }
+        mock_get_health_service.return_value = mock_health_service
 
         response = await http_client.get("/health")
         assert response.status_code == 200
@@ -61,9 +73,13 @@ class TestHTTPAuthentication:
         assert data["session"]["authenticated"] is True
         assert data["session"]["session_duration"] == 3600
 
-    @patch("open_stocks_mcp.tools.session_manager.get_session_manager")
+    @patch("open_stocks_mcp.server.http_transport.get_health_service")
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
     async def test_health_check_with_unauthenticated_session(
-        self, mock_get_session_manager: Mock, http_client: httpx.AsyncClient
+        self,
+        mock_get_session_manager: Mock,
+        mock_get_health_service: Mock,
+        http_client: httpx.AsyncClient,
     ) -> None:
         """Test health check when session is not authenticated"""
         # Mock unauthenticated session
@@ -74,15 +90,22 @@ class TestHTTPAuthentication:
             "username": None,
         }
         mock_get_session_manager.return_value = mock_session_manager
+        mock_health_service = AsyncMock()
+        mock_health_service.get_status.return_value = {
+            "status": "degraded",
+            "components": {"session": {"status": "degraded"}},
+            "timestamp": 123.0,
+        }
+        mock_get_health_service.return_value = mock_health_service
 
         response = await http_client.get("/health")
         assert response.status_code == 200
 
         data = response.json()
-        assert data["status"] == "healthy"
+        assert data["status"] == "degraded"
         assert data["session"]["authenticated"] is False
 
-    @patch("open_stocks_mcp.tools.session_manager.get_session_manager")
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
     async def test_session_refresh_success(
         self, mock_get_session_manager: Mock, http_client: httpx.AsyncClient
     ) -> None:
@@ -104,7 +127,7 @@ class TestHTTPAuthentication:
         assert data["status"] == "success"
         assert data["session"]["authenticated"] is True
 
-    @patch("open_stocks_mcp.tools.session_manager.get_session_manager")
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
     async def test_session_refresh_failure(
         self, mock_get_session_manager: Mock, http_client: httpx.AsyncClient
     ) -> None:
@@ -120,7 +143,7 @@ class TestHTTPAuthentication:
         data = response.json()
         assert "Authentication failed" in data["detail"]
 
-    @patch("open_stocks_mcp.tools.session_manager.get_session_manager")
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
     async def test_session_refresh_exception(
         self, mock_get_session_manager: Mock, http_client: httpx.AsyncClient
     ) -> None:
@@ -144,9 +167,9 @@ class TestHTTPAuthentication:
 class TestHTTPSessionStatus:
     """Test session status reporting"""
 
-    @patch("open_stocks_mcp.tools.session_manager.get_session_manager")
-    @patch("open_stocks_mcp.tools.rate_limiter.get_rate_limiter")
-    @patch("open_stocks_mcp.monitoring.get_metrics_collector")
+    @patch("open_stocks_mcp.server.http_transport.get_session_manager")
+    @patch("open_stocks_mcp.server.http_transport.get_rate_limiter")
+    @patch("open_stocks_mcp.server.http_transport.get_metrics_collector")
     async def test_server_status_comprehensive(
         self,
         mock_get_metrics_collector: Mock,
@@ -185,7 +208,7 @@ class TestHTTPSessionStatus:
 
         data = response.json()
         assert data["server"]["status"] == "running"
-        assert data["server"]["version"] == "0.6.4"
+        assert data["server"]["version"] == __version__
         assert data["server"]["transport"] == "http"
         assert data["session"]["authenticated"] is True
         assert data["rate_limiting"]["total_requests"] == 100
@@ -253,7 +276,7 @@ class TestHTTPSecurity:
 
         data = response.json()
         assert data["name"] == "Open Stocks MCP Server"
-        assert data["version"] == "0.6.4"
+        assert data["version"] == __version__
         assert data["transport"] == "http"
         assert "endpoints" in data
         assert data["endpoints"]["mcp"] == "/mcp"
@@ -379,14 +402,14 @@ class TestNonLoopbackBindingRequiresAuth:
 class TestHTTPErrorHandling:
     """Test error handling scenarios"""
 
-    @patch("open_stocks_mcp.monitoring.get_metrics_collector")
+    @patch("open_stocks_mcp.server.http_transport.get_health_service")
     async def test_health_check_service_error(
-        self, mock_get_metrics_collector: Mock, http_client: httpx.AsyncClient
+        self, mock_get_health_service: Mock, http_client: httpx.AsyncClient
     ) -> None:
         """Test health check when service components fail"""
-        mock_metrics_collector = AsyncMock()
-        mock_metrics_collector.get_health_status.side_effect = Exception("Service down")
-        mock_get_metrics_collector.return_value = mock_metrics_collector
+        mock_health_service = AsyncMock()
+        mock_health_service.get_status.side_effect = Exception("Service down")
+        mock_get_health_service.return_value = mock_health_service
 
         response = await http_client.get("/health")
         assert response.status_code == 503  # Service Unavailable

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -78,7 +78,7 @@ class TestHTTPEndpoints:
         assert response.status_code == 200
 
         data = response.json()
-        assert data["status"] == "healthy"
+        assert data["status"] in {"healthy", "degraded", "unhealthy"}
         assert data["version"] == __version__
         assert data["transport"] == "http"
         assert "timestamp" in data

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from open_stocks_mcp.server.app import attempt_login, create_mcp_server, mcp
+from open_stocks_mcp.server.app import (
+    attempt_login,
+    create_mcp_server,
+    health_check,
+    mcp,
+)
 
 
 @pytest.mark.journey_system
@@ -156,4 +161,24 @@ class TestToolRegistration:
         assert account_info_tool is not None
         assert (
             account_info_tool.description == "Gets basic Robinhood account information."
+        )
+
+    @pytest.mark.asyncio
+    async def test_health_check_tool_returns_structured_components(self) -> None:
+        """Health tool should return structured component payload from helper."""
+        expected = {
+            "result": {
+                "status": "success",
+                "health_status": "healthy",
+                "components": {"broker:robinhood": {"status": "healthy"}},
+            }
+        }
+        with patch(
+            "open_stocks_mcp.server.app.get_health_check_data", return_value=expected
+        ):
+            result = await health_check()
+
+        assert result["result"]["status"] == "success"
+        assert (
+            result["result"]["components"]["broker:robinhood"]["status"] == "healthy"
         )

--- a/tests/server/test_tool_helpers.py
+++ b/tests/server/test_tool_helpers.py
@@ -175,23 +175,27 @@ class TestHealthCheckHelper:
 
     @pytest.mark.asyncio
     async def test_returns_health_status(self) -> None:
-        fake_health = {"healthy": True, "checks": {"db": "ok"}}
+        fake_health = {
+            "status": "degraded",
+            "components": {"metrics": {"status": "healthy", "last_checked": "x"}},
+            "timestamp": 123.0,
+        }
 
         async def fake_get_health() -> dict:
             return fake_health
 
         with patch(
-            "open_stocks_mcp.server.tool_helpers.get_metrics_collector"
-        ) as mock_get_mc:
-            mc = MagicMock()
-            mc.get_health_status.side_effect = fake_get_health
-            mock_get_mc.return_value = mc
+            "open_stocks_mcp.server.tool_helpers.get_health_service"
+        ) as mock_get_hs:
+            hs = MagicMock()
+            hs.get_status.side_effect = fake_get_health
+            mock_get_hs.return_value = hs
 
             response = await get_health_check_data()
 
         assert response["result"]["status"] == "success"
-        assert response["result"]["healthy"] is True
-        assert response["result"]["checks"] == {"db": "ok"}
+        assert response["result"]["health_status"] == "degraded"
+        assert "components" in response["result"]
 
 
 @pytest.mark.journey_system

--- a/tests/unit/test_health_service.py
+++ b/tests/unit/test_health_service.py
@@ -1,0 +1,130 @@
+"""Unit tests for component health aggregation."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from open_stocks_mcp.brokers.base import BrokerAuthStatus
+from open_stocks_mcp.config import load_config
+from open_stocks_mcp.health import HealthService
+
+
+def _fake_broker(name: str, status: BrokerAuthStatus, error_message: str | None = None) -> MagicMock:
+    broker = MagicMock()
+    broker.name = name
+    broker.auth_info.status = status
+    broker.auth_info.error_message = error_message
+    return broker
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_structured_snapshot_from_cached_broker_status() -> None:
+    registry = MagicMock()
+    robinhood = _fake_broker("robinhood", BrokerAuthStatus.AUTHENTICATED)
+    schwab = _fake_broker("schwab", BrokerAuthStatus.NOT_CONFIGURED)
+    registry.list_brokers.return_value = ["robinhood", "schwab"]
+    registry.get_broker.side_effect = lambda name: {"robinhood": robinhood, "schwab": schwab}[name]
+
+    metrics_collector = AsyncMock()
+    metrics_collector.get_health_status.return_value = {"status": "healthy", "issues": []}
+
+    session_manager = MagicMock()
+    session_manager.get_session_info.return_value = {"authenticated": True, "session_duration": 123}
+
+    service = HealthService(
+        registry=registry,
+        metrics_collector=metrics_collector,
+        session_manager=session_manager,
+    )
+
+    result = await service.get_status()
+
+    assert set(result.keys()) == {"status", "components", "timestamp"}
+    assert result["components"]["broker:robinhood"]["status"] == "healthy"
+    assert result["components"]["broker:schwab"]["status"] == "unhealthy"
+    assert result["components"]["metrics"]["status"] == "healthy"
+    assert result["status"] == "unhealthy"
+    assert not robinhood.authenticate.called
+    assert not robinhood.is_authenticated.called
+    assert not schwab.authenticate.called
+    assert not schwab.is_authenticated.called
+
+
+@pytest.mark.asyncio
+async def test_metrics_component_transitions_healthy_to_degraded_to_unhealthy() -> None:
+    registry = MagicMock()
+    registry.list_brokers.return_value = []
+    metrics_collector = AsyncMock()
+    metrics_collector.get_health_status.side_effect = [
+        {"status": "healthy", "issues": []},
+        {"status": "degraded", "issues": ["a"]},
+        {"status": "unhealthy", "issues": ["b"]},
+    ]
+    session_manager = MagicMock()
+    session_manager.get_session_info.return_value = {"authenticated": True}
+
+    service = HealthService(registry=registry, metrics_collector=metrics_collector, session_manager=session_manager)
+
+    first = await service.get_status()
+    second = await service.get_status()
+    third = await service.get_status()
+
+    assert first["components"]["metrics"]["status"] == "healthy"
+    assert second["components"]["metrics"]["status"] == "degraded"
+    assert third["components"]["metrics"]["status"] == "unhealthy"
+
+
+@pytest.mark.asyncio
+async def test_broker_component_transitions_on_auth_status_change() -> None:
+    broker = _fake_broker("robinhood", BrokerAuthStatus.NOT_CONFIGURED)
+    registry = MagicMock()
+    registry.list_brokers.return_value = ["robinhood"]
+    registry.get_broker.return_value = broker
+    metrics_collector = AsyncMock()
+    metrics_collector.get_health_status.return_value = {"status": "healthy", "issues": []}
+    session_manager = MagicMock()
+    session_manager.get_session_info.return_value = {"authenticated": True}
+    service = HealthService(registry=registry, metrics_collector=metrics_collector, session_manager=session_manager)
+
+    s1 = await service.get_status()
+    broker.auth_info.status = BrokerAuthStatus.AUTHENTICATING
+    s2 = await service.get_status()
+    broker.auth_info.status = BrokerAuthStatus.AUTHENTICATED
+    s3 = await service.get_status()
+    broker.auth_info.status = BrokerAuthStatus.TOKEN_EXPIRED
+    s4 = await service.get_status()
+
+    assert s1["components"]["broker:robinhood"]["status"] == "unhealthy"
+    assert s2["components"]["broker:robinhood"]["status"] == "degraded"
+    assert s3["components"]["broker:robinhood"]["status"] == "healthy"
+    assert s4["components"]["broker:robinhood"]["status"] == "unhealthy"
+
+
+@pytest.mark.asyncio
+async def test_monitoring_disabled_skips_metrics_collection() -> None:
+    registry = MagicMock()
+    registry.list_brokers.return_value = []
+    metrics_collector = AsyncMock()
+    session_manager = MagicMock()
+    session_manager.get_session_info.return_value = {"authenticated": True}
+    service = HealthService(
+        registry=registry,
+        metrics_collector=metrics_collector,
+        session_manager=session_manager,
+        monitoring_enabled=False,
+    )
+
+    result = await service.get_status()
+    metrics_collector.get_health_status.assert_not_called()
+    assert result["components"]["metrics"]["status"] == "healthy"
+    assert result["components"]["metrics"]["detail"] == "monitoring disabled"
+
+
+def test_load_config_reads_monitoring_enabled_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MONITORING_ENABLED", "false")
+    cfg = load_config()
+    assert cfg.monitoring_enabled is False
+
+    monkeypatch.delenv("MONITORING_ENABLED", raising=False)
+    cfg_default = load_config()
+    assert cfg_default.monitoring_enabled is True

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,50 @@
+"""Unit tests for monitoring health thresholds."""
+
+from datetime import datetime
+
+import pytest
+
+from open_stocks_mcp.monitoring import MetricsCollector
+
+
+@pytest.mark.asyncio
+async def test_get_health_status_thresholds_map_correctly() -> None:
+    collector = MetricsCollector()
+    now = datetime.now()
+
+    collector.api_calls.extend(
+        [
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+            (now, "tool", True),
+        ]
+    )
+
+    collector.errors.extend([(now, "tool", "err")])
+    healthy = await collector.get_health_status()
+    assert healthy["status"] == "healthy"
+
+    collector.errors.extend([(now, "tool", "err"), (now, "tool", "err")])
+    degraded = await collector.get_health_status()
+    assert degraded["status"] == "degraded"
+
+    collector.errors.extend([(now, "tool", "err"), (now, "tool", "err"), (now, "tool", "err")])
+    unhealthy = await collector.get_health_status()
+    assert unhealthy["status"] == "unhealthy"


### PR DESCRIPTION
Closes #161

## Changes
- add `HealthService` in `src/open_stocks_mcp/health.py` to aggregate component status for metrics, session, and per-broker auth state
- enrich HTTP `/health` to return structured component payload while preserving legacy `session`/`health` fields for compatibility
- update MCP `health_check` helper to source data from `HealthService`
- add `MONITORING_ENABLED` config toggle and support disabled monitoring mode in health output
- fix metrics threshold ordering so severe error/latency conditions correctly map to `unhealthy`
- add unit tests for health state transitions, broker auth mapping, monitoring toggle, and threshold mapping

## Test plan
- `uv run pytest tests/unit/test_health_service.py tests/unit/test_monitoring.py tests/server/test_tool_helpers.py tests/http_transport/test_http_server.py::TestHTTPEndpoints::test_health_check -q`
- `uv run ruff check src/open_stocks_mcp/health.py src/open_stocks_mcp/config.py src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/tool_helpers.py src/open_stocks_mcp/server/http_transport.py tests/unit/test_health_service.py tests/unit/test_monitoring.py tests/server/test_tool_helpers.py tests/server/test_server_app.py tests/http_transport/test_http_server.py tests/http_transport/test_http_auth.py`
- `uv run mypy src/open_stocks_mcp/health.py src/open_stocks_mcp/config.py src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/tool_helpers.py src/open_stocks_mcp/server/http_transport.py`
