### PR TITLE
feat: configure retry and timeout defaults

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -4,12 +4,86 @@ import os
 from dataclasses import dataclass
 
 
+def _env_int(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _env_optional_int(name: str) -> int | None:
+    raw_value = os.getenv(name)
+    if raw_value is None or raw_value == "":
+        return None
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _env_float(name: str, default: float) -> float:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        return float(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a number") from exc
+
+
+@dataclass
+class RetryConfig:
+    """Configuration for transient API retry behavior."""
+
+    max_retries: int = 3
+    initial_delay: float = 1.0
+    backoff_factor: float = 2.0
+    auth_max_retries: int = 1
+    authentication_max_retries: int | None = None
+    network_max_retries: int | None = None
+    rate_limit_max_retries: int | None = None
+    api_max_retries: int | None = None
+    data_max_retries: int | None = None
+
+    def max_retries_for(self, error_type: str) -> int:
+        """Return retry attempts for a classified error type."""
+        overrides = {
+            "authentication": self.authentication_max_retries,
+            "network": self.network_max_retries,
+            "rate_limit": self.rate_limit_max_retries,
+            "api": self.api_max_retries,
+            "data": self.data_max_retries,
+        }
+        override = overrides.get(error_type)
+        if override is not None:
+            return override
+        return self.max_retries
+
+
+@dataclass
+class TimeoutConfig:
+    """Configuration for HTTP request timeout behavior."""
+
+    request_timeout_seconds: float = 120.0
+
+
 @dataclass
 class ServerConfig:
     """Configuration for the MCP server"""
 
     name: str = "Open Stocks MCP"
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
+    retry: RetryConfig | None = None
+    timeout: TimeoutConfig | None = None
+
+    def __post_init__(self) -> None:
+        if self.retry is None:
+            self.retry = RetryConfig()
+        if self.timeout is None:
+            self.timeout = TimeoutConfig()
 
 
 def load_config() -> ServerConfig:
@@ -17,4 +91,28 @@ def load_config() -> ServerConfig:
     return ServerConfig(
         name=os.getenv("MCP_SERVER_NAME", "Open Stocks MCP"),
         log_level=os.getenv("LOG_LEVEL", "INFO"),
+        retry=RetryConfig(
+            max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", 3),
+            initial_delay=_env_float("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY", 1.0),
+            backoff_factor=_env_float("OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR", 2.0),
+            auth_max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_AUTH_MAX_RETRIES", 1),
+            authentication_max_retries=_env_optional_int(
+                "OPEN_STOCKS_MCP_RETRY_AUTHENTICATION_MAX_RETRIES"
+            ),
+            network_max_retries=_env_optional_int(
+                "OPEN_STOCKS_MCP_RETRY_NETWORK_MAX_RETRIES"
+            ),
+            rate_limit_max_retries=_env_optional_int(
+                "OPEN_STOCKS_MCP_RETRY_RATE_LIMIT_MAX_RETRIES"
+            ),
+            api_max_retries=_env_optional_int("OPEN_STOCKS_MCP_RETRY_API_MAX_RETRIES"),
+            data_max_retries=_env_optional_int(
+                "OPEN_STOCKS_MCP_RETRY_DATA_MAX_RETRIES"
+            ),
+        ),
+        timeout=TimeoutConfig(
+            request_timeout_seconds=_env_float(
+                "OPEN_STOCKS_MCP_HTTP_REQUEST_TIMEOUT_SECONDS", 120.0
+            )
+        ),
     )

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -15,6 +15,7 @@ from mcp.server.fastmcp import FastMCP
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from open_stocks_mcp import __version__
+from open_stocks_mcp.config import load_config
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.monitoring import get_metrics_collector
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
@@ -186,7 +187,11 @@ def create_http_server(mcp_server: FastMCP, api_key: str | None = None) -> FastA
         allow_headers=["*"],
     )
 
-    app.add_middleware(TimeoutMiddleware, timeout=120.0)
+    timeout_config = load_config().timeout
+    request_timeout = (
+        timeout_config.request_timeout_seconds if timeout_config is not None else 120.0
+    )
+    app.add_middleware(TimeoutMiddleware, timeout=request_timeout)
     app.add_middleware(SecurityMiddleware)
     app.add_middleware(BearerAuthMiddleware, api_key=api_key)
 
@@ -297,7 +302,9 @@ def create_http_server(mcp_server: FastMCP, api_key: str | None = None) -> FastA
 
             tools = await list_available_tools(mcp_server)
             if not isinstance(tools, dict) or "error" in tools or "result" not in tools:
-                logger.error("list_available_tools returned an unexpected or error response")
+                logger.error(
+                    "list_available_tools returned an unexpected or error response"
+                )
                 raise HTTPException(status_code=500, detail="Failed to list tools")
             return tools
         except HTTPException:

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -5,6 +5,7 @@ import functools
 from collections.abc import Callable
 from typing import Any
 
+from open_stocks_mcp.config import load_config
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.exceptions import (
     AuthenticationError,
@@ -16,9 +17,9 @@ from open_stocks_mcp.tools.exceptions import (
 async def execute_with_retry(
     func: Callable[..., Any],
     *args: Any,
-    max_retries: int = 3,
-    delay: float = 1.0,
-    backoff_factor: float = 2.0,
+    max_retries: int | None = None,
+    delay: float | None = None,
+    backoff_factor: float | None = None,
     handle_auth_errors: bool = True,
     rate_limit: bool = True,
     endpoint: str | None = None,
@@ -29,12 +30,23 @@ async def execute_with_retry(
     from open_stocks_mcp.tools.session_manager import get_session_manager
 
     last_exception = None
+    retry_config = load_config().retry
+    if retry_config is None:
+        raise RuntimeError("Retry configuration unavailable")
+    configured_max_retries = (
+        retry_config.max_retries if max_retries is None else max_retries
+    )
+    retry_delay = retry_config.initial_delay if delay is None else delay
+    retry_backoff_factor = (
+        retry_config.backoff_factor if backoff_factor is None else backoff_factor
+    )
     session_manager = get_session_manager()
     rate_limiter = get_rate_limiter() if rate_limit else None
     auth_retry_count = 0
-    max_auth_retries = 1
+    max_auth_retries = retry_config.auth_max_retries
 
-    for attempt in range(max_retries + 1):
+    attempt = 0
+    while attempt <= configured_max_retries:
         try:
             if rate_limiter:
                 await rate_limiter.acquire(endpoint)
@@ -52,6 +64,10 @@ async def execute_with_retry(
         except Exception as e:
             last_exception = e
             classified_error = classify_error(e)
+            if max_retries is None:
+                configured_max_retries = retry_config.max_retries_for(
+                    classified_error.error_type
+                )
 
             if isinstance(classified_error, AuthenticationError) and handle_auth_errors:
                 if auth_retry_count < max_auth_retries:
@@ -63,8 +79,9 @@ async def execute_with_retry(
                     try:
                         success = await session_manager.refresh_session()
                         if success:
-                            logger.info("Re-authentication successful, retrying request")
-                            attempt -= 1
+                            logger.info(
+                                "Re-authentication successful, retrying request"
+                            )
                             continue
                         logger.error("Re-authentication failed")
                         raise classified_error
@@ -79,14 +96,15 @@ async def execute_with_retry(
                 logger.error(f"Data error, not retrying: {e}")
                 raise classified_error from e
 
-            if attempt < max_retries:
-                wait_time = delay * (backoff_factor**attempt)
+            if attempt < configured_max_retries:
+                wait_time = retry_delay * (retry_backoff_factor**attempt)
                 logger.warning(
                     f"Attempt {attempt + 1} failed, retrying in {wait_time}s: {e}"
                 )
                 await asyncio.sleep(wait_time)
+                attempt += 1
             else:
-                logger.error(f"All {max_retries + 1} attempts failed: {e}")
+                logger.error(f"All {configured_max_retries + 1} attempts failed: {e}")
                 raise classified_error from e
 
     if last_exception:

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -9,7 +9,8 @@ import httpx
 import pytest
 from mcp.server.fastmcp import FastMCP
 
-from open_stocks_mcp.server.http_transport import create_http_server
+from open_stocks_mcp import __version__
+from open_stocks_mcp.server.http_transport import TimeoutMiddleware, create_http_server
 
 
 @pytest.fixture
@@ -24,6 +25,22 @@ def mcp_server() -> FastMCP:
         return {"result": {"message": "test successful", "status": "success"}}
 
     return server
+
+
+def test_timeout_middleware_uses_configured_timeout(
+    monkeypatch: pytest.MonkeyPatch, mcp_server: FastMCP
+) -> None:
+    """Configured HTTP request timeout is wired into middleware."""
+    monkeypatch.setenv("OPEN_STOCKS_MCP_HTTP_REQUEST_TIMEOUT_SECONDS", "7.5")
+
+    app = create_http_server(mcp_server)
+
+    timeout_middleware = next(
+        middleware
+        for middleware in app.user_middleware
+        if middleware.cls is TimeoutMiddleware
+    )
+    assert timeout_middleware.kwargs["timeout"] == 7.5
 
 
 @pytest.fixture
@@ -51,7 +68,7 @@ class TestHTTPEndpoints:
 
         data = response.json()
         assert data["name"] == "Open Stocks MCP Server"
-        assert data["version"] == "0.6.4"
+        assert data["version"] == __version__
         assert data["transport"] == "http"
         assert "endpoints" in data
 
@@ -62,7 +79,7 @@ class TestHTTPEndpoints:
 
         data = response.json()
         assert data["status"] == "healthy"
-        assert data["version"] == "0.6.4"
+        assert data["version"] == __version__
         assert data["transport"] == "http"
         assert "timestamp" in data
 
@@ -118,11 +135,11 @@ class TestMCPIntegration:
         # Should get a method not allowed or proper response, not 404
         assert response.status_code != 404
 
-    async def test_sse_endpoint(self, http_client: httpx.AsyncClient) -> None:
-        """Test SSE endpoint is accessible"""
-        response = await http_client.get("/sse")
-        # Should get a method not allowed or proper response, not 404
-        assert response.status_code != 404
+    async def test_sse_endpoint(self, mcp_server: FastMCP) -> None:
+        """Test SSE endpoint is registered."""
+        app = create_http_server(mcp_server)
+
+        assert any(getattr(route, "path", None) == "/sse" for route in app.routes)
 
     @pytest.mark.anyio
     async def test_mcp_endpoint_rejects_oversized_body(

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,0 +1,92 @@
+"""Tests for configurable retry behavior."""
+
+from collections.abc import Callable
+from unittest.mock import Mock
+
+import pytest
+
+from open_stocks_mcp.tools import rate_limiter, retry
+from open_stocks_mcp.tools import session_manager as session_manager_module
+from open_stocks_mcp.tools.error_handling import NetworkError, execute_with_retry
+
+
+def _patch_retry_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[float]:
+    session_manager = Mock()
+    session_manager.update_last_successful_call = Mock()
+    session_manager.refresh_session = Mock()
+    monkeypatch.setattr(
+        session_manager_module, "get_session_manager", lambda: session_manager
+    )
+    monkeypatch.setattr(rate_limiter, "get_rate_limiter", lambda: None)
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(retry.asyncio, "sleep", fake_sleep)
+    return sleep_calls
+
+
+def _always_fails(counter: list[int]) -> Callable[[], None]:
+    def fail() -> None:
+        counter.append(1)
+        raise RuntimeError("connection timeout")
+
+    return fail
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_uses_configured_retry_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", "2")
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY", "0.25")
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR", "3.0")
+    sleep_calls = _patch_retry_dependencies(monkeypatch)
+    attempts: list[int] = []
+
+    with pytest.raises(NetworkError):
+        await execute_with_retry(_always_fails(attempts))
+
+    assert len(attempts) == 3
+    assert sleep_calls == [0.25, 0.75]
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_uses_per_error_class_retry_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", "0")
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_NETWORK_MAX_RETRIES", "2")
+    sleep_calls = _patch_retry_dependencies(monkeypatch)
+    attempts: list[int] = []
+
+    with pytest.raises(NetworkError):
+        await execute_with_retry(_always_fails(attempts))
+
+    assert len(attempts) == 3
+    assert sleep_calls == [1.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_explicit_arguments_override_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", "3")
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_NETWORK_MAX_RETRIES", "3")
+    sleep_calls = _patch_retry_dependencies(monkeypatch)
+    attempts: list[int] = []
+
+    with pytest.raises(NetworkError):
+        await execute_with_retry(
+            _always_fails(attempts),
+            max_retries=0,
+            delay=0.5,
+            backoff_factor=10.0,
+        )
+
+    assert len(attempts) == 1
+    assert sleep_calls == []


### PR DESCRIPTION
Closes #159

## Changes
- Add `RetryConfig` and `TimeoutConfig` to `open_stocks_mcp.config` with environment-backed retry/timeout knobs.
- Resolve `execute_with_retry()` defaults from config while preserving explicit call-site retry overrides and per-error-class retry overrides.
- Propagate configured HTTP request timeout into `TimeoutMiddleware`.
- Add focused retry and timeout coverage, and repair stale/hanging HTTP transport assertions so the transport file can run cleanly.

## Test plan
- `uv run pytest tests/unit/test_error_handling.py -q`
- `uv run pytest tests/http_transport/test_http_server.py -q`
- `uv run pytest tests/unit/test_error_handling.py tests/http_transport/test_http_server.py -q -k 'retry or timeout'`
- `uv run ruff check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/server/http_transport.py tests/unit/test_error_handling.py tests/http_transport/test_http_server.py`
- `uv run ruff format --check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/server/http_transport.py tests/unit/test_error_handling.py tests/http_transport/test_http_server.py`
- `uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/server/http_transport.py`
- `git diff --check`

## Note
- Attempted `uv run pytest tests/unit/ -m 'not slow and not exception_test' -q` twice; both runs stalled in the existing full unit-suite path after reaching `tests/unit/test_options_tools.py`, so the worktree pytest processes were stopped and the affected focused/file-level suites above were used for verification.