### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -1,7 +1,7 @@
 """Robinhood broker implementation using existing robin-stocks integration."""
 
 from datetime import datetime
-from typing import Any, cast
+from typing import Any
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
 from open_stocks_mcp.logging_config import logger

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -34,10 +34,13 @@ def test_logout_reraises_exception_and_still_clears_state() -> None:
     manager.last_successful_call = datetime.now()
     manager._failed_login_attempts = 1
 
-    with patch(
-        "open_stocks_mcp.tools.session_manager.rh.logout",
-        side_effect=RuntimeError("logout failure"),
-    ), pytest.raises(RuntimeError, match="logout failure"):
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.rh.logout",
+            side_effect=RuntimeError("logout failure"),
+        ),
+        pytest.raises(RuntimeError, match="logout failure"),
+    ):
         asyncio.run(manager.logout())
 
     assert manager._is_authenticated is False


### PR DESCRIPTION
## Cleanup Changes

**Tools applied:** ruff

**Summary of fixes:**
- Removed unused import (`cast`) from robinhood.py
- Reformatted context manager syntax in test_session_manager.py (PEP 617 style)

**Files changed:** 2
- src/open_stocks_mcp/brokers/robinhood.py (1 insertion, 1 deletion)
- tests/unit/test_session_manager.py (7 insertions, 4 deletions)