### PR TITLE
feat: implement health service component status mapping

### DIFF
--- a/src/open_stocks_mcp/health.py
+++ b/src/open_stocks_mcp/health.py
@@ -75,9 +75,12 @@ class HealthService:
             return ComponentStatus.DEGRADED
         return ComponentStatus.HEALTHY
 
-    async def _get_registry(self) -> BrokerRegistry:
+    async def _get_registry(self) -> BrokerRegistry | None:
         if self.registry is None:
-            self.registry = await get_broker_registry()
+            try:
+                self.registry = await get_broker_registry()
+            except Exception:
+                return None
         return self.registry
 
     def _get_session_manager(self) -> SessionManager:
@@ -105,7 +108,9 @@ class HealthService:
                 name="metrics",
                 status=metrics_state,
                 last_checked=now,
-                detail=", ".join(metrics.get("issues", [])) if metrics.get("issues") else None,
+                detail=", ".join(metrics.get("issues", []))
+                if metrics.get("issues")
+                else None,
             )
         else:
             metrics_component = ComponentHealth(
@@ -121,7 +126,7 @@ class HealthService:
         session_status = (
             ComponentStatus.HEALTHY
             if session_info.get("authenticated", False)
-            else ComponentStatus.DEGRADED
+            else ComponentStatus.UNHEALTHY
         )
         session_component = ComponentHealth(
             name="session",
@@ -136,25 +141,34 @@ class HealthService:
         components["session"] = session_component.to_dict()
         component_states.append(session_component.status)
 
+        broker_states: list[ComponentStatus] = []
         registry = await self._get_registry()
-        for broker_name in registry.list_brokers():
-            broker = registry.get_broker(broker_name)
-            if broker is None:
-                continue
-            broker_status = self._map_broker_auth_status(broker.auth_info.status)
-            broker_component = ComponentHealth(
-                name=f"broker:{broker_name}",
-                status=broker_status,
-                last_checked=now,
-                error_message=broker.auth_info.error_message,
-            )
-            components[f"broker:{broker_name}"] = broker_component.to_dict()
-            component_states.append(broker_component.status)
+        if registry is not None:
+            for broker_name in registry.list_brokers():
+                broker = registry.get_broker(broker_name)
+                if broker is None:
+                    continue
+                broker_status = self._map_broker_auth_status(broker.auth_info.status)
+                broker_component = ComponentHealth(
+                    name=f"broker:{broker_name}",
+                    status=broker_status,
+                    last_checked=now,
+                    error_message=broker.auth_info.error_message,
+                )
+                components[f"broker:{broker_name}"] = broker_component.to_dict()
+                component_states.append(broker_component.status)
+                broker_states.append(broker_component.status)
 
         overall = ComponentStatus.HEALTHY
-        if any(state == ComponentStatus.UNHEALTHY for state in component_states):
+        core_states = component_states[:2]
+        if any(state == ComponentStatus.UNHEALTHY for state in core_states) or (
+            broker_states
+            and all(state == ComponentStatus.UNHEALTHY for state in broker_states)
+        ):
             overall = ComponentStatus.UNHEALTHY
-        elif any(state == ComponentStatus.DEGRADED for state in component_states):
+        elif any(
+            state == ComponentStatus.DEGRADED for state in component_states
+        ) or any(state == ComponentStatus.UNHEALTHY for state in broker_states):
             overall = ComponentStatus.DEGRADED
 
         return {

--- a/tests/unit/test_health_service.py
+++ b/tests/unit/test_health_service.py
@@ -6,10 +6,12 @@ import pytest
 
 from open_stocks_mcp.brokers.base import BrokerAuthStatus
 from open_stocks_mcp.config import load_config
-from open_stocks_mcp.health import HealthService
+from open_stocks_mcp.health import HealthService, get_health_service
 
 
-def _fake_broker(name: str, status: BrokerAuthStatus, error_message: str | None = None) -> MagicMock:
+def _fake_broker(
+    name: str, status: BrokerAuthStatus, error_message: str | None = None
+) -> MagicMock:
     broker = MagicMock()
     broker.name = name
     broker.auth_info.status = status
@@ -18,18 +20,29 @@ def _fake_broker(name: str, status: BrokerAuthStatus, error_message: str | None 
 
 
 @pytest.mark.asyncio
-async def test_get_status_returns_structured_snapshot_from_cached_broker_status() -> None:
+async def test_get_status_returns_structured_snapshot_from_cached_broker_status() -> (
+    None
+):
     registry = MagicMock()
     robinhood = _fake_broker("robinhood", BrokerAuthStatus.AUTHENTICATED)
     schwab = _fake_broker("schwab", BrokerAuthStatus.NOT_CONFIGURED)
     registry.list_brokers.return_value = ["robinhood", "schwab"]
-    registry.get_broker.side_effect = lambda name: {"robinhood": robinhood, "schwab": schwab}[name]
+    registry.get_broker.side_effect = lambda name: {
+        "robinhood": robinhood,
+        "schwab": schwab,
+    }[name]
 
     metrics_collector = AsyncMock()
-    metrics_collector.get_health_status.return_value = {"status": "healthy", "issues": []}
+    metrics_collector.get_health_status.return_value = {
+        "status": "healthy",
+        "issues": [],
+    }
 
     session_manager = MagicMock()
-    session_manager.get_session_info.return_value = {"authenticated": True, "session_duration": 123}
+    session_manager.get_session_info.return_value = {
+        "authenticated": True,
+        "session_duration": 123,
+    }
 
     service = HealthService(
         registry=registry,
@@ -43,11 +56,13 @@ async def test_get_status_returns_structured_snapshot_from_cached_broker_status(
     assert result["components"]["broker:robinhood"]["status"] == "healthy"
     assert result["components"]["broker:schwab"]["status"] == "unhealthy"
     assert result["components"]["metrics"]["status"] == "healthy"
-    assert result["status"] == "unhealthy"
+    assert result["status"] == "degraded"
     assert not robinhood.authenticate.called
     assert not robinhood.is_authenticated.called
+    assert not robinhood.get_account_info.called
     assert not schwab.authenticate.called
     assert not schwab.is_authenticated.called
+    assert not schwab.get_account_info.called
 
 
 @pytest.mark.asyncio
@@ -63,7 +78,11 @@ async def test_metrics_component_transitions_healthy_to_degraded_to_unhealthy() 
     session_manager = MagicMock()
     session_manager.get_session_info.return_value = {"authenticated": True}
 
-    service = HealthService(registry=registry, metrics_collector=metrics_collector, session_manager=session_manager)
+    service = HealthService(
+        registry=registry,
+        metrics_collector=metrics_collector,
+        session_manager=session_manager,
+    )
 
     first = await service.get_status()
     second = await service.get_status()
@@ -81,10 +100,17 @@ async def test_broker_component_transitions_on_auth_status_change() -> None:
     registry.list_brokers.return_value = ["robinhood"]
     registry.get_broker.return_value = broker
     metrics_collector = AsyncMock()
-    metrics_collector.get_health_status.return_value = {"status": "healthy", "issues": []}
+    metrics_collector.get_health_status.return_value = {
+        "status": "healthy",
+        "issues": [],
+    }
     session_manager = MagicMock()
     session_manager.get_session_info.return_value = {"authenticated": True}
-    service = HealthService(registry=registry, metrics_collector=metrics_collector, session_manager=session_manager)
+    service = HealthService(
+        registry=registry,
+        metrics_collector=metrics_collector,
+        session_manager=session_manager,
+    )
 
     s1 = await service.get_status()
     broker.auth_info.status = BrokerAuthStatus.AUTHENTICATING
@@ -98,6 +124,117 @@ async def test_broker_component_transitions_on_auth_status_change() -> None:
     assert s2["components"]["broker:robinhood"]["status"] == "degraded"
     assert s3["components"]["broker:robinhood"]["status"] == "healthy"
     assert s4["components"]["broker:robinhood"]["status"] == "unhealthy"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("broker_status", "expected"),
+    [
+        (BrokerAuthStatus.AUTHENTICATED, "healthy"),
+        (BrokerAuthStatus.AUTHENTICATING, "degraded"),
+        (BrokerAuthStatus.MFA_REQUIRED, "degraded"),
+        (BrokerAuthStatus.NOT_CONFIGURED, "unhealthy"),
+        (BrokerAuthStatus.NOT_AUTHENTICATED, "unhealthy"),
+        (BrokerAuthStatus.AUTH_FAILED, "unhealthy"),
+        (BrokerAuthStatus.TOKEN_EXPIRED, "unhealthy"),
+    ],
+)
+async def test_broker_auth_status_mapping(
+    broker_status: BrokerAuthStatus, expected: str
+) -> None:
+    broker = _fake_broker("robinhood", broker_status)
+    registry = MagicMock()
+    registry.list_brokers.return_value = ["robinhood"]
+    registry.get_broker.return_value = broker
+    metrics_collector = AsyncMock()
+    metrics_collector.get_health_status.return_value = {
+        "status": "healthy",
+        "issues": [],
+    }
+    session_manager = MagicMock()
+    session_manager.get_session_info.return_value = {"authenticated": True}
+    service = HealthService(
+        registry=registry,
+        metrics_collector=metrics_collector,
+        session_manager=session_manager,
+    )
+
+    status = await service.get_status()
+    assert status["components"]["broker:robinhood"]["status"] == expected
+
+
+@pytest.mark.asyncio
+async def test_overall_status_aggregation_rules() -> None:
+    metrics_collector = AsyncMock()
+    metrics_collector.get_health_status.return_value = {
+        "status": "healthy",
+        "issues": [],
+    }
+
+    registry_partial = MagicMock()
+    broker_ok = _fake_broker("robinhood", BrokerAuthStatus.AUTHENTICATED)
+    broker_bad = _fake_broker("schwab", BrokerAuthStatus.NOT_CONFIGURED)
+    registry_partial.list_brokers.return_value = ["robinhood", "schwab"]
+    registry_partial.get_broker.side_effect = lambda name: {
+        "robinhood": broker_ok,
+        "schwab": broker_bad,
+    }[name]
+
+    session_healthy = MagicMock()
+    session_healthy.get_session_info.return_value = {"authenticated": True}
+    partial = HealthService(
+        registry=registry_partial,
+        metrics_collector=metrics_collector,
+        session_manager=session_healthy,
+    )
+    assert (await partial.get_status())["status"] == "degraded"
+
+    registry_all_bad = MagicMock()
+    registry_all_bad.list_brokers.return_value = ["robinhood"]
+    registry_all_bad.get_broker.return_value = _fake_broker(
+        "robinhood", BrokerAuthStatus.NOT_AUTHENTICATED
+    )
+    all_bad = HealthService(
+        registry=registry_all_bad,
+        metrics_collector=metrics_collector,
+        session_manager=session_healthy,
+    )
+    assert (await all_bad.get_status())["status"] == "unhealthy"
+
+    session_unhealthy = MagicMock()
+    session_unhealthy.get_session_info.return_value = {"authenticated": False}
+    core_unhealthy = HealthService(
+        registry=registry_partial,
+        metrics_collector=metrics_collector,
+        session_manager=session_unhealthy,
+    )
+    assert (await core_unhealthy.get_status())["status"] == "unhealthy"
+
+
+@pytest.mark.asyncio
+async def test_registry_lookup_failure_omits_broker_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_registry() -> None:
+        raise RuntimeError("registry init failed")
+
+    monkeypatch.setattr("open_stocks_mcp.health.get_broker_registry", fail_registry)
+    metrics_collector = AsyncMock()
+    metrics_collector.get_health_status.return_value = {
+        "status": "healthy",
+        "issues": [],
+    }
+    session_manager = MagicMock()
+    session_manager.get_session_info.return_value = {"authenticated": True}
+    service = HealthService(
+        registry=None,
+        metrics_collector=metrics_collector,
+        session_manager=session_manager,
+    )
+
+    result = await service.get_status()
+    assert result["status"] == "healthy"
+    assert "broker:robinhood" not in result["components"]
 
 
 @pytest.mark.asyncio
@@ -120,7 +257,9 @@ async def test_monitoring_disabled_skips_metrics_collection() -> None:
     assert result["components"]["metrics"]["detail"] == "monitoring disabled"
 
 
-def test_load_config_reads_monitoring_enabled_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_config_reads_monitoring_enabled_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("MONITORING_ENABLED", "false")
     cfg = load_config()
     assert cfg.monitoring_enabled is False
@@ -128,3 +267,10 @@ def test_load_config_reads_monitoring_enabled_env(monkeypatch: pytest.MonkeyPatc
     monkeypatch.delenv("MONITORING_ENABLED", raising=False)
     cfg_default = load_config()
     assert cfg_default.monitoring_enabled is True
+
+
+def test_get_health_service_returns_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("open_stocks_mcp.health._health_service", None)
+    first = get_health_service()
+    second = get_health_service()
+    assert first is second


### PR DESCRIPTION
Closes #226

## Changes
- update `HealthService` component aggregation semantics so core-component outages force `unhealthy`, partial broker outages degrade, and all-broker outages become `unhealthy`
- make broker registry lookup lazy and fault-tolerant when no registry is injected
- expand unit coverage for broker auth-status mapping, overall aggregation cases, registry lookup failure, and singleton accessor behavior
- enforce that health checks use cached broker auth state without triggering broker API methods

## Test plan
- uv run pytest tests/unit/test_health_service.py -v
- uv run ruff check . --fix && uv run ruff format .
- uv run mypy src/open_stocks_mcp/health.py