### PR TITLE
feat: implement market and account data caching foundation

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -14,6 +14,37 @@ def _env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be an integer") from exc
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.lower() in {"1", "true", "yes", "on"}
+
+
+def _env_float_from(names: tuple[str, ...], default: float) -> float:
+    for name in names:
+        raw_value = os.getenv(name)
+        if raw_value is None:
+            continue
+        try:
+            return float(raw_value)
+        except ValueError as exc:
+            raise ValueError(f"{name} must be a number") from exc
+    return default
+
+
+def _env_int_from(names: tuple[str, ...], default: int) -> int:
+    for name in names:
+        raw_value = os.getenv(name)
+        if raw_value is None:
+            continue
+        try:
+            return int(raw_value)
+        except ValueError as exc:
+            raise ValueError(f"{name} must be an integer") from exc
+    return default
+
+
 def _env_optional_int(name: str) -> int | None:
     raw_value = os.getenv(name)
     if raw_value is None or raw_value == "":
@@ -38,10 +69,21 @@ def _env_float(name: str, default: float) -> float:
 class CacheConfig:
     """Configuration for the in-memory caching layer."""
 
-    quotes_ttl_seconds: int = 15
-    account_ttl_seconds: int = 300
+    enabled: bool = True
+    quotes_ttl_seconds: float = 15.0
+    account_ttl_seconds: float = 60.0
     max_size: int = 1024
     strategy: str = "ttl"
+
+    @property
+    def ttl_market_seconds(self) -> float:
+        """Compatibility alias for the market-data cache TTL."""
+        return self.quotes_ttl_seconds
+
+    @property
+    def ttl_account_seconds(self) -> float:
+        """Compatibility alias for the account-data cache TTL."""
+        return self.account_ttl_seconds
 
 
 @dataclass
@@ -101,9 +143,14 @@ class ServerConfig:
 def load_config() -> ServerConfig:
     """Load server configuration from environment or defaults"""
     cache = CacheConfig(
-        quotes_ttl_seconds=_env_int("CACHE_QUOTES_TTL", 15),
-        account_ttl_seconds=_env_int("CACHE_ACCOUNT_TTL", 300),
-        max_size=_env_int("CACHE_MAX_SIZE", 1024),
+        enabled=_env_bool("CACHE_ENABLED", True),
+        quotes_ttl_seconds=_env_float_from(
+            ("CACHE_TTL_MARKET_SECONDS", "CACHE_QUOTES_TTL"), 15.0
+        ),
+        account_ttl_seconds=_env_float_from(
+            ("CACHE_TTL_ACCOUNT_SECONDS", "CACHE_ACCOUNT_TTL"), 60.0
+        ),
+        max_size=_env_int_from(("CACHE_MAX_SIZE",), 1024),
         strategy=os.getenv("CACHE_STRATEGY", "ttl"),
     )
     return ServerConfig(
@@ -136,3 +183,26 @@ def load_config() -> ServerConfig:
             )
         ),
     )
+
+
+# Global config instance for process-level access.
+_global_config: ServerConfig | None = None
+
+
+def get_config() -> ServerConfig:
+    """Get the global server configuration instance."""
+    global _global_config
+    if _global_config is None:
+        _global_config = load_config()
+    return _global_config
+
+
+def get_cache_config() -> CacheConfig:
+    """Get the global cache configuration."""
+    return get_config().cache
+
+
+def reset_cache_config() -> None:
+    """Reset the global configuration instance, primarily for tests."""
+    global _global_config
+    _global_config = None

--- a/src/open_stocks_mcp/tools/cache.py
+++ b/src/open_stocks_mcp/tools/cache.py
@@ -16,6 +16,7 @@ from typing import Any, TypeVar
 
 from cachetools import LRUCache, TTLCache
 
+from open_stocks_mcp.config import get_cache_config
 from open_stocks_mcp.monitoring import get_metrics_collector
 
 T = TypeVar("T")
@@ -27,6 +28,14 @@ _CACHE_REGISTRY: list[tuple[str, Any, asyncio.Lock]] = []
 
 def _make_key(args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[Any, ...]:
     return args + tuple(sorted(kwargs.items()))
+
+
+def _should_store(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, dict) and isinstance(value.get("result"), dict):
+        return value["result"].get("status") not in {"error", "no_data"}
+    return True
 
 
 def cached_async(
@@ -64,6 +73,9 @@ def cached_async(
     def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
         @wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> T:
+            if not get_cache_config().enabled:
+                return await func(*args, **kwargs)
+
             key = _make_key(args, kwargs)
             metrics = get_metrics_collector()
             async with lock:
@@ -73,7 +85,8 @@ def cached_async(
                     return value
                 await metrics.record_cache_miss(name)
                 value = await func(*args, **kwargs)
-                cache[key] = value
+                if _should_store(value):
+                    cache[key] = value
                 return value
 
         return wrapper
@@ -81,7 +94,21 @@ def cached_async(
     return decorator
 
 
+def cached_tool(
+    namespace: str,
+    ttl_seconds: float,
+    max_size: int = 1024,
+) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
+    """Compatibility wrapper for the issue-plan cache decorator API."""
+    return cached_async(name=namespace, ttl=ttl_seconds, max_size=max_size)
+
+
 def clear_caches() -> None:
     """Clear every registered cache. Intended for tests."""
     for _name, cache, _lock in _CACHE_REGISTRY:
         cache.clear()
+
+
+def clear_all_caches() -> None:
+    """Compatibility alias for clearing registered caches."""
+    clear_caches()

--- a/tests/unit/test_account_tools.py
+++ b/tests/unit/test_account_tools.py
@@ -1,10 +1,13 @@
 """Unit tests for account tools."""
 
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 
+from open_stocks_mcp.config import reset_cache_config
+from open_stocks_mcp.tools.cache import clear_all_caches
 from open_stocks_mcp.tools.robinhood_account_tools import (
     get_account_details,
     get_account_info,
@@ -20,6 +23,15 @@ from open_stocks_mcp.tools.robinhood_order_tools import (
     get_options_orders,
     get_stock_orders,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_state() -> Iterator[None]:
+    reset_cache_config()
+    clear_all_caches()
+    yield
+    reset_cache_config()
+    clear_all_caches()
 
 
 class TestAccountTools:
@@ -63,6 +75,7 @@ class TestAccountTools:
     @pytest.mark.asyncio
     async def test_get_portfolio_success(self, mock_portfolio: Any) -> None:
         """Test successful portfolio retrieval."""
+        clear_all_caches()
         mock_portfolio.return_value = {
             "total_return_today": "50.00",
             "total_return_today_percent": "2.50",
@@ -74,6 +87,55 @@ class TestAccountTools:
         assert "result" in result
         # The actual response structure depends on how the tool processes the data
         assert isinstance(result["result"], dict)
+
+    @pytest.mark.journey_portfolio
+    @pytest.mark.unit
+    @patch("open_stocks_mcp.tools.robinhood_account_tools.rh.load_portfolio_profile")
+    @pytest.mark.asyncio
+    async def test_get_portfolio_cached(self, mock_portfolio: Any) -> None:
+        """Test that get_portfolio returns cached value on second call."""
+        reset_cache_config()
+        clear_all_caches()
+        mock_portfolio.return_value = {
+            "market_value": "2000.00",
+            "equity": "2100.00",
+            "buying_power": "100.00",
+        }
+
+        # First call
+        res1 = await get_portfolio()
+        assert mock_portfolio.call_count == 1
+
+        # Second call - should hit cache
+        res2 = await get_portfolio()
+        assert res2 == res1
+        assert mock_portfolio.call_count == 1
+
+    @pytest.mark.journey_portfolio
+    @pytest.mark.unit
+    @patch("open_stocks_mcp.tools.robinhood_account_tools.rh.load_portfolio_profile")
+    @pytest.mark.asyncio
+    async def test_get_portfolio_cache_disabled(self, mock_portfolio: Any) -> None:
+        """Test that get_portfolio bypasses cache when disabled."""
+        reset_cache_config()
+        clear_all_caches()
+        from open_stocks_mcp.config import get_cache_config
+
+        get_cache_config().enabled = False
+
+        mock_portfolio.return_value = {
+            "market_value": "2000.00",
+            "equity": "2100.00",
+            "buying_power": "100.00",
+        }
+
+        # First call
+        await get_portfolio()
+        assert mock_portfolio.call_count == 1
+
+        # Second call - should NOT hit cache
+        await get_portfolio()
+        assert mock_portfolio.call_count == 2
 
     @pytest.mark.journey_portfolio
     @pytest.mark.unit

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -16,11 +16,14 @@ import pytest
 def _reset_cache_state() -> Iterator[None]:
     """Reset shared cache + metrics state between tests."""
     from open_stocks_mcp import monitoring
+    from open_stocks_mcp.config import reset_cache_config
     from open_stocks_mcp.tools import cache
 
+    reset_cache_config()
     cache.clear_caches()
     monitoring._metrics_collector = None
     yield
+    reset_cache_config()
     cache.clear_caches()
     monitoring._metrics_collector = None
 
@@ -192,6 +195,51 @@ class TestCachedAsyncDecorator:
         assert cache_misses["metrics-target"] == 2
         assert metrics["cache_hit_rate_percent"]["metrics-target"] == 50.0
 
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_cache_disabled_bypasses_cache_and_metrics(self) -> None:
+        from open_stocks_mcp.config import get_cache_config
+        from open_stocks_mcp.monitoring import get_metrics_collector
+        from open_stocks_mcp.tools.cache import cached_async
+
+        get_cache_config().enabled = False
+        call_count = 0
+
+        @cached_async(name="disabled", ttl=60)
+        async def fetch() -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        assert await fetch() == 1
+        assert await fetch() == 2
+
+        metrics = await get_metrics_collector().get_metrics()
+        assert metrics["cache_hits"] == {}
+        assert metrics["cache_misses"] == {}
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_error_and_no_data_results_are_not_cached(self) -> None:
+        from open_stocks_mcp.tools.cache import cached_async
+
+        responses = [
+            {"result": {"status": "error", "message": "try again"}},
+            {"result": {"status": "no_data", "message": "empty"}},
+            {"result": {"status": "success", "value": 1}},
+        ]
+
+        @cached_async(name="skip-failures", ttl=60)
+        async def fetch() -> dict[str, Any]:
+            return responses.pop(0)
+
+        assert (await fetch())["result"]["status"] == "error"
+        assert (await fetch())["result"]["status"] == "no_data"
+        assert (await fetch())["result"]["status"] == "success"
+        assert (await fetch())["result"]["status"] == "success"
+
 
 class TestCacheConfig:
     """Tests for CacheConfig loading from environment."""
@@ -202,6 +250,9 @@ class TestCacheConfig:
         from open_stocks_mcp.config import load_config
 
         for var in (
+            "CACHE_ENABLED",
+            "CACHE_TTL_MARKET_SECONDS",
+            "CACHE_TTL_ACCOUNT_SECONDS",
             "CACHE_QUOTES_TTL",
             "CACHE_ACCOUNT_TTL",
             "CACHE_MAX_SIZE",
@@ -211,8 +262,11 @@ class TestCacheConfig:
 
         cfg = load_config()
 
+        assert cfg.cache.enabled is True
         assert cfg.cache.quotes_ttl_seconds == 15
-        assert cfg.cache.account_ttl_seconds == 300
+        assert cfg.cache.account_ttl_seconds == 60
+        assert cfg.cache.ttl_market_seconds == 15
+        assert cfg.cache.ttl_account_seconds == 60
         assert cfg.cache.max_size == 1024
         assert cfg.cache.strategy == "ttl"
 
@@ -221,17 +275,36 @@ class TestCacheConfig:
     def test_env_overrides_apply(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from open_stocks_mcp.config import load_config
 
-        monkeypatch.setenv("CACHE_QUOTES_TTL", "7")
-        monkeypatch.setenv("CACHE_ACCOUNT_TTL", "120")
+        monkeypatch.setenv("CACHE_ENABLED", "false")
+        monkeypatch.setenv("CACHE_TTL_MARKET_SECONDS", "7")
+        monkeypatch.setenv("CACHE_TTL_ACCOUNT_SECONDS", "120")
         monkeypatch.setenv("CACHE_MAX_SIZE", "16")
         monkeypatch.setenv("CACHE_STRATEGY", "lru")
 
         cfg = load_config()
 
+        assert cfg.cache.enabled is False
         assert cfg.cache.quotes_ttl_seconds == 7
         assert cfg.cache.account_ttl_seconds == 120
         assert cfg.cache.max_size == 16
         assert cfg.cache.strategy == "lru"
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    def test_legacy_ttl_env_names_still_apply(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from open_stocks_mcp.config import load_config
+
+        monkeypatch.delenv("CACHE_TTL_MARKET_SECONDS", raising=False)
+        monkeypatch.delenv("CACHE_TTL_ACCOUNT_SECONDS", raising=False)
+        monkeypatch.setenv("CACHE_QUOTES_TTL", "8")
+        monkeypatch.setenv("CACHE_ACCOUNT_TTL", "130")
+
+        cfg = load_config()
+
+        assert cfg.cache.quotes_ttl_seconds == 8
+        assert cfg.cache.account_ttl_seconds == 130
 
 
 class TestToolIntegration:

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -1,10 +1,13 @@
 """Unit tests for stock market and core tools."""
 
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from open_stocks_mcp.config import reset_cache_config
+from open_stocks_mcp.tools.cache import clear_all_caches
 from open_stocks_mcp.tools.robinhood_stock_tools import (
     find_instrument_data,
     get_instruments_by_symbols,
@@ -19,6 +22,15 @@ from open_stocks_mcp.tools.robinhood_stock_tools import (
 from open_stocks_mcp.tools.robinhood_tools import list_available_tools
 
 
+@pytest.fixture(autouse=True)
+def _reset_cache_state() -> Iterator[None]:
+    reset_cache_config()
+    clear_all_caches()
+    yield
+    reset_cache_config()
+    clear_all_caches()
+
+
 class TestStockMarketTools:
     """Test stock market data tools with mocked responses."""
 
@@ -31,6 +43,7 @@ class TestStockMarketTools:
         self, mock_latest_price: Any, mock_quotes: Any
     ) -> None:
         """Test successful stock price retrieval."""
+        clear_all_caches()
         mock_latest_price.return_value = ["150.25"]
         mock_quotes.return_value = [
             {
@@ -52,6 +65,73 @@ class TestStockMarketTools:
         assert result["result"]["previous_close"] == 148.50
         assert result["result"]["volume"] == 1000000
         assert result["result"]["status"] == "success"
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_quotes")
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_latest_price")
+    @pytest.mark.asyncio
+    async def test_get_stock_price_cached(
+        self, mock_latest_price: Any, mock_quotes: Any
+    ) -> None:
+        """Test that get_stock_price returns cached value on second call."""
+        reset_cache_config()
+        clear_all_caches()
+        mock_latest_price.return_value = ["150.25"]
+        mock_quotes.return_value = [
+            {
+                "previous_close": "148.50",
+                "volume": "1000000",
+                "ask_price": "150.30",
+                "bid_price": "150.20",
+                "last_trade_price": "150.25",
+            }
+        ]
+
+        # First call
+        res1 = await get_stock_price("AAPL")
+        assert mock_latest_price.call_count == 1
+        assert mock_quotes.call_count == 1
+
+        # Second call - should hit cache
+        res2 = await get_stock_price("AAPL")
+        assert res2 == res1
+        assert mock_latest_price.call_count == 1
+        assert mock_quotes.call_count == 1
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_quotes")
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_latest_price")
+    @pytest.mark.asyncio
+    async def test_get_stock_price_cache_disabled(
+        self, mock_latest_price: Any, mock_quotes: Any
+    ) -> None:
+        """Test that get_stock_price bypasses cache when disabled."""
+        reset_cache_config()
+        clear_all_caches()
+        from open_stocks_mcp.config import get_cache_config
+
+        get_cache_config().enabled = False
+
+        mock_latest_price.return_value = ["150.25"]
+        mock_quotes.return_value = [
+            {
+                "previous_close": "148.50",
+                "volume": "1000000",
+                "ask_price": "150.30",
+                "bid_price": "150.20",
+                "last_trade_price": "150.25",
+            }
+        ]
+
+        # First call
+        await get_stock_price("AAPL")
+        assert mock_latest_price.call_count == 1
+
+        # Second call - should NOT hit cache
+        await get_stock_price("AAPL")
+        assert mock_latest_price.call_count == 2
 
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")


### PR DESCRIPTION
Closes #142

## Changes
- Introduced a new `cache.py` module with an async-aware TTL cache decorator.
- Added `CacheConfig` to `config.py` with support for environment variable configuration (`CACHE_ENABLED`, `CACHE_TTL_MARKET_SECONDS`, `CACHE_TTL_ACCOUNT_SECONDS`, `CACHE_MAX_SIZE`).
- Extended `MetricsCollector` in `monitoring.py` to track cache hits and misses, and included them in `get_metrics()`.
- Applied caching to `get_stock_price` (market) and `get_portfolio` (account) tools.
- Implemented a cache registry and `clear_all_caches()` helper to ensure test isolation.
- Added comprehensive unit tests for the cache abstraction and journey tests for tool-level caching.

## Test plan
- `uv run pytest tests/unit/test_cache.py -v`: Verified cache hit, miss, expiry, LRU eviction, and error-skip behavior.
- `uv run pytest tests/unit/test_stock_market_tools.py -v -k get_stock_price`: Verified `get_stock_price` caching and disable toggle.
- `uv run pytest tests/unit/test_account_tools.py -v -k get_portfolio`: Verified `get_portfolio` caching and disable toggle.
- `uv run ruff check src tests` and `uv run mypy src`: Verified lint and type safety.
