### PR TITLE
feat: add in-memory caching layer for market and account data

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -1,7 +1,7 @@
 """Server configuration for Open Stocks MCP MCP server"""
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 def _env_int(name: str, default: int) -> int:
@@ -32,6 +32,16 @@ def _env_float(name: str, default: float) -> float:
         return float(raw_value)
     except ValueError as exc:
         raise ValueError(f"{name} must be a number") from exc
+
+
+@dataclass
+class CacheConfig:
+    """Configuration for the in-memory caching layer."""
+
+    quotes_ttl_seconds: int = 15
+    account_ttl_seconds: int = 300
+    max_size: int = 1024
+    strategy: str = "ttl"
 
 
 @dataclass
@@ -76,6 +86,7 @@ class ServerConfig:
 
     name: str = "Open Stocks MCP"
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
+    cache: CacheConfig = field(default_factory=CacheConfig)
     retry: RetryConfig | None = None
     timeout: TimeoutConfig | None = None
 
@@ -88,9 +99,16 @@ class ServerConfig:
 
 def load_config() -> ServerConfig:
     """Load server configuration from environment or defaults"""
+    cache = CacheConfig(
+        quotes_ttl_seconds=_env_int("CACHE_QUOTES_TTL", 15),
+        account_ttl_seconds=_env_int("CACHE_ACCOUNT_TTL", 300),
+        max_size=_env_int("CACHE_MAX_SIZE", 1024),
+        strategy=os.getenv("CACHE_STRATEGY", "ttl"),
+    )
     return ServerConfig(
         name=os.getenv("MCP_SERVER_NAME", "Open Stocks MCP"),
         log_level=os.getenv("LOG_LEVEL", "INFO"),
+        cache=cache,
         retry=RetryConfig(
             max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", 3),
             initial_delay=_env_float("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY", 1.0),

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -32,6 +32,10 @@ class MetricsCollector:
         self.total_errors = 0
         self.session_refreshes = 0
 
+        # Cache hit/miss counters, keyed by cache name
+        self.cache_hits: dict[str, int] = defaultdict(int)
+        self.cache_misses: dict[str, int] = defaultdict(int)
+
         self._lock = asyncio.Lock()
 
     async def record_api_call(
@@ -77,6 +81,16 @@ class MetricsCollector:
         async with self._lock:
             self.session_refreshes += 1
             logger.info(f"Session refresh recorded. Total: {self.session_refreshes}")
+
+    async def record_cache_hit(self, name: str) -> None:
+        """Record a cache hit for the named cache."""
+        async with self._lock:
+            self.cache_hits[name] += 1
+
+    async def record_cache_miss(self, name: str) -> None:
+        """Record a cache miss for the named cache."""
+        async with self._lock:
+            self.cache_misses[name] += 1
 
     def _clean_old_entries(self, now: datetime) -> None:
         """Remove entries older than the window size."""
@@ -155,6 +169,15 @@ class MetricsCollector:
                     "success_rate": (successful / total * 100.0) if total > 0 else 0.0,
                 }
 
+            cache_hit_rate: dict[str, float] = {}
+            for name in set(self.cache_hits) | set(self.cache_misses):
+                hits = self.cache_hits.get(name, 0)
+                misses = self.cache_misses.get(name, 0)
+                total = hits + misses
+                cache_hit_rate[name] = (
+                    round(hits / total * 100.0, 2) if total > 0 else 0.0
+                )
+
             return {
                 "window_minutes": self.window_size.total_seconds() / 60,
                 "total_calls": self.total_calls,
@@ -169,6 +192,9 @@ class MetricsCollector:
                 "session_refreshes": self.session_refreshes,
                 "error_types": dict(self.error_types),
                 "tool_usage": tool_stats,
+                "cache_hits": dict(self.cache_hits),
+                "cache_misses": dict(self.cache_misses),
+                "cache_hit_rate_percent": cache_hit_rate,
                 "timestamp": now.isoformat(),
             }
 

--- a/src/open_stocks_mcp/tools/cache.py
+++ b/src/open_stocks_mcp/tools/cache.py
@@ -1,0 +1,87 @@
+"""In-memory async caching layer for tool functions.
+
+Wraps async callables with a TTL or LRU cache (powered by ``cachetools``) and
+records hit/miss counters into the global :class:`MetricsCollector`. Used to
+suppress redundant Robin Stocks API calls for hot read-only paths such as
+quotes and portfolio overviews.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import Any, TypeVar
+
+from cachetools import LRUCache, TTLCache
+
+from open_stocks_mcp.monitoring import get_metrics_collector
+
+T = TypeVar("T")
+
+# Module-level registry so clear_caches() can reset every wrapped function's
+# state — tests in particular rely on this to avoid leaking across cases.
+_CACHE_REGISTRY: list[tuple[str, Any, asyncio.Lock]] = []
+
+
+def _make_key(args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[Any, ...]:
+    return args + tuple(sorted(kwargs.items()))
+
+
+def cached_async(
+    name: str,
+    *,
+    ttl: float | None = None,
+    max_size: int = 1024,
+    strategy: str = "ttl",
+    clock: Callable[[], float] | None = None,
+) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
+    """Return a decorator that memoizes an async callable.
+
+    Args:
+        name: Logical cache name used for metrics counters.
+        ttl: Time-to-live in seconds (TTL strategy). Defaults to 60 when unset.
+        max_size: Maximum number of cached entries.
+        strategy: ``"ttl"`` (default) or ``"lru"``.
+        clock: Optional monotonic clock for tests; only honored by the TTL
+            strategy. Defaults to :func:`time.monotonic`.
+    """
+    if strategy not in {"ttl", "lru"}:
+        raise ValueError(f"Unsupported cache strategy: {strategy!r}")
+
+    if strategy == "ttl":
+        timer = clock or time.monotonic
+        cache: Any = TTLCache(
+            maxsize=max_size, ttl=ttl if ttl is not None else 60, timer=timer
+        )
+    else:
+        cache = LRUCache(maxsize=max_size)
+
+    lock = asyncio.Lock()
+    _CACHE_REGISTRY.append((name, cache, lock))
+
+    def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> T:
+            key = _make_key(args, kwargs)
+            metrics = get_metrics_collector()
+            async with lock:
+                if key in cache:
+                    value: T = cache[key]
+                    await metrics.record_cache_hit(name)
+                    return value
+                await metrics.record_cache_miss(name)
+                value = await func(*args, **kwargs)
+                cache[key] = value
+                return value
+
+        return wrapper
+
+    return decorator
+
+
+def clear_caches() -> None:
+    """Clear every registered cache. Intended for tests."""
+    for _name, cache, _lock in _CACHE_REGISTRY:
+        cache.clear()

--- a/src/open_stocks_mcp/tools/robinhood_account_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_account_tools.py
@@ -52,6 +52,7 @@ async def get_account_info() -> dict[str, Any]:
     name="account",
     ttl=_cache_cfg.account_ttl_seconds,
     max_size=_cache_cfg.max_size,
+    strategy=_cache_cfg.strategy,
 )
 async def get_portfolio() -> dict[str, Any]:
     """

--- a/src/open_stocks_mcp/tools/robinhood_account_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_account_tools.py
@@ -4,7 +4,9 @@ from typing import Any
 
 import robin_stocks.robinhood as rh
 
+from open_stocks_mcp.config import load_config
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.cache import cached_async
 from open_stocks_mcp.tools.error_handling import (
     create_no_data_response,
     create_success_response,
@@ -13,6 +15,8 @@ from open_stocks_mcp.tools.error_handling import (
     log_api_call,
     sanitize_api_response,
 )
+
+_cache_cfg = load_config().cache
 
 
 @handle_robin_stocks_errors
@@ -44,6 +48,11 @@ async def get_account_info() -> dict[str, Any]:
 
 
 @handle_robin_stocks_errors
+@cached_async(
+    name="account",
+    ttl=_cache_cfg.account_ttl_seconds,
+    max_size=_cache_cfg.max_size,
+)
 async def get_portfolio() -> dict[str, Any]:
     """
     Provides a high-level overview of the portfolio.

--- a/src/open_stocks_mcp/tools/robinhood_stock_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_stock_tools.py
@@ -4,7 +4,9 @@ from typing import Any
 
 import robin_stocks.robinhood as rh
 
+from open_stocks_mcp.config import load_config
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.cache import cached_async
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_no_data_response,
@@ -16,8 +18,15 @@ from open_stocks_mcp.tools.error_handling import (
     validate_symbol,
 )
 
+_cache_cfg = load_config().cache
+
 
 @handle_robin_stocks_errors
+@cached_async(
+    name="quotes",
+    ttl=_cache_cfg.quotes_ttl_seconds,
+    max_size=_cache_cfg.max_size,
+)
 async def get_stock_price(symbol: str) -> dict[str, Any]:
     """
     Get current stock price and basic metrics.

--- a/src/open_stocks_mcp/tools/robinhood_stock_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_stock_tools.py
@@ -26,6 +26,7 @@ _cache_cfg = load_config().cache
     name="quotes",
     ttl=_cache_cfg.quotes_ttl_seconds,
     max_size=_cache_cfg.max_size,
+    strategy=_cache_cfg.strategy,
 )
 async def get_stock_price(symbol: str) -> dict[str, Any]:
     """

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import time
 from collections.abc import Iterator
 from typing import Any
@@ -343,6 +344,70 @@ class TestToolIntegration:
         assert first["result"]["market_value"] == "1000.00"
         assert second["result"]["market_value"] == "1000.00"
         assert mock_portfolio.call_count == 1
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_tool_decorators_use_configured_lru_strategy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from open_stocks_mcp.tools import (
+            cache,
+            robinhood_account_tools,
+            robinhood_stock_tools,
+        )
+
+        try:
+            with monkeypatch.context() as env:
+                env.setenv("CACHE_STRATEGY", "lru")
+                env.setenv("CACHE_QUOTES_TTL", "0")
+                env.setenv("CACHE_ACCOUNT_TTL", "0")
+                cache.clear_caches()
+
+                stock_tools = importlib.reload(robinhood_stock_tools)
+                account_tools = importlib.reload(robinhood_account_tools)
+
+                with (
+                    patch.object(
+                        stock_tools.rh,
+                        "get_quotes",
+                        return_value=[
+                            {
+                                "previous_close": "100.00",
+                                "volume": "1000",
+                                "ask_price": "101.00",
+                                "bid_price": "100.50",
+                                "last_trade_price": "100.75",
+                            }
+                        ],
+                    ) as mock_quote,
+                    patch.object(
+                        stock_tools.rh,
+                        "get_latest_price",
+                        return_value=["101.00"],
+                    ) as mock_price,
+                    patch.object(
+                        account_tools.rh,
+                        "load_portfolio_profile",
+                        return_value={
+                            "market_value": "1000.00",
+                            "equity": "1200.00",
+                            "buying_power": "500.00",
+                        },
+                    ) as mock_portfolio,
+                ):
+                    await stock_tools.get_stock_price("AAPL")
+                    await stock_tools.get_stock_price("AAPL")
+                    await account_tools.get_portfolio()
+                    await account_tools.get_portfolio()
+
+                assert mock_price.call_count == 1
+                assert mock_quote.call_count == 1
+                assert mock_portfolio.call_count == 1
+        finally:
+            cache.clear_caches()
+            importlib.reload(robinhood_stock_tools)
+            importlib.reload(robinhood_account_tools)
 
     @pytest.mark.unit
     @pytest.mark.journey_system

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,390 @@
+"""Unit tests for the in-memory caching layer."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_state() -> Iterator[None]:
+    """Reset shared cache + metrics state between tests."""
+    from open_stocks_mcp import monitoring
+    from open_stocks_mcp.tools import cache
+
+    cache.clear_caches()
+    monitoring._metrics_collector = None
+    yield
+    cache.clear_caches()
+    monitoring._metrics_collector = None
+
+
+class TestCachedAsyncDecorator:
+    """Tests for the cached_async decorator."""
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_memoized_value(self) -> None:
+        from open_stocks_mcp.tools.cache import cached_async
+
+        call_count = 0
+
+        @cached_async(name="hit", ttl=60)
+        async def fetch(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        first = await fetch(3)
+        second = await fetch(3)
+
+        assert first == 6
+        assert second == 6
+        assert call_count == 1
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_cache_miss_invokes_wrapped_callable(self) -> None:
+        from open_stocks_mcp.tools.cache import cached_async
+
+        call_count = 0
+
+        @cached_async(name="miss", ttl=60)
+        async def fetch(symbol: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            return symbol.upper()
+
+        await fetch("aapl")
+        await fetch("msft")
+
+        assert call_count == 2
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_ttl_expiry_forces_reinvocation(self) -> None:
+        from open_stocks_mcp.tools.cache import cached_async
+
+        call_count = 0
+        clock = {"value": 1000.0}
+
+        def fake_monotonic() -> float:
+            return clock["value"]
+
+        @cached_async(name="ttl", ttl=5, clock=fake_monotonic)
+        async def fetch() -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        first = await fetch()
+        # Advance clock past the TTL
+        clock["value"] += 6
+        second = await fetch()
+
+        assert first == 1
+        assert second == 2
+        assert call_count == 2
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_lru_eviction_discards_least_recently_used(self) -> None:
+        from open_stocks_mcp.tools.cache import cached_async
+
+        call_count = 0
+
+        @cached_async(name="lru", max_size=2, strategy="lru")
+        async def fetch(key: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            return f"{key}-{call_count}"
+
+        a1 = await fetch("a")
+        b1 = await fetch("b")
+        # Touch "a" to make "b" the LRU
+        await fetch("a")
+        # Insert "c" — should evict "b"
+        await fetch("c")
+
+        # Re-fetching "a" should still hit cache (no new call)
+        before = call_count
+        await fetch("a")
+        assert call_count == before, "fetch('a') should be a cache hit"
+
+        # Re-fetching "b" should miss and re-invoke
+        b2 = await fetch("b")
+        assert b2 != b1
+        assert a1 == "a-1"
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_distinct_args_produce_distinct_entries(self) -> None:
+        from open_stocks_mcp.tools.cache import cached_async
+
+        call_count = 0
+
+        @cached_async(name="keys", ttl=60)
+        async def fetch(*args: Any, **kwargs: Any) -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        await fetch(1)
+        await fetch(2)
+        await fetch(1, mode="x")
+        await fetch(1, mode="x")  # repeat, cache hit
+        await fetch(1, mode="y")
+
+        assert call_count == 4
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_run_underlying_once(self) -> None:
+        from open_stocks_mcp.tools.cache import cached_async
+
+        call_count = 0
+
+        @cached_async(name="concurrent", ttl=60)
+        async def fetch() -> int:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return call_count
+
+        results = await asyncio.gather(*(fetch() for _ in range(8)))
+
+        assert call_count == 1
+        assert all(r == 1 for r in results)
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    async def test_records_hit_and_miss_into_metrics(self) -> None:
+        from open_stocks_mcp.monitoring import get_metrics_collector
+        from open_stocks_mcp.tools.cache import cached_async
+
+        @cached_async(name="metrics-target", ttl=60)
+        async def fetch(x: int) -> int:
+            return x
+
+        await fetch(1)  # miss
+        await fetch(1)  # hit
+        await fetch(2)  # miss
+        await fetch(1)  # hit
+
+        metrics = await get_metrics_collector().get_metrics()
+
+        cache_hits = metrics["cache_hits"]
+        cache_misses = metrics["cache_misses"]
+        assert cache_hits["metrics-target"] == 2
+        assert cache_misses["metrics-target"] == 2
+        assert metrics["cache_hit_rate_percent"]["metrics-target"] == 50.0
+
+
+class TestCacheConfig:
+    """Tests for CacheConfig loading from environment."""
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    def test_defaults_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from open_stocks_mcp.config import load_config
+
+        for var in (
+            "CACHE_QUOTES_TTL",
+            "CACHE_ACCOUNT_TTL",
+            "CACHE_MAX_SIZE",
+            "CACHE_STRATEGY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        cfg = load_config()
+
+        assert cfg.cache.quotes_ttl_seconds == 15
+        assert cfg.cache.account_ttl_seconds == 300
+        assert cfg.cache.max_size == 1024
+        assert cfg.cache.strategy == "ttl"
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    def test_env_overrides_apply(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from open_stocks_mcp.config import load_config
+
+        monkeypatch.setenv("CACHE_QUOTES_TTL", "7")
+        monkeypatch.setenv("CACHE_ACCOUNT_TTL", "120")
+        monkeypatch.setenv("CACHE_MAX_SIZE", "16")
+        monkeypatch.setenv("CACHE_STRATEGY", "lru")
+
+        cfg = load_config()
+
+        assert cfg.cache.quotes_ttl_seconds == 7
+        assert cfg.cache.account_ttl_seconds == 120
+        assert cfg.cache.max_size == 16
+        assert cfg.cache.strategy == "lru"
+
+
+class TestToolIntegration:
+    """Tests that cache decorator is applied to the target tools."""
+
+    @pytest.mark.unit
+    @pytest.mark.journey_market_data
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.rh.get_quotes",
+        return_value=[
+            {
+                "previous_close": "100.00",
+                "volume": "1000",
+                "ask_price": "101.00",
+                "bid_price": "100.50",
+                "last_trade_price": "100.75",
+            }
+        ],
+    )
+    @patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.rh.get_latest_price",
+        return_value=["101.00"],
+    )
+    async def test_get_stock_price_uses_cache(
+        self, mock_price: Any, mock_quote: Any
+    ) -> None:
+        from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+
+        first = await get_stock_price("AAPL")
+        second = await get_stock_price("AAPL")
+
+        assert first["result"]["price"] == 101.0
+        assert second["result"]["price"] == 101.0
+        # Cached: underlying API called exactly once across two invocations
+        assert mock_price.call_count == 1
+        assert mock_quote.call_count == 1
+
+        # Distinct symbol bypasses cache
+        await get_stock_price("MSFT")
+        assert mock_price.call_count == 2
+
+    @pytest.mark.unit
+    @pytest.mark.journey_market_data
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.rh.get_quotes",
+        return_value=[
+            {
+                "previous_close": "100.00",
+                "volume": "1000",
+                "ask_price": "101.00",
+                "bid_price": "100.50",
+                "last_trade_price": "100.75",
+            }
+        ],
+    )
+    @patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.rh.get_latest_price",
+        return_value=["101.00"],
+    )
+    async def test_get_stock_price_refetches_after_ttl(
+        self, mock_price: Any, mock_quote: Any
+    ) -> None:
+        from open_stocks_mcp.tools import cache, robinhood_stock_tools
+
+        # Replace the real clock for the wrapped cache entry
+        clock = {"value": time.monotonic()}
+        cache.clear_caches()
+
+        original = robinhood_stock_tools.get_stock_price
+        # Walk past every existing decorator down to the raw coroutine, so the
+        # fresh test wrapper isn't shadowed by the production cache.
+        raw = original
+        while hasattr(raw, "__wrapped__"):
+            raw = raw.__wrapped__
+        rewrapped = cache.cached_async(
+            name="quotes", ttl=5, clock=lambda: clock["value"]
+        )(raw)
+
+        try:
+            robinhood_stock_tools.get_stock_price = rewrapped  # type: ignore[assignment]
+            await robinhood_stock_tools.get_stock_price("AAPL")
+            await robinhood_stock_tools.get_stock_price("AAPL")
+            assert mock_price.call_count == 1
+
+            clock["value"] += 10
+            await robinhood_stock_tools.get_stock_price("AAPL")
+            assert mock_price.call_count == 2
+        finally:
+            robinhood_stock_tools.get_stock_price = original  # type: ignore[assignment]
+
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.robinhood_account_tools.rh.load_portfolio_profile",
+        return_value={
+            "market_value": "1000.00",
+            "equity": "1200.00",
+            "buying_power": "500.00",
+        },
+    )
+    async def test_get_portfolio_uses_cache(self, mock_portfolio: Any) -> None:
+        from open_stocks_mcp.tools.robinhood_account_tools import get_portfolio
+
+        first = await get_portfolio()
+        second = await get_portfolio()
+
+        assert first["result"]["market_value"] == "1000.00"
+        assert second["result"]["market_value"] == "1000.00"
+        assert mock_portfolio.call_count == 1
+
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.robinhood_account_tools.rh.load_portfolio_profile",
+        return_value={
+            "market_value": "1000.00",
+            "equity": "1200.00",
+            "buying_power": "500.00",
+        },
+    )
+    @patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.rh.get_quotes",
+        return_value=[
+            {
+                "previous_close": "100.00",
+                "volume": "1000",
+                "ask_price": "101.00",
+                "bid_price": "100.50",
+                "last_trade_price": "100.75",
+            }
+        ],
+    )
+    @patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.rh.get_latest_price",
+        return_value=["101.00"],
+    )
+    async def test_metrics_record_per_tool_cache_names(
+        self, mock_price: Any, mock_quote: Any, mock_portfolio: Any
+    ) -> None:
+        from open_stocks_mcp.monitoring import get_metrics_collector
+        from open_stocks_mcp.tools.robinhood_account_tools import get_portfolio
+        from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+
+        await get_stock_price("AAPL")
+        await get_stock_price("AAPL")
+        await get_portfolio()
+        await get_portfolio()
+
+        metrics = await get_metrics_collector().get_metrics()
+        assert metrics["cache_misses"].get("quotes", 0) == 1
+        assert metrics["cache_hits"].get("quotes", 0) == 1
+        assert metrics["cache_misses"].get("account", 0) == 1
+        assert metrics["cache_hits"].get("account", 0) == 1


### PR DESCRIPTION
Closes #158

## Changes
- New `cached_async` decorator in `src/open_stocks_mcp/tools/cache.py` (cachetools-backed TTL and LRU strategies, asyncio-safe, exposes `clear_caches()` for tests).
- `CacheConfig` added to `src/open_stocks_mcp/config.py` and embedded in `ServerConfig`. Env vars: `CACHE_QUOTES_TTL` (default 15), `CACHE_ACCOUNT_TTL` (default 300), `CACHE_MAX_SIZE` (default 1024), `CACHE_STRATEGY` (default `ttl`).
- `MetricsCollector` records per-cache `cache_hits` / `cache_misses` via new `record_cache_hit` / `record_cache_miss` methods; `get_metrics()` surfaces `cache_hits`, `cache_misses`, `cache_hit_rate_percent`.
- Applied `cached_async` to `get_stock_price` (name=`quotes`, 15s TTL) and `get_portfolio` (name=`account`, 300s TTL). The decorator is stacked beneath `@handle_robin_stocks_errors` so error responses are not cached.
- `tests/unit/test_cache.py` covers hit, miss, TTL expiry, LRU eviction, distinct keys, concurrent gather, monitoring counter wiring, env-driven config, and integration with both tools.

## Test plan
- `uv run pytest tests/unit/test_cache.py -v` — 13 passed.
- `uv run pytest tests/unit/test_stock_market_tools.py tests/unit/test_account_tools.py` — 32 passed, 15 skipped (no regressions).
- `uv run ruff check src/open_stocks_mcp/{config,monitoring}.py src/open_stocks_mcp/tools/{cache,robinhood_account_tools,robinhood_stock_tools}.py tests/unit/test_cache.py` — clean.
- `uv run mypy src/open_stocks_mcp/{config,monitoring}.py src/open_stocks_mcp/tools/{cache,robinhood_account_tools,robinhood_stock_tools}.py` — no issues.