### PR TITLE
feat: implement API tool reference generator and committed Markdown

### DIFF
--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1,4 +1,4 @@
-# Open Stocks MCP - Tool Reference
+# Open Stocks MCP — Tool Reference
 
 104 tools registered
 

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -6,7 +6,7 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-HEADER = "# Open Stocks MCP - Tool Reference\n"
+HEADER = "# Open Stocks MCP — Tool Reference\n"
 
 
 async def build_doc(mcp: Any) -> str:

--- a/tests/unit/test_api_docs_generator.py
+++ b/tests/unit/test_api_docs_generator.py
@@ -16,7 +16,7 @@ def test_generate_writes_tools_md(tmp_path):
     assert output_path.exists()
 
     content = output_path.read_text(encoding="utf-8")
-    assert "# Open Stocks MCP - Tool Reference" in content
+    assert "# Open Stocks MCP — Tool Reference" in content
     assert re.search(r"\n\d+ tools registered\n", content)
     assert "### list_tools" in content
     assert "### account_info" in content


### PR DESCRIPTION
Closes #211

## Changes
- Implemented scripts/generate_api_docs.py to deterministically generate a Markdown tool reference.
- Added tests/unit/test_api_docs_generator.py to verify the generator output.
- Generated and committed docs/api/tools.md containing all registered MCP tools.
- Ensured the header uses the requested em dash.

## Test plan
- Run pytest tests/unit/test_api_docs_generator.py -v
- Run python scripts/generate_api_docs.py to regenerate the documentation.