### PR TITLE
feat: delegate robinhood broker quotes to stock tool

### DIFF
--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -153,14 +153,9 @@ class RobinhoodBroker(BaseBroker):
         if not self.is_available():
             return self.create_unavailable_response(f"get stock quote for {symbol}")
 
-        # TODO: Phase 2 - delegate to existing get_stock_quote_by_id() function
-        # For now, return placeholder
-        return {
-            "result": {
-                "error": "Not yet implemented in broker adapter",
-                "status": "not_implemented",
-            }
-        }
+        from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+
+        return await get_stock_price(symbol)
 
     async def get_stock_price(self, symbol: str) -> dict[str, Any]:
         """Get current stock price."""

--- a/tests/unit/test_robinhood_broker.py
+++ b/tests/unit/test_robinhood_broker.py
@@ -1,0 +1,90 @@
+"""Unit tests for Robinhood broker stock quote delegation."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from open_stocks_mcp.brokers.base import BrokerAuthStatus
+from open_stocks_mcp.brokers.robinhood import RobinhoodBroker
+
+
+@pytest.fixture
+def robinhood_broker() -> RobinhoodBroker:
+    """Create a Robinhood broker instance for testing."""
+    return RobinhoodBroker()
+
+
+@pytest.mark.journey_market_data
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_stock_quote_delegates_to_get_stock_price_success(
+    robinhood_broker: RobinhoodBroker,
+) -> None:
+    """Delegates quote lookups to the live stock price tool path."""
+    robinhood_broker._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+    expected = {
+        "result": {
+            "symbol": "AAPL",
+            "price": 150.25,
+            "previous_close": 148.5,
+            "volume": 1000000,
+            "ask_price": 150.30,
+            "bid_price": 150.20,
+            "last_trade_price": 150.25,
+            "status": "success",
+        }
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.get_stock_price",
+        new=AsyncMock(return_value=expected),
+    ) as mock_get_stock_price:
+        result = await robinhood_broker.get_stock_quote("AAPL")
+
+    assert result == expected
+    mock_get_stock_price.assert_awaited_once_with("AAPL")
+
+
+@pytest.mark.journey_market_data
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_stock_quote_unavailable_broker_does_not_call_tool(
+    robinhood_broker: RobinhoodBroker,
+) -> None:
+    """Unavailable broker returns standardized response without tool delegation."""
+    robinhood_broker._auth_info.status = BrokerAuthStatus.NOT_CONFIGURED
+
+    with patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.get_stock_price",
+        new=AsyncMock(),
+    ) as mock_get_stock_price:
+        result = await robinhood_broker.get_stock_quote("AAPL")
+
+    assert result["result"]["status"] == "broker_unavailable"
+    assert result["result"]["broker"] == "robinhood"
+    mock_get_stock_price.assert_not_called()
+
+
+@pytest.mark.journey_market_data
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_stock_quote_returns_delegated_error_response(
+    robinhood_broker: RobinhoodBroker,
+) -> None:
+    """Delegated error responses are returned unchanged."""
+    robinhood_broker._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+    expected = {
+        "result": {
+            "status": "error",
+            "error": "Invalid symbol format: 123INVALID",
+        }
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.get_stock_price",
+        new=AsyncMock(return_value=expected),
+    ) as mock_get_stock_price:
+        result = await robinhood_broker.get_stock_quote("123INVALID")
+
+    assert result == expected
+    mock_get_stock_price.assert_awaited_once_with("123INVALID")


### PR DESCRIPTION
Closes #284

## Changes
- wire `RobinhoodBroker.get_stock_quote` to delegate to `get_stock_price(symbol)` after the existing availability guard
- add focused unit tests for delegated success, broker-unavailable behavior, and delegated error passthrough
- keep response payload shape/error propagation aligned with existing stock tool behavior

## Test plan
- `uv run pytest tests/unit/test_robinhood_broker.py -v -k stock_quote`
- `uv run pytest tests/unit/test_robinhood_broker.py -v`
- `uv run pytest tests/unit/test_stock_market_tools.py -v -k "get_stock_price or get_stock_quote_by_id"`
- `uv run ruff check src tests`
- `uv run mypy src`