### PR TITLE
docs: tighten market data notebook quickstart validation

### DIFF
--- a/examples/notebooks/01_market_data_quickstart.ipynb
+++ b/examples/notebooks/01_market_data_quickstart.ipynb
@@ -21,7 +21,7 @@
         "\\n",
         "Start the server first:\\n",
         "```bash\\n",
-        "uv run open-stocks-mcp-server --transport http --port 3001\\n",
+        "open-stocks-mcp-server --transport http --port 3001\\n",
         "```"
       ]
     },
@@ -31,9 +31,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "import os\\n",
         "from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StreamableHTTPConnectionParams\\n",
         "\\n",
-        "toolset = MCPToolset(connection_params=StreamableHTTPConnectionParams(url=\"http://localhost:3001/mcp\"))"
+        "http_url = os.environ.get(\"MCP_HTTP_URL\", \"http://localhost:3001/mcp\")\\n",
+        "toolset = MCPToolset(connection_params=StreamableHTTPConnectionParams(url=http_url))"
       ]
     },
     {
@@ -45,8 +47,7 @@
         "# Example read-only calls\\n",
         "stock_price(\"AAPL\")\\n",
         "market_hours()\\n",
-        "portfolio()\\n",
-        "account_info()"
+        "portfolio()"
       ]
     },
     {

--- a/tests/unit/test_example_notebooks.py
+++ b/tests/unit/test_example_notebooks.py
@@ -12,14 +12,27 @@ NOTEBOOK_02 = Path("examples/notebooks/02_trading_safe_dry_run.ipynb")
 def test_market_data_notebook_is_valid():
     notebook = json.loads(NOTEBOOK_01.read_text(encoding="utf-8"))
 
+    def source_text(cell: dict) -> str:
+        source = cell.get("source", "")
+        if isinstance(source, list):
+            return "".join(source)
+        return str(source)
+
     assert notebook.get("nbformat", 0) >= 4
     first_cell = notebook["cells"][0]
     assert first_cell["cell_type"] == "markdown"
-    first_source = "".join(first_cell.get("source", []))
+    first_source = source_text(first_cell)
     assert "Prerequisites & Safety" in first_source
     assert "ROBINHOOD_USERNAME" in first_source
 
-    code_sources = ["".join(cell.get("source", [])) for cell in notebook["cells"] if cell["cell_type"] == "code"]
+    code_cells = [cell for cell in notebook["cells"] if cell["cell_type"] == "code"]
+    code_sources = [source_text(cell) for cell in code_cells]
+
+    assert any("MCP_HTTP_URL" in src and "http://localhost:3001/mcp" in src for src in code_sources)
+    for cell in code_cells:
+        assert cell.get("outputs") == []
+        assert cell.get("execution_count") is None
+
     assert any(
         token in src for src in code_sources for token in ["account_info", "portfolio", "stock_price"]
     )


### PR DESCRIPTION
Closes #213

## Changes
- tighten `test_market_data_notebook_is_valid` to normalize notebook cell `source` values and assert unexecuted code cells (`outputs: []`, `execution_count: null`)
- assert notebook setup code references `MCP_HTTP_URL` with default `http://localhost:3001/mcp`
- update `examples/notebooks/01_market_data_quickstart.ipynb` to use the HTTP startup snippet and env-driven MCP URL pattern from `examples/google_adk_agent/agent.py`
- keep market-data calls as read-only examples: `stock_price("AAPL")`, `market_hours()`, `portfolio()`

## Notes
- The implementation plan step that expected an initial failing run due to a missing notebook was not reproducible because `examples/notebooks/01_market_data_quickstart.ipynb` already exists on `main`.

## Test plan
- `uv run pytest tests/unit/test_example_notebooks.py::test_market_data_notebook_is_valid -v`
- `uv run ruff check tests`
- `uv run pytest tests -k 'docs or examples'`
