### PR TITLE
test: add read-only ADK evals for system/monitoring tools

### DIFF
--- a/tests/evals/0_sys_health_check_test.json
+++ b/tests/evals/0_sys_health_check_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "sys_health_check_test_set",
+  "name": "System Health Check Test",
+  "description": "System/monitoring read-only eval that exercises the MCP server health_check tool via agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "sys_health_check_test",
+      "conversation": [
+        {
+          "invocation_id": "sys-health-check-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Report the current health status of the MCP server."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "The MCP server is healthy. The reported status is \"success\" with no issues detected and a 0% error rate."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "health_check"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/0_sys_metrics_summary_test.json
+++ b/tests/evals/0_sys_metrics_summary_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "sys_metrics_summary_test_set",
+  "name": "System Metrics Summary Test",
+  "description": "System/monitoring read-only eval that exercises the MCP server metrics_summary tool to retrieve observability counters and latency metrics",
+  "eval_cases": [
+    {
+      "eval_id": "sys_metrics_summary_test",
+      "conversation": [
+        {
+          "invocation_id": "sys-metrics-summary-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Summarize the MCP server metrics for monitoring purposes."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "The metrics_summary tool returns the MCP server observability snapshot, including request counters, latency percentiles, and error rates for the running process."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "metrics_summary"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/0_sys_rate_limit_status_test.json
+++ b/tests/evals/0_sys_rate_limit_status_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "sys_rate_limit_status_test_set",
+  "name": "System Rate Limit Status Test",
+  "description": "System/monitoring read-only eval that exercises the MCP server rate_limit_status tool to inspect Robin Stocks API rate-limit usage and remaining quota",
+  "eval_cases": [
+    {
+      "eval_id": "sys_rate_limit_status_test",
+      "conversation": [
+        {
+          "invocation_id": "sys-rate-limit-status-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What is the current rate-limit utilization on the Robin Stocks API?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "The rate_limit_status tool returns the current Robin Stocks API rate-limit counters, including used capacity and remaining quota in the active window."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "rate_limit_status"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/0_sys_session_status_test.json
+++ b/tests/evals/0_sys_session_status_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "sys_session_status_test_set",
+  "name": "System Session Status Test",
+  "description": "System/monitoring read-only eval that exercises the MCP server session_status tool to inspect Robinhood session and authentication state",
+  "eval_cases": [
+    {
+      "eval_id": "sys_session_status_test",
+      "conversation": [
+        {
+          "invocation_id": "sys-session-status-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What is the current Robinhood session and authentication status?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "The session_status tool reports the current Robinhood session state, including whether the session is authenticated and any associated session metadata."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "session_status"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -118,7 +118,27 @@ list_available_tools_test_set:
 adk eval examples/google-adk-agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 2. Creating Custom Evaluation Tests
+### 2. System & Monitoring Read-Only Evals (`0_sys_*`)
+
+Read-only evals that exercise server-local MCP monitoring tools. These do not invoke any trading or order-placement paths.
+
+- `tests/evals/0_sys_health_check_test.json` — exercises the `health_check` tool to report MCP server health.
+- `tests/evals/0_sys_session_status_test.json` — exercises the `session_status` tool to inspect Robinhood session and authentication state.
+- `tests/evals/0_sys_metrics_summary_test.json` — exercises the `metrics_summary` tool to retrieve observability counters and latency metrics.
+- `tests/evals/0_sys_rate_limit_status_test.json` — exercises the `rate_limit_status` tool to inspect Robin Stocks API rate-limit usage.
+
+These evals are strictly read-only: prompts and expected responses describe server state only, with no order placement, cancellation, or trading-path tools referenced. Because the four tools target server-local monitoring state, ADK execution requires `GOOGLE_API_KEY` and a reachable MCP server, but does **not** require live Robinhood credentials for these specific calls (the underlying Robin Stocks rate-limit counters track quota without performing a broker call).
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/0_sys_health_check_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/0_sys_session_status_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/0_sys_metrics_summary_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/0_sys_rate_limit_status_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 3. Creating Custom Evaluation Tests
 
 #### Test File Structure
 ```json


### PR DESCRIPTION
Closes #180

## Changes
- Add four read-only ADK eval JSONs under `tests/evals/0_sys_*_test.json` for the server-local monitoring tools `health_check`, `session_status`, `metrics_summary`, and `rate_limit_status`.
- Each eval invokes exactly one tool with empty args and uses the existing `tests/evals/1_acc_health_check_test.json` shape (`session_input.app_name = stock_trader_agent`).
- Prompts and expected responses describe server state only; no order placement, cancellation, or trading-path tools are referenced.
- Update `tests/evals/ADK-testing-evals.md` with a new `System & Monitoring Read-Only Evals` subsection listing the four evals, the tool each exercises, and the credential assumptions (`GOOGLE_API_KEY` + reachable MCP server; live Robinhood credentials not required for these calls).

## Test plan
- [x] `python -c 'import json,glob;[json.load(open(p)) for p in sorted(glob.glob("tests/evals/0_sys_*_test.json"))]'` — all four JSONs parse.
- [x] Schema check: all four files have one eval case, one tool use with empty args, `app_name == stock_trader_agent`, and the tool name set is exactly `{health_check, session_status, metrics_summary, rate_limit_status}`.
- [x] `ls tests/evals/0_sys_*_test.json | wc -l` returns `4`.
- [x] Manifest references all four eval filenames.
- [ ] Optional live run (requires `GOOGLE_API_KEY` and MCP server on port 3001):
  `adk eval examples/google_adk_agent tests/evals/0_sys_health_check_test.json --config_file_path tests/evals/test_config.json`