### PR TITLE
fix: preserve interactive MFA prompt visibility

### DIFF
--- a/src/open_stocks_mcp/tools/session_manager.py
+++ b/src/open_stocks_mcp/tools/session_manager.py
@@ -252,9 +252,10 @@ class SessionManager:
         if sys.stdin.isatty():
             try:
                 # Use stderr for prompt to avoid polluting stdout in some environments
-                sys.stderr.write("\nROBINHOOD MFA REQUIRED\n")
-                sys.stderr.write("Enter verification code: ")
-                sys.stderr.flush()
+                prompt_stream = getattr(sys, "__stderr__", None) or sys.stderr
+                prompt_stream.write("\nROBINHOOD MFA REQUIRED\n")
+                prompt_stream.write("Enter verification code: ")
+                prompt_stream.flush()
                 return sys.stdin.readline().strip()
             except Exception as e:
                 logger.error(f"Failed to read interactive MFA code: {e}")

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -1,6 +1,8 @@
 """Unit tests for session manager behavior."""
 
 import asyncio
+import io
+from contextlib import redirect_stderr
 from datetime import datetime
 from unittest.mock import patch
 
@@ -100,3 +102,28 @@ def test_logout_reraises_exception_and_still_clears_state() -> None:
     assert manager.login_time is None
     assert manager.last_successful_call is None
     assert manager._failed_login_attempts == 0
+
+
+def test_interactive_mfa_prompt_uses_original_stderr_when_stderr_is_redirected() -> (
+    None
+):
+    """Interactive MFA prompt should bypass redirected stderr capture."""
+    manager = SessionManager()
+
+    fake_stdin = io.StringIO("654321\n")
+    fake_stdin.isatty = lambda: True  # type: ignore[attr-defined]
+    original_stderr = io.StringIO()
+    redirected_stderr = io.StringIO()
+
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("sys.stdin", fake_stdin),
+        patch("sys.__stderr__", original_stderr),
+        redirect_stderr(redirected_stderr),
+    ):
+        code = manager._resolve_mfa_code()
+
+    assert code == "654321"
+    assert "ROBINHOOD MFA REQUIRED" in original_stderr.getvalue()
+    assert "Enter verification code:" in original_stderr.getvalue()
+    assert "ROBINHOOD MFA REQUIRED" not in redirected_stderr.getvalue()


### PR DESCRIPTION
Closes #299

## Changes
- write interactive MFA prompt output to the original stderr stream (`sys.__stderr__`) with fallback to `sys.stderr`
- add regression test covering `_resolve_mfa_code()` behavior when stderr is redirected
- keep existing env-var MFA and device-approval behavior unchanged

## Test plan
- uv run pytest tests/unit/test_session_manager.py::test_interactive_mfa_prompt_uses_original_stderr_when_stderr_is_redirected -v
- uv run pytest tests/unit/test_session_manager.py -v
- uv run ruff check src/open_stocks_mcp/tools/session_manager.py tests/unit/test_session_manager.py
- uv run ruff format --check src/open_stocks_mcp/tools/session_manager.py tests/unit/test_session_manager.py
- uv run mypy src/open_stocks_mcp/tools/session_manager.py