### PR TITLE
test: add response-time health threshold coverage

### DIFF
--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -53,6 +53,22 @@ async def test_get_health_status_thresholds_map_correctly() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_health_status_response_time_thresholds_map_correctly() -> None:
+    collector = MetricsCollector()
+    now = datetime.now()
+
+    collector.api_calls.extend([(now, "tool", True) for _ in range(20)])
+    collector.response_times.extend([(now, 6.0) for _ in range(20)])
+    degraded = await collector.get_health_status()
+    assert degraded["status"] == "degraded"
+
+    collector.response_times.clear()
+    collector.response_times.extend([(now, 12.0) for _ in range(20)])
+    unhealthy = await collector.get_health_status()
+    assert unhealthy["status"] == "unhealthy"
+
+
+@pytest.mark.asyncio
 async def test_get_metrics_includes_per_tool_latency_and_throughput() -> None:
     collector = MetricsCollector(window_size_minutes=1)
 


### PR DESCRIPTION
Closes #225

## Changes
- Added  in .
- Covers degraded mapping at ~6000ms average response time.
- Covers unhealthy mapping at ~12000ms average response time.
- Keeps existing metrics error-rate transition coverage intact.

## Test plan
- ============================= test session starts ==============================
platform darwin -- Python 3.10.6, pytest-9.0.2, pluggy-1.6.0 -- /opt/homebrew/opt/python@3.10/bin/python3.10
cachedir: .pytest_cache
rootdir: /Users/wes/Development/Open Agent Tools/open-stocks-mcp/.foreman/worktrees/225
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, cov-7.0.0
asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 7 items

tests/unit/test_health_service.py::test_get_status_returns_structured_snapshot_from_cached_broker_status PASSED [ 14%]
tests/unit/test_health_service.py::test_metrics_component_transitions_healthy_to_degraded_to_unhealthy PASSED [ 28%]
tests/unit/test_health_service.py::test_broker_component_transitions_on_auth_status_change PASSED [ 42%]
tests/unit/test_health_service.py::test_monitoring_disabled_skips_metrics_collection PASSED [ 57%]
tests/unit/test_health_service.py::test_load_config_reads_monitoring_enabled_env PASSED [ 71%]
tests/unit/test_monitoring.py::test_get_health_status_thresholds_map_correctly PASSED [ 85%]
tests/unit/test_monitoring.py::test_get_health_status_response_time_thresholds_map_correctly PASSED [100%]

============================== 7 passed in 0.41s ===============================
- All checks passed!
- Would reformat: src/open_stocks_mcp/health.py
Would reformat: tests/unit/test_health_service.py
2 files would be reformatted, 2 files already formatted (currently reports pre-existing formatting drift)
- Success: no issues found in 2 source files
- 1 file left unchanged
- All checks passed!
- 1 file already formatted
- ============================= test session starts ==============================
platform darwin -- Python 3.10.6, pytest-9.0.2, pluggy-1.6.0 -- /opt/homebrew/opt/python@3.10/bin/python3.10
cachedir: .pytest_cache
rootdir: /Users/wes/Development/Open Agent Tools/open-stocks-mcp/.foreman/worktrees/225
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, cov-7.0.0
asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 2 items

tests/unit/test_monitoring.py::test_get_health_status_thresholds_map_correctly PASSED [ 50%]
tests/unit/test_monitoring.py::test_get_health_status_response_time_thresholds_map_correctly PASSED [100%]

============================== 2 passed in 0.04s ===============================