### PR TITLE
feat: add per-tool MCP metrics endpoint and instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,17 @@ open-stocks-mcp-server --transport stdio
 # Health check (HTTP transport)
 curl http://localhost:3001/health
 
+# Prometheus metrics (no auth required)
+curl http://localhost:3001/metrics
+
 # Interactive testing
 uv run mcp dev src/open_stocks_mcp/server/app.py
 ```
+
+The `/metrics` endpoint exposes:
+- `open_stocks_mcp_tool_calls_total` (counter by tool)
+- `open_stocks_mcp_tool_calls_per_minute` (gauge by tool)
+- `open_stocks_mcp_tool_latency_ms` (gauge by tool and quantile: `0.50`, `0.95`, `0.99`)
 
 ## Docker Deployment
 

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -1,6 +1,7 @@
 """Enhanced monitoring and metrics for the MCP server."""
 
 import asyncio
+import math
 import time
 from collections import defaultdict, deque
 from datetime import datetime, timedelta
@@ -25,6 +26,9 @@ class MetricsCollector:
         self.errors: deque[tuple[datetime, str, str | None]] = deque()
         self.response_times: deque[tuple[datetime, float]] = deque()
         self.tool_usage: dict[str, deque[tuple[datetime, bool]]] = defaultdict(deque)
+        self.tool_response_times: dict[str, deque[tuple[datetime, float]]] = (
+            defaultdict(deque)
+        )
         self.error_types: dict[str, int] = defaultdict(int)
 
         # Counters
@@ -68,6 +72,7 @@ class MetricsCollector:
 
             # Record tool usage
             self.tool_usage[tool_name].append((now, success))
+            self.tool_response_times[tool_name].append((now, duration))
 
             # Record error if failed
             if not success:
@@ -113,6 +118,25 @@ class MetricsCollector:
             while tool_calls and tool_calls[0][0] < cutoff:
                 tool_calls.popleft()
 
+        # Clean per-tool response times
+        for tool_durations in self.tool_response_times.values():
+            while tool_durations and tool_durations[0][0] < cutoff:
+                tool_durations.popleft()
+
+    @staticmethod
+    def _percentile(samples: list[float], quantile: float) -> float:
+        """Return percentile for a sorted sample list."""
+        if not samples:
+            return 0.0
+        rank = max(1, math.ceil(quantile * len(samples)))
+        index = min(len(samples) - 1, rank - 1)
+        return samples[index]
+
+    @staticmethod
+    def _escape_prometheus_label_value(value: str) -> str:
+        """Escape a label value according to Prometheus text format."""
+        return value.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
     async def get_metrics(self) -> dict[str, Any]:
         """Get current metrics summary.
 
@@ -143,30 +167,35 @@ class MetricsCollector:
             response_times_sorted = (
                 sorted(t[1] for t in self.response_times) if self.response_times else []
             )
-            p50 = (
-                response_times_sorted[len(response_times_sorted) // 2]
-                if response_times_sorted
-                else 0
-            )
-            p95 = (
-                response_times_sorted[int(len(response_times_sorted) * 0.95)]
-                if response_times_sorted
-                else 0
-            )
-            p99 = (
-                response_times_sorted[int(len(response_times_sorted) * 0.99)]
-                if response_times_sorted
-                else 0
-            )
+            p50 = self._percentile(response_times_sorted, 0.50)
+            p95 = self._percentile(response_times_sorted, 0.95)
+            p99 = self._percentile(response_times_sorted, 0.99)
 
             # Tool usage stats
             tool_stats = {}
             for tool, calls in self.tool_usage.items():
                 successful = sum(1 for _, success in calls if success)
                 total = len(calls)
+                durations = sorted(
+                    duration for _, duration in self.tool_response_times.get(tool, [])
+                )
                 tool_stats[tool] = {
                     "calls": total,
                     "success_rate": (successful / total * 100.0) if total > 0 else 0.0,
+                    "calls_per_minute": round(
+                        total / (self.window_size.total_seconds() / 60), 2
+                    )
+                    if total > 0
+                    else 0.0,
+                    "p50_response_time_ms": round(
+                        self._percentile(durations, 0.50) * 1000, 2
+                    ),
+                    "p95_response_time_ms": round(
+                        self._percentile(durations, 0.95) * 1000, 2
+                    ),
+                    "p99_response_time_ms": round(
+                        self._percentile(durations, 0.99) * 1000, 2
+                    ),
                 }
 
             cache_hit_rate: dict[str, float] = {}
@@ -197,6 +226,56 @@ class MetricsCollector:
                 "cache_hit_rate_percent": cache_hit_rate,
                 "timestamp": now.isoformat(),
             }
+
+    async def format_prometheus_metrics(self) -> str:
+        """Return metrics in Prometheus exposition format."""
+        metrics = await self.get_metrics()
+
+        lines = [
+            "# HELP open_stocks_mcp_total_calls Total API calls observed.",
+            "# TYPE open_stocks_mcp_total_calls counter",
+            f"open_stocks_mcp_total_calls {metrics['total_calls']}",
+            "# HELP open_stocks_mcp_total_errors Total API errors observed.",
+            "# TYPE open_stocks_mcp_total_errors counter",
+            f"open_stocks_mcp_total_errors {metrics['total_errors']}",
+            "# HELP open_stocks_mcp_calls_in_window API calls in rolling window.",
+            "# TYPE open_stocks_mcp_calls_in_window gauge",
+            f"open_stocks_mcp_calls_in_window {metrics['calls_in_window']}",
+            "# HELP open_stocks_mcp_errors_in_window API errors in rolling window.",
+            "# TYPE open_stocks_mcp_errors_in_window gauge",
+            f"open_stocks_mcp_errors_in_window {metrics['errors_in_window']}",
+            "# HELP open_stocks_mcp_tool_calls_total Total calls per tool.",
+            "# TYPE open_stocks_mcp_tool_calls_total counter",
+            "# HELP open_stocks_mcp_tool_calls_per_minute Calls per minute per tool.",
+            "# TYPE open_stocks_mcp_tool_calls_per_minute gauge",
+            "# HELP open_stocks_mcp_tool_latency_ms Tool latency percentile in milliseconds.",
+            "# TYPE open_stocks_mcp_tool_latency_ms gauge",
+        ]
+
+        for tool_name, tool_metrics in metrics["tool_usage"].items():
+            escaped_tool = self._escape_prometheus_label_value(tool_name)
+            lines.append(
+                f'open_stocks_mcp_tool_calls_total{{tool="{escaped_tool}"}} '
+                f"{tool_metrics['calls']}"
+            )
+            lines.append(
+                f'open_stocks_mcp_tool_calls_per_minute{{tool="{escaped_tool}"}} '
+                f"{tool_metrics['calls_per_minute']}"
+            )
+            lines.append(
+                f'open_stocks_mcp_tool_latency_ms{{tool="{escaped_tool}",quantile="0.50"}} '
+                f"{tool_metrics['p50_response_time_ms']}"
+            )
+            lines.append(
+                f'open_stocks_mcp_tool_latency_ms{{tool="{escaped_tool}",quantile="0.95"}} '
+                f"{tool_metrics['p95_response_time_ms']}"
+            )
+            lines.append(
+                f'open_stocks_mcp_tool_latency_ms{{tool="{escaped_tool}",quantile="0.99"}} '
+                f"{tool_metrics['p99_response_time_ms']}"
+            )
+
+        return "\n".join(lines) + "\n"
 
     async def get_health_status(self) -> dict[str, Any]:
         """Get health status based on metrics.

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -371,6 +371,7 @@ def create_http_server(
                 "sse": "/sse",
                 "health": "/health",
                 "status": "/status",
+                "metrics": "/metrics",
             },
             "documentation": "/docs",
         }
@@ -418,6 +419,24 @@ def create_http_server(
         except Exception as e:
             logger.error(f"Failed to list tools: {e}")
             raise HTTPException(status_code=500, detail="Failed to list tools") from e
+
+    @app.get("/metrics")
+    async def metrics() -> Response:
+        """Prometheus metrics endpoint (no auth required)."""
+        try:
+            metrics_collector = _require_metrics_collector()
+            content = await metrics_collector.format_prometheus_metrics()
+            return Response(
+                content=content,
+                media_type="text/plain; version=0.0.4; charset=utf-8",
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to render metrics: {e}")
+            raise HTTPException(
+                status_code=500, detail="Failed to render metrics"
+            ) from e
 
     # Mount the MCP HTTP endpoints
     # Create a simple MCP endpoint that handles JSON-RPC directly
@@ -528,8 +547,20 @@ def create_http_server(
                             headers={"content-type": "application/json"},
                         )
 
-                    # Call the tool using FastMCP's method
-                    tool_result = await mcp_server.call_tool(tool_name, arguments)
+                    # Record duration and success/failure for tool calls only.
+                    start = time.perf_counter()
+                    metrics_collector = _require_metrics_collector()
+                    try:
+                        tool_result = await mcp_server.call_tool(tool_name, arguments)
+                    except Exception as exc:
+                        duration = time.perf_counter() - start
+                        await metrics_collector.record_api_call(
+                            tool_name=tool_name,
+                            duration=duration,
+                            success=False,
+                            error_type=type(exc).__name__,
+                        )
+                        raise
 
                     # Convert CallToolResult to MCP protocol format
                     if hasattr(tool_result, "content"):
@@ -570,6 +601,15 @@ def create_http_server(
                                 }
                             ]
                         }
+
+                    duration = time.perf_counter() - start
+                    is_error = bool(result.get("isError", False))
+                    await metrics_collector.record_api_call(
+                        tool_name=tool_name,
+                        duration=duration,
+                        success=not is_error,
+                        error_type="ToolExecutionError" if is_error else None,
+                    )
 
                 elif method == "notifications/initialized":
                     # Handle initialization notification (no response needed for notifications)
@@ -704,6 +744,7 @@ async def run_http_server(
     logger.info(f"  - SSE Events: http://{host}:{port}/sse")
     logger.info(f"  - Health Check: http://{host}:{port}/health")
     logger.info(f"  - Server Status: http://{host}:{port}/status")
+    logger.info(f"  - Metrics: http://{host}:{port}/metrics")
     logger.info(f"  - Tools List: http://{host}:{port}/tools")
     logger.info(f"  - API Documentation: http://{host}:{port}/docs")
     logger.info(

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -85,12 +85,58 @@ async def http_client(mcp_server: FastMCP) -> Any:
     """Create an HTTP client for testing"""
     from httpx import ASGITransport
 
-    app = create_http_server(mcp_server)
+    # Ensure a clean collector state for each HTTP test.
+    with patch("open_stocks_mcp.monitoring._metrics_collector", None):
+        app = create_http_server(mcp_server)
 
-    # Configure test client with ASGI transport
-    transport = ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client
+        # Configure test client with ASGI transport
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            yield client
+
+
+@pytest.mark.integration
+@pytest.mark.journey_system
+class TestMetricsEndpoint:
+    """Test metrics endpoint behavior."""
+
+    async def test_metrics_endpoint_no_auth_and_plain_text(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        response = await http_client.get("/metrics")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/plain")
+        assert "open_stocks_mcp_total_calls" in response.text
+
+    @pytest.mark.anyio
+    async def test_metrics_reflects_tools_call_activity(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 20,
+            "method": "tools/call",
+            "params": {"name": "account_info", "arguments": {}},
+        }
+        call_response = await http_client.post("/mcp", json=payload)
+        assert call_response.status_code == 200
+
+        metrics_response = await http_client.get("/metrics")
+        assert metrics_response.status_code == 200
+        assert (
+            'open_stocks_mcp_tool_calls_total{tool="account_info"} 1'
+            in metrics_response.text
+        )
+        assert (
+            'open_stocks_mcp_tool_calls_per_minute{tool="account_info"} '
+            in metrics_response.text
+        )
+        assert (
+            'open_stocks_mcp_tool_latency_ms{tool="account_info",quantile="0.50"} '
+            in metrics_response.text
+        )
 
 
 @pytest.mark.integration

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,6 +1,6 @@
-"""Unit tests for monitoring health thresholds."""
+"""Unit tests for monitoring metrics and health thresholds."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -45,6 +45,69 @@ async def test_get_health_status_thresholds_map_correctly() -> None:
     degraded = await collector.get_health_status()
     assert degraded["status"] == "degraded"
 
-    collector.errors.extend([(now, "tool", "err"), (now, "tool", "err"), (now, "tool", "err")])
+    collector.errors.extend(
+        [(now, "tool", "err"), (now, "tool", "err"), (now, "tool", "err")]
+    )
     unhealthy = await collector.get_health_status()
     assert unhealthy["status"] == "unhealthy"
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_includes_per_tool_latency_and_throughput() -> None:
+    collector = MetricsCollector(window_size_minutes=1)
+
+    await collector.record_api_call("tool_a", 0.10, True)
+    await collector.record_api_call("tool_a", 0.20, False, error_type="RuntimeError")
+    await collector.record_api_call("tool_a", 0.30, True)
+    await collector.record_api_call("tool_b", 0.40, True)
+
+    metrics = await collector.get_metrics()
+    tool_usage = metrics["tool_usage"]
+
+    assert "tool_a" in tool_usage
+    assert "tool_b" in tool_usage
+    assert tool_usage["tool_a"]["calls"] == 3
+    assert tool_usage["tool_a"]["success_rate"] == pytest.approx(66.666, rel=1e-2)
+    assert tool_usage["tool_a"]["calls_per_minute"] == pytest.approx(3.0)
+    assert tool_usage["tool_a"]["p50_response_time_ms"] == 200.0
+    assert tool_usage["tool_a"]["p95_response_time_ms"] == 300.0
+    assert tool_usage["tool_a"]["p99_response_time_ms"] == 300.0
+    assert tool_usage["tool_b"]["calls"] == 1
+    assert tool_usage["tool_b"]["calls_per_minute"] == pytest.approx(1.0)
+    assert metrics["total_errors"] == 1
+    assert metrics["error_types"]["RuntimeError"] == 1
+
+
+@pytest.mark.asyncio
+async def test_prometheus_output_contains_tool_metrics() -> None:
+    collector = MetricsCollector(window_size_minutes=1)
+    await collector.record_api_call('tool"name\\x', 0.10, True)
+
+    output = await collector.format_prometheus_metrics()
+
+    assert "open_stocks_mcp_tool_calls_total" in output
+    assert "open_stocks_mcp_tool_calls_per_minute" in output
+    assert "open_stocks_mcp_tool_latency_ms" in output
+    assert 'tool="tool\\"name\\\\x"' in output
+    assert 'quantile="0.50"' in output
+    assert 'quantile="0.95"' in output
+    assert 'quantile="0.99"' in output
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_cleans_stale_tool_samples() -> None:
+    collector = MetricsCollector(window_size_minutes=1)
+    now = datetime.now()
+    stale = now - timedelta(minutes=2)
+
+    collector.api_calls.append((stale, "old_tool", True))
+    collector.response_times.append((stale, 1.0))
+    collector.tool_usage["old_tool"].append((stale, True))
+    collector.tool_response_times["old_tool"].append((stale, 1.0))
+
+    await collector.record_api_call("new_tool", 0.05, True)
+    metrics = await collector.get_metrics()
+
+    assert metrics["calls_in_window"] == 1
+    assert metrics["tool_usage"]["new_tool"]["calls"] == 1
+    assert metrics["tool_usage"]["old_tool"]["calls"] == 0


### PR DESCRIPTION
Closes #162

## Changes
- add per-tool duration tracking in MetricsCollector with per-tool p50/p95/p99 and calls-per-minute
- add Prometheus formatter with stable metric names and escaped label handling
- instrument HTTP JSON-RPC `tools/call` requests to record tool latency/success/failure
- add unauthenticated `GET /metrics` endpoint and expose it in root endpoint metadata/startup logs
- add unit + HTTP tests covering collector metrics and `/metrics` output
- document metrics scrape usage in README

## Test plan
- `uv run pytest tests/unit/test_monitoring.py -q`
- `uv run pytest tests/http_transport/test_http_server.py -q -k 'metrics or tool_call'`
- `uv run ruff check src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/http_transport.py tests/unit/test_monitoring.py tests/http_transport/test_http_server.py`
- `uv run ruff format --check src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/http_transport.py tests/unit/test_monitoring.py tests/http_transport/test_http_server.py`
- `uv run mypy .`

## Notes
- Running the broader combined suite `uv run pytest tests/unit/test_monitoring.py tests/http_transport/test_http_server.py -q` intermittently hits a pre-existing live-server assertion in `TestLiveHTTPServer.test_server_startup` where `/health` may return `degraded` instead of `healthy`.