### PR TITLE
feat: align health_check payload with health service

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -10,10 +10,10 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 from open_stocks_mcp.config import ServerConfig, load_config
+from open_stocks_mcp.health import get_health_service
 from open_stocks_mcp.logging_config import logger, setup_logging
 from open_stocks_mcp.server.tool_helpers import (
     get_broker_status_data,
-    get_health_check_data,
     get_list_brokers_data,
     get_list_tools_data,
     get_metrics_summary_data,
@@ -293,7 +293,8 @@ async def metrics_summary() -> dict[str, Any]:
 @mcp.tool()
 async def health_check() -> dict[str, Any]:
     """Gets health status of the MCP server."""
-    return await get_health_check_data()
+    health_status = await get_health_service().get_status()
+    return {"result": health_status}
 
 
 # Market Data Tools

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -182,7 +182,10 @@ class TestHTTPEndpoints:
                 "metrics": {"status": "healthy"},
                 "session": {"status": "healthy", "detail": "authenticated"},
                 "broker:robinhood": {"status": "healthy"},
-                "broker:schwab": {"status": "unhealthy", "error_message": "not configured"},
+                "broker:schwab": {
+                    "status": "unhealthy",
+                    "error_message": "not configured",
+                },
             },
         }
         mock_get_health_service.return_value = mock_health_service
@@ -200,9 +203,7 @@ class TestHTTPEndpoints:
         assert data["components"]["session"]["detail"] == "authenticated"
         assert data["components"]["broker:robinhood"]["status"] == "healthy"
         assert data["components"]["broker:schwab"]["status"] == "unhealthy"
-        assert (
-            data["components"]["broker:schwab"]["error_message"] == "not configured"
-        )
+        assert data["components"]["broker:schwab"]["error_message"] == "not configured"
         # Assert legacy keys are gone
         assert "session" not in data
         assert "health" not in data
@@ -249,7 +250,9 @@ class TestHTTPEndpoints:
             setattr(mock_robinhood, method, AsyncMock())
             setattr(mock_schwab, method, AsyncMock())
 
-        with patch("open_stocks_mcp.brokers.registry.get_broker_registry") as mock_get_registry:
+        with patch(
+            "open_stocks_mcp.brokers.registry.get_broker_registry"
+        ) as mock_get_registry:
             mock_registry = Mock()
             mock_registry.get_all_brokers.return_value = [mock_robinhood, mock_schwab]
             mock_get_registry.return_value = mock_registry
@@ -260,6 +263,39 @@ class TestHTTPEndpoints:
             for method in live_methods:
                 getattr(mock_robinhood, method).assert_not_awaited()
                 getattr(mock_schwab, method).assert_not_awaited()
+
+    async def test_health_endpoint_reports_monitoring_disabled(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """Health endpoint should preserve disabled-monitoring component details."""
+        expected_health = {
+            "status": "healthy",
+            "components": {
+                "metrics": {
+                    "status": "healthy",
+                    "detail": "monitoring disabled",
+                    "last_checked": "2026-01-01T00:00:00+00:00",
+                }
+            },
+            "timestamp": 1704067200.0,
+        }
+        health_service = AsyncMock()
+        health_service.get_status.return_value = expected_health
+
+        with patch(
+            "open_stocks_mcp.server.http_transport.get_health_service",
+            return_value=health_service,
+        ):
+            response = await http_client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert data["components"]["metrics"]["status"] == "healthy"
+        assert data["components"]["metrics"]["detail"] == "monitoring disabled"
+        assert data["version"] == __version__
+        assert data["transport"] == "http"
+        assert "timestamp" in data
 
     async def test_server_status(self, http_client: httpx.AsyncClient) -> None:
         """Test server status endpoint"""

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -1,6 +1,6 @@
 """Tests for server app module."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -173,18 +173,21 @@ class TestToolRegistration:
 
     @pytest.mark.asyncio
     async def test_health_check_tool_returns_structured_components(self) -> None:
-        """Health tool should return structured component payload from helper."""
-        expected = {
-            "result": {
-                "status": "success",
-                "health_status": "healthy",
-                "components": {"broker:robinhood": {"status": "healthy"}},
-            }
+        """Health tool should return structured component payload from service."""
+        expected_health = {
+            "status": "healthy",
+            "components": {
+                "metrics": {"status": "healthy"},
+                "broker:robinhood": {"status": "healthy"},
+            },
+            "timestamp": "2026-01-01T00:00:00+00:00",
         }
+        health_service = MagicMock()
+        health_service.get_status = AsyncMock(return_value=expected_health)
+
         with patch(
-            "open_stocks_mcp.server.app.get_health_check_data", return_value=expected
+            "open_stocks_mcp.server.app.get_health_service", return_value=health_service
         ):
             result = await health_check()
 
-        assert result["result"]["status"] == "success"
-        assert result["result"]["components"]["broker:robinhood"]["status"] == "healthy"
+        assert result == {"result": expected_health}


### PR DESCRIPTION
Closes #223

## Changes
- switched MCP `health_check` tool to return `get_health_service().get_status()` directly inside the existing `{"result": ...}` envelope
- updated server tool registration test to assert structured status/components payload parity from `HealthService`
- added HTTP `/health` test covering monitoring-disabled metrics detail (`detail="monitoring disabled"`) while preserving endpoint metadata fields

## Test plan
- uv run pytest tests/server/test_server_app.py::TestToolRegistration::test_health_check_tool_returns_structured_components tests/http_transport/test_http_server.py::TestHTTPEndpoints::test_health_endpoint_reports_monitoring_disabled -v
- uv run ruff check src/open_stocks_mcp/server/app.py tests/server/test_server_app.py tests/http_transport/test_http_server.py
- uv run ruff format --check src/open_stocks_mcp/server/app.py tests/server/test_server_app.py tests/http_transport/test_http_server.py
- uv run mypy src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/health.py src/open_stocks_mcp/config.py