### PR TITLE
test: add comprehensive error handling coverage

### DIFF
--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,4 +1,4 @@
-"""Unit tests for error handling facade and related helper behavior."""
+"""Unit tests for error handling helpers and retry behavior."""
 
 import asyncio
 from collections.abc import Callable
@@ -94,26 +94,23 @@ def _always_fails(counter: list[int]) -> Callable[[], None]:
         ("malformed payload", DataError),
     ],
 )
-def test_classify_error_cases(
-    message: str, expected_type: type[RobinStocksError]
-) -> None:
+def test_classify_error(message: str, expected_type: type[RobinStocksError]) -> None:
     classified = classify_error(RuntimeError(message))
     assert isinstance(classified, expected_type)
 
 
-def test_classify_error_fallback_api_error() -> None:
+def test_classify_error_falls_back_to_api_error() -> None:
     classified = classify_error(RuntimeError("kaboom"))
     assert isinstance(classified, APIError)
     assert "kaboom" in classified.message
 
 
-def test_exception_classes_and_error_types() -> None:
-    original = ValueError("bad")
-    base = RobinStocksError("base", "custom", original)
-
-    assert base.message == "base"
-    assert base.error_type == "custom"
-    assert base.original_error is original
+def test_exception_types_expose_error_type_and_original_error() -> None:
+    original = RuntimeError("root")
+    generic = RobinStocksError("oops", "custom", original)
+    assert generic.message == "oops"
+    assert generic.error_type == "custom"
+    assert generic.original_error is original
 
     assert AuthenticationError().error_type == "authentication"
     assert RateLimitError().error_type == "rate_limit"
@@ -123,61 +120,44 @@ def test_exception_classes_and_error_types() -> None:
 
 
 def test_create_error_response_without_context() -> None:
-    response = create_error_response(RuntimeError("rate limit hit"))
-    result = response["result"]
-
-    assert result["error"] == "Rate limit exceeded"
-    assert result["error_type"] == "rate_limit"
-    assert result["status"] == "error"
-    assert "context" not in result
+    response = create_error_response(RuntimeError("unauthorized"))
+    assert response["result"]["status"] == "error"
+    assert response["result"]["error_type"] == "authentication"
+    assert "context" not in response["result"]
 
 
-@pytest.mark.parametrize(
-    "error",
-    [AuthenticationError("auth"), RateLimitError("rate"), APIError("api")],
-)
-def test_create_error_response_with_context_matches_classification(
-    error: Exception,
-) -> None:
-    response = create_error_response(error, "in test")
-    result = response["result"]
-
-    assert result["context"] == "in test"
-    assert result["error_type"] == classify_error(error).error_type
+def test_create_error_response_with_context() -> None:
+    response = create_error_response(RuntimeError("rate limit hit"), "in test")
+    assert response["result"]["context"] == "in test"
+    assert response["result"]["error_type"] == "rate_limit"
 
 
-def test_create_success_response_default_status() -> None:
-    payload = {"value": 1}
+def test_create_success_response_default_and_custom_status() -> None:
+    payload = {"symbol": "AAPL"}
     response = create_success_response(payload)
-
     assert response["result"]["status"] == "success"
-    assert response["result"]["value"] == 1
+    assert response["result"]["symbol"] == "AAPL"
+
+    partial = create_success_response({"status": "partial", "symbol": "MSFT"})
+    assert partial["result"]["status"] == "partial"
 
 
-def test_create_success_response_preserves_status() -> None:
-    response = create_success_response({"status": "partial", "value": 2})
-    assert response["result"]["status"] == "partial"
-    assert response["result"]["value"] == 2
+def test_create_no_data_response() -> None:
+    no_context = create_no_data_response("no data")
+    assert no_context == {"result": {"message": "no data", "status": "no_data"}}
 
-
-def test_create_no_data_response_variants() -> None:
-    assert create_no_data_response("no data") == {
-        "result": {"message": "no data", "status": "no_data"}
-    }
-    assert create_no_data_response("no data", {"symbol": "AAPL"}) == {
-        "result": {"message": "no data", "status": "no_data", "symbol": "AAPL"}
-    }
+    with_context = create_no_data_response("no data", {"symbol": "AAPL"})
+    assert with_context["result"]["symbol"] == "AAPL"
 
 
 @pytest.mark.asyncio
-async def test_handle_robin_stocks_errors_success_and_metadata() -> None:
+async def test_handle_robin_stocks_errors_async_behavior_and_metadata() -> None:
     async def sample(symbol: str, span: str = "day") -> dict[str, str]:
         return {"symbol": symbol, "span": span}
 
-    decorated: Any = handle_robin_stocks_errors(sample)
-
-    assert await decorated("AAPL") == {"symbol": "AAPL", "span": "day"}
-    assert decorated.__wrapped__ is sample
+    decorated = handle_robin_stocks_errors(sample)
+    assert await decorated("AAPL", span="week") == {"symbol": "AAPL", "span": "week"}
+    assert getattr(decorated, "__wrapped__", None) is sample
     assert decorated.__name__ == "sample"
     assert (
         inspect.signature(decorated).parameters == inspect.signature(sample).parameters
@@ -187,10 +167,10 @@ async def test_handle_robin_stocks_errors_success_and_metadata() -> None:
 
 @pytest.mark.asyncio
 async def test_handle_robin_stocks_errors_classifies_exception() -> None:
-    async def boom() -> Any:
+    async def boom() -> dict[str, Any]:
         raise RuntimeError("rate limit hit")
 
-    decorated: Any = handle_robin_stocks_errors(boom)
+    decorated = handle_robin_stocks_errors(boom)
     assert await decorated() == {
         "result": {
             "error": "Rate limit exceeded",
@@ -201,14 +181,13 @@ async def test_handle_robin_stocks_errors_classifies_exception() -> None:
     }
 
 
-def test_handle_robin_stocks_sync_errors_success_and_metadata() -> None:
+def test_handle_robin_stocks_sync_errors_behavior_and_metadata() -> None:
     def sample(symbol: str, span: str = "day") -> dict[str, str]:
         return {"symbol": symbol, "span": span}
 
-    decorated: Any = handle_robin_stocks_sync_errors(sample)
-
+    decorated = handle_robin_stocks_sync_errors(sample)
     assert decorated("AAPL") == {"symbol": "AAPL", "span": "day"}
-    assert decorated.__wrapped__ is sample
+    assert getattr(decorated, "__wrapped__", None) is sample
     assert decorated.__name__ == "sample"
     assert (
         inspect.signature(decorated).parameters == inspect.signature(sample).parameters
@@ -217,10 +196,10 @@ def test_handle_robin_stocks_sync_errors_success_and_metadata() -> None:
 
 
 def test_handle_robin_stocks_sync_errors_classifies_exception() -> None:
-    def boom() -> Any:
+    def boom() -> dict[str, Any]:
         raise RuntimeError("rate limit hit")
 
-    decorated: Any = handle_robin_stocks_sync_errors(boom)
+    decorated = handle_robin_stocks_sync_errors(boom)
     assert decorated() == {
         "result": {
             "error": "Rate limit exceeded",
@@ -232,27 +211,30 @@ def test_handle_robin_stocks_sync_errors_classifies_exception() -> None:
 
 
 @pytest.mark.asyncio
-async def test_handle_schwab_errors_behaves_like_robinhood_variant() -> None:
+async def test_handle_schwab_errors_behavior_and_metadata() -> None:
     async def sample(symbol: str) -> dict[str, str]:
         return {"symbol": symbol}
 
-    decorated: Any = handle_schwab_errors(sample)
-    assert await decorated("MSFT") == {"symbol": "MSFT"}
-    assert decorated.__wrapped__ is sample
+    decorated = handle_schwab_errors(sample)
+    assert await decorated("AAPL") == {"symbol": "AAPL"}
+    assert getattr(decorated, "__wrapped__", None) is sample
     assert decorated.__name__ == "sample"
     assert (
         inspect.signature(decorated).parameters == inspect.signature(sample).parameters
     )
     assert inspect.iscoroutinefunction(decorated) is True
 
-    async def boom() -> Any:
-        raise RuntimeError("rate limit hit")
 
-    decorated_boom: Any = handle_schwab_errors(boom)
-    assert await decorated_boom() == {
+@pytest.mark.asyncio
+async def test_handle_schwab_errors_classifies_exception() -> None:
+    async def boom() -> dict[str, Any]:
+        raise RuntimeError("network down")
+
+    decorated = handle_schwab_errors(boom)
+    assert await decorated() == {
         "result": {
-            "error": "Rate limit exceeded",
-            "error_type": "rate_limit",
+            "error": "Network connectivity issue",
+            "error_type": "network",
             "status": "error",
             "context": "in boom",
         }
@@ -260,36 +242,45 @@ async def test_handle_schwab_errors_behaves_like_robinhood_variant() -> None:
 
 
 @pytest.mark.asyncio
-async def test_schema_preserved_for_local_fastmcp_decorated_tool() -> None:
-    server = FastMCP("test")
+async def test_decorated_tool_schema_is_not_collapsed() -> None:
+    test_mcp = FastMCP("test")
 
-    @server.tool()
+    @test_mcp.tool()
     @handle_robin_stocks_errors
-    async def decorated_tool(symbol: str, span: str = "day") -> dict[str, str]:
-        return {"symbol": symbol, "span": span}
+    async def decorated_price(symbol: str) -> dict[str, Any]:
+        return {"result": {"symbol": symbol}}
 
-    tools = await server.list_tools()
-    target = next(tool for tool in tools if tool.name == "decorated_tool")
-    assert "symbol" in target.inputSchema.get("properties", {})
-    assert "span" in target.inputSchema.get("properties", {})
+    tools = await test_mcp.list_tools()
+    entry = next(tool for tool in tools if tool.name == "decorated_price")
+    schema = (
+        entry.inputSchema.model_dump()
+        if hasattr(entry.inputSchema, "model_dump")
+        else entry.inputSchema
+    )
+    assert schema["properties"]["symbol"]["type"] == "string"
 
 
 @pytest.mark.asyncio
-async def test_production_stock_price_schema_has_symbol_property() -> None:
+async def test_production_stock_price_tool_schema_includes_symbol() -> None:
     tools = await production_mcp.list_tools()
     stock_price_tool = next(tool for tool in tools if tool.name == "stock_price")
-    assert "symbol" in stock_price_tool.inputSchema.get("properties", {})
+    schema = (
+        stock_price_tool.inputSchema.model_dump()
+        if hasattr(stock_price_tool.inputSchema, "model_dump")
+        else stock_price_tool.inputSchema
+    )
+    assert schema["properties"]["symbol"]["type"] == "string"
 
 
 @pytest.fixture
-def patched_retry_dependencies(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
-    fake_session = SimpleNamespace(
-        update_last_successful_call=Mock(),
-        should_block_auth_retries=Mock(return_value=False),
-        refresh_session=AsyncMock(return_value=True),
-    )
+def retry_patch(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    fake_session = Mock()
+    fake_session.update_last_successful_call = Mock()
+    fake_session.refresh_session = AsyncMock(return_value=True)
+    fake_session.should_block_auth_retries = Mock(return_value=False)
+
     fake_rate_limiter = SimpleNamespace(acquire=AsyncMock())
-    fake_sleep = AsyncMock()
+    sleep_mock = AsyncMock()
 
     monkeypatch.setattr(
         "open_stocks_mcp.tools.session_manager.get_session_manager",
@@ -299,12 +290,12 @@ def patched_retry_dependencies(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any
         "open_stocks_mcp.tools.rate_limiter.get_rate_limiter",
         lambda: fake_rate_limiter,
     )
-    monkeypatch.setattr("open_stocks_mcp.tools.retry.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("open_stocks_mcp.tools.retry.asyncio.sleep", sleep_mock)
 
     return {
         "session": fake_session,
         "rate_limiter": fake_rate_limiter,
-        "sleep": fake_sleep,
+        "sleep": sleep_mock,
     }
 
 
@@ -478,43 +469,37 @@ async def test_execute_with_retry_uses_registry_single_flight_for_auth_refresh()
 
 @pytest.mark.asyncio
 async def test_execute_with_retry_returns_value_on_first_success(
-    patched_retry_dependencies: dict[str, Any],
+    retry_patch: dict[str, Any],
 ) -> None:
-    async def target() -> str:
+    async def ok() -> str:
         return "ok"
 
-    result = await execute_with_retry(target)
+    result = await execute_with_retry(ok)
     assert result == "ok"
-    patched_retry_dependencies[
-        "session"
-    ].update_last_successful_call.assert_called_once()
-    patched_retry_dependencies["sleep"].assert_not_awaited()
+    retry_patch["session"].update_last_successful_call.assert_called_once()
+    retry_patch["sleep"].assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_execute_with_retry_runs_sync_func_in_executor(
-    patched_retry_dependencies: dict[str, Any],
+async def test_execute_with_retry_runs_sync_in_executor(
+    retry_patch: dict[str, Any],
 ) -> None:
     def add(a: int, b: int = 1) -> int:
         return a + b
 
     result = await execute_with_retry(add, 2, b=3)
     assert result == 5
-    patched_retry_dependencies[
-        "session"
-    ].update_last_successful_call.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_execute_with_retry_retries_then_succeeds(
-    patched_retry_dependencies: dict[str, Any],
+    retry_patch: dict[str, Any],
 ) -> None:
-    calls = 0
+    calls = {"count": 0}
 
     async def flaky() -> str:
-        nonlocal calls
-        calls += 1
-        if calls < 3:
+        calls["count"] += 1
+        if calls["count"] < 3:
             raise RuntimeError("connection refused")
         return "ok"
 
@@ -522,113 +507,90 @@ async def test_execute_with_retry_retries_then_succeeds(
         flaky, max_retries=3, delay=0.1, backoff_factor=2.0
     )
     assert result == "ok"
-    assert calls == 3
-    patched_retry_dependencies["sleep"].assert_any_await(0.1)
-    patched_retry_dependencies["sleep"].assert_any_await(0.2)
+    assert calls["count"] == 3
+    retry_patch["sleep"].assert_any_await(0.1)
+    retry_patch["sleep"].assert_any_await(0.2)
 
 
 @pytest.mark.asyncio
 async def test_execute_with_retry_raises_after_max_retries(
-    patched_retry_dependencies: dict[str, Any],
+    retry_patch: dict[str, Any],
 ) -> None:
-    calls = 0
+    calls = {"count": 0}
 
-    async def always_fail() -> str:
-        nonlocal calls
-        calls += 1
+    async def always_fails() -> str:
+        calls["count"] += 1
         raise RuntimeError("connection refused")
 
     with pytest.raises(NetworkError):
-        await execute_with_retry(always_fail, max_retries=2, delay=0.01)
+        await execute_with_retry(always_fails, max_retries=2, delay=0.01)
 
-    assert calls == 3
+    assert calls["count"] == 3
 
 
 @pytest.mark.asyncio
 async def test_execute_with_retry_does_not_retry_on_data_error(
-    patched_retry_dependencies: dict[str, Any],
+    retry_patch: dict[str, Any],
 ) -> None:
-    calls = 0
+    calls = {"count": 0}
 
-    async def data_fail() -> str:
-        nonlocal calls
-        calls += 1
+    async def bad_data() -> str:
+        calls["count"] += 1
         raise RuntimeError("json decode error")
 
     with pytest.raises(DataError):
-        await execute_with_retry(data_fail, max_retries=3)
+        await execute_with_retry(bad_data, max_retries=3)
 
-    assert calls == 1
-    patched_retry_dependencies["sleep"].assert_not_awaited()
+    assert calls["count"] == 1
+    retry_patch["sleep"].assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_execute_with_retry_reauth_on_authentication_error(
-    patched_retry_dependencies: dict[str, Any],
+    retry_patch: dict[str, Any],
 ) -> None:
-    calls = 0
+    calls = {"count": 0}
 
-    async def auth_then_ok() -> str:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
+    async def auth_once() -> str:
+        calls["count"] += 1
+        if calls["count"] == 1:
             raise RuntimeError("unauthorized")
         return "ok"
 
-    result = await execute_with_retry(auth_then_ok, max_retries=2)
+    result = await execute_with_retry(auth_once, max_retries=1)
     assert result == "ok"
-    patched_retry_dependencies["session"].refresh_session.assert_awaited_once()
+    retry_patch["session"].refresh_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_execute_with_retry_raises_when_reauth_fails(
-    patched_retry_dependencies: dict[str, Any],
+    retry_patch: dict[str, Any],
 ) -> None:
-    patched_retry_dependencies["session"].refresh_session = AsyncMock(
-        return_value=False
-    )
+    retry_patch["session"].refresh_session = AsyncMock(return_value=False)
 
-    async def always_auth_fail() -> str:
+    async def auth_fails() -> str:
         raise RuntimeError("token expired")
 
     with pytest.raises(AuthenticationError):
-        await execute_with_retry(always_auth_fail, max_retries=2)
+        await execute_with_retry(auth_fails, max_retries=1)
 
-    patched_retry_dependencies["session"].refresh_session.assert_awaited_once()
+    retry_patch["session"].refresh_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_execute_with_retry_skips_rate_limiter_when_disabled(
-    monkeypatch: pytest.MonkeyPatch,
+    retry_patch: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    fake_session = SimpleNamespace(
-        update_last_successful_call=Mock(),
-        should_block_auth_retries=Mock(return_value=False),
-        refresh_session=AsyncMock(return_value=True),
-    )
-
-    rate_limiter_called = False
-
-    def fail_get_rate_limiter() -> Any:
-        nonlocal rate_limiter_called
-        rate_limiter_called = True
-        raise AssertionError("rate limiter should not be requested")
-
+    get_rate_limiter = Mock(side_effect=AssertionError("should not be called"))
     monkeypatch.setattr(
-        "open_stocks_mcp.tools.session_manager.get_session_manager",
-        lambda: fake_session,
-    )
-    monkeypatch.setattr(
-        "open_stocks_mcp.tools.rate_limiter.get_rate_limiter",
-        fail_get_rate_limiter,
+        "open_stocks_mcp.tools.rate_limiter.get_rate_limiter", get_rate_limiter
     )
 
-    async def target() -> str:
+    async def ok() -> str:
         return "ok"
 
-    result = await execute_with_retry(target, rate_limit=False)
-    assert result == "ok"
-    assert rate_limiter_called is False
+    assert await execute_with_retry(ok, rate_limit=False) == "ok"
+    get_rate_limiter.assert_not_called()
 
 
 @pytest.mark.parametrize("symbol", ["A", "AAPL", "GOOGL", "BRK", "abc", "BRK1"])
@@ -636,9 +598,16 @@ def test_validate_symbol_valid(symbol: str) -> None:
     assert validate_symbol(symbol) is True
 
 
-@pytest.mark.parametrize("symbol", ["", None, "TOOLONG", "BR-K", "  ", "BR.K"])
-def test_validate_symbol_invalid(symbol: str | None) -> None:
-    assert validate_symbol(cast(str, symbol)) is False
+@pytest.mark.parametrize(
+    "symbol",
+    ["", "TOOLONG", "BR-K", "  ", "BR.K"],
+)
+def test_validate_symbol_invalid(symbol: str) -> None:
+    assert validate_symbol(symbol) is False
+
+
+def test_validate_symbol_invalid_none() -> None:
+    assert validate_symbol(None) is False  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
@@ -665,48 +634,34 @@ def test_validate_span_invalid(span: str) -> None:
     assert validate_span(span) is False
 
 
-def test_sanitize_api_response_recursive_redaction() -> None:
+def test_sanitize_api_response_redacts_recursive_values() -> None:
     payload = {
         "Token": "abc",
-        "user": {
-            "password": "secret",
-            "nested": [{"SSN": "123-45-6789"}, {"safe": "ok"}],
-        },
-        "value": 3,
+        "user": {"password": "pw", "nested": [{"SSN": "123"}]},
+        "safe": 7,
     }
-
     sanitized = sanitize_api_response(payload)
     assert sanitized["Token"] == "[REDACTED]"
     assert sanitized["user"]["password"] == "[REDACTED]"
     assert sanitized["user"]["nested"][0]["SSN"] == "[REDACTED]"
-    assert sanitized["user"]["nested"][1]["safe"] == "ok"
-    assert sanitized["value"] == 3
+    assert sanitized["safe"] == 7
 
 
-def test_sanitize_api_response_scalars_unchanged() -> None:
+def test_sanitize_api_response_preserves_scalars() -> None:
     assert sanitize_api_response("x") == "x"
     assert sanitize_api_response(5) == 5
     assert sanitize_api_response(None) is None
 
 
-def test_log_api_call_includes_symbol_and_excludes_sensitive(
+def test_log_api_call_excludes_sensitive_kwargs(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level("INFO")
     log_api_call(
-        "stock_price",
-        symbol="AAPL",
-        password="secret",
-        token="abc",
-        key="k",
-        secret="s",
-        period="day",
+        "stock_price", symbol="AAPL", token="secret", include_extended_hours=True
     )
-
     message = caplog.records[-1].message
     assert "stock_price" in message
     assert "AAPL" in message
-    assert "password" not in message
     assert "token" not in message
-    assert "secret" not in message
-    assert "'period': 'day'" in message
+    assert "include_extended_hours" in message

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,11 +1,10 @@
 """Unit tests for error handling helpers and retry behavior."""
 
 import asyncio
-from collections.abc import Callable
 import inspect
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -50,6 +49,14 @@ def _patch_retry_dependencies(
         session_manager_module, "get_session_manager", lambda: session_manager
     )
     monkeypatch.setattr(rate_limiter, "get_rate_limiter", lambda: None)
+    breaker = Mock()
+    breaker.before_request = AsyncMock(return_value=None)
+    breaker.record_success = AsyncMock(return_value=None)
+    breaker.record_failure = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "open_stocks_mcp.tools.circuit_breaker.get_broker_circuit_breaker",
+        lambda: breaker,
+    )
 
     sleep_calls: list[float] = []
 
@@ -280,6 +287,10 @@ def retry_patch(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     fake_session.should_block_auth_retries = Mock(return_value=False)
 
     fake_rate_limiter = SimpleNamespace(acquire=AsyncMock())
+    fake_breaker = Mock()
+    fake_breaker.before_request = AsyncMock(return_value=None)
+    fake_breaker.record_success = AsyncMock(return_value=None)
+    fake_breaker.record_failure = AsyncMock(return_value=None)
     sleep_mock = AsyncMock()
 
     monkeypatch.setattr(
@@ -290,11 +301,16 @@ def retry_patch(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         "open_stocks_mcp.tools.rate_limiter.get_rate_limiter",
         lambda: fake_rate_limiter,
     )
+    monkeypatch.setattr(
+        "open_stocks_mcp.tools.circuit_breaker.get_broker_circuit_breaker",
+        lambda: fake_breaker,
+    )
     monkeypatch.setattr("open_stocks_mcp.tools.retry.asyncio.sleep", sleep_mock)
 
     return {
         "session": fake_session,
         "rate_limiter": fake_rate_limiter,
+        "breaker": fake_breaker,
         "sleep": sleep_mock,
     }
 
@@ -354,7 +370,9 @@ async def test_execute_with_retry_explicit_arguments_override_config(
 
 
 @pytest.mark.asyncio
-async def test_execute_with_retry_blocks_auth_retry_when_pickle_clear_failures_persist() -> None:
+async def test_execute_with_retry_blocks_auth_retry_when_pickle_clear_failures_persist() -> (
+    None
+):
     """Auth retries should short-circuit when session cache clear keeps failing."""
 
     def auth_fail() -> None:
@@ -402,7 +420,9 @@ async def test_execute_with_retry_attempts_reauth_when_not_blocked() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_with_retry_uses_registry_single_flight_for_auth_refresh() -> None:
+async def test_execute_with_retry_uses_registry_single_flight_for_auth_refresh() -> (
+    None
+):
     calls = 0
 
     def auth_fail_then_success_factory() -> Callable[[], str]:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,19 +1,42 @@
-"""Tests for configurable retry behavior and authentication error handling."""
+"""Unit tests for error handling facade and related helper behavior."""
 
 import asyncio
 from collections.abc import Callable
+import inspect
+from types import SimpleNamespace
 from typing import Any
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from mcp.server.fastmcp import FastMCP
 
+from open_stocks_mcp.server.app import mcp as production_mcp
 from open_stocks_mcp.tools import rate_limiter, retry
 from open_stocks_mcp.tools import session_manager as session_manager_module
 from open_stocks_mcp.tools.error_handling import (
+    APIError,
     AuthenticationError,
+    DataError,
     NetworkError,
+    RateLimitError,
+    RobinStocksError,
+    classify_error,
+    create_error_response,
+    create_no_data_response,
+    create_success_response,
     execute_with_retry,
+    handle_robin_stocks_errors,
+    handle_robin_stocks_sync_errors,
+    handle_schwab_errors,
+    log_api_call,
+    sanitize_api_response,
+    validate_period,
+    validate_span,
+    validate_symbol,
 )
+
+pytestmark = [pytest.mark.unit, pytest.mark.journey_system]
 
 
 def _patch_retry_dependencies(
@@ -43,6 +66,246 @@ def _always_fails(counter: list[int]) -> Callable[[], None]:
         raise RuntimeError("connection timeout")
 
     return fail
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_type"),
+    [
+        ("unauthorized", AuthenticationError),
+        ("login expired", AuthenticationError),
+        ("token revoked", AuthenticationError),
+        ("session timeout", AuthenticationError),
+        ("invalid credentials", AuthenticationError),
+        ("rate limit hit", RateLimitError),
+        ("too many requests", RateLimitError),
+        ("429 returned", RateLimitError),
+        ("quota exceeded", RateLimitError),
+        ("throttled", RateLimitError),
+        ("connection reset", NetworkError),
+        ("network down", NetworkError),
+        ("timeout", NetworkError),
+        ("dns failure", NetworkError),
+        ("could not resolve", NetworkError),
+        ("host unreachable", NetworkError),
+        ("json decode error", DataError),
+        ("failed to parse", DataError),
+        ("decode error", DataError),
+        ("invalid data", DataError),
+        ("malformed payload", DataError),
+    ],
+)
+def test_classify_error_cases(
+    message: str, expected_type: type[RobinStocksError]
+) -> None:
+    classified = classify_error(RuntimeError(message))
+    assert isinstance(classified, expected_type)
+
+
+def test_classify_error_fallback_api_error() -> None:
+    classified = classify_error(RuntimeError("kaboom"))
+    assert isinstance(classified, APIError)
+    assert "kaboom" in classified.message
+
+
+def test_exception_classes_and_error_types() -> None:
+    original = ValueError("bad")
+    base = RobinStocksError("base", "custom", original)
+
+    assert base.message == "base"
+    assert base.error_type == "custom"
+    assert base.original_error is original
+
+    assert AuthenticationError().error_type == "authentication"
+    assert RateLimitError().error_type == "rate_limit"
+    assert NetworkError().error_type == "network"
+    assert DataError().error_type == "data"
+    assert APIError().error_type == "api"
+
+
+def test_create_error_response_without_context() -> None:
+    response = create_error_response(RuntimeError("rate limit hit"))
+    result = response["result"]
+
+    assert result["error"] == "Rate limit exceeded"
+    assert result["error_type"] == "rate_limit"
+    assert result["status"] == "error"
+    assert "context" not in result
+
+
+@pytest.mark.parametrize(
+    "error",
+    [AuthenticationError("auth"), RateLimitError("rate"), APIError("api")],
+)
+def test_create_error_response_with_context_matches_classification(
+    error: Exception,
+) -> None:
+    response = create_error_response(error, "in test")
+    result = response["result"]
+
+    assert result["context"] == "in test"
+    assert result["error_type"] == classify_error(error).error_type
+
+
+def test_create_success_response_default_status() -> None:
+    payload = {"value": 1}
+    response = create_success_response(payload)
+
+    assert response["result"]["status"] == "success"
+    assert response["result"]["value"] == 1
+
+
+def test_create_success_response_preserves_status() -> None:
+    response = create_success_response({"status": "partial", "value": 2})
+    assert response["result"]["status"] == "partial"
+    assert response["result"]["value"] == 2
+
+
+def test_create_no_data_response_variants() -> None:
+    assert create_no_data_response("no data") == {
+        "result": {"message": "no data", "status": "no_data"}
+    }
+    assert create_no_data_response("no data", {"symbol": "AAPL"}) == {
+        "result": {"message": "no data", "status": "no_data", "symbol": "AAPL"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_robin_stocks_errors_success_and_metadata() -> None:
+    async def sample(symbol: str, span: str = "day") -> dict[str, str]:
+        return {"symbol": symbol, "span": span}
+
+    decorated: Any = handle_robin_stocks_errors(sample)
+
+    assert await decorated("AAPL") == {"symbol": "AAPL", "span": "day"}
+    assert decorated.__wrapped__ is sample
+    assert decorated.__name__ == "sample"
+    assert (
+        inspect.signature(decorated).parameters == inspect.signature(sample).parameters
+    )
+    assert inspect.iscoroutinefunction(decorated) is True
+
+
+@pytest.mark.asyncio
+async def test_handle_robin_stocks_errors_classifies_exception() -> None:
+    async def boom() -> Any:
+        raise RuntimeError("rate limit hit")
+
+    decorated: Any = handle_robin_stocks_errors(boom)
+    assert await decorated() == {
+        "result": {
+            "error": "Rate limit exceeded",
+            "error_type": "rate_limit",
+            "status": "error",
+            "context": "in boom",
+        }
+    }
+
+
+def test_handle_robin_stocks_sync_errors_success_and_metadata() -> None:
+    def sample(symbol: str, span: str = "day") -> dict[str, str]:
+        return {"symbol": symbol, "span": span}
+
+    decorated: Any = handle_robin_stocks_sync_errors(sample)
+
+    assert decorated("AAPL") == {"symbol": "AAPL", "span": "day"}
+    assert decorated.__wrapped__ is sample
+    assert decorated.__name__ == "sample"
+    assert (
+        inspect.signature(decorated).parameters == inspect.signature(sample).parameters
+    )
+    assert inspect.iscoroutinefunction(decorated) is False
+
+
+def test_handle_robin_stocks_sync_errors_classifies_exception() -> None:
+    def boom() -> Any:
+        raise RuntimeError("rate limit hit")
+
+    decorated: Any = handle_robin_stocks_sync_errors(boom)
+    assert decorated() == {
+        "result": {
+            "error": "Rate limit exceeded",
+            "error_type": "rate_limit",
+            "status": "error",
+            "context": "in boom",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_schwab_errors_behaves_like_robinhood_variant() -> None:
+    async def sample(symbol: str) -> dict[str, str]:
+        return {"symbol": symbol}
+
+    decorated: Any = handle_schwab_errors(sample)
+    assert await decorated("MSFT") == {"symbol": "MSFT"}
+    assert decorated.__wrapped__ is sample
+    assert decorated.__name__ == "sample"
+    assert (
+        inspect.signature(decorated).parameters == inspect.signature(sample).parameters
+    )
+    assert inspect.iscoroutinefunction(decorated) is True
+
+    async def boom() -> Any:
+        raise RuntimeError("rate limit hit")
+
+    decorated_boom: Any = handle_schwab_errors(boom)
+    assert await decorated_boom() == {
+        "result": {
+            "error": "Rate limit exceeded",
+            "error_type": "rate_limit",
+            "status": "error",
+            "context": "in boom",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_schema_preserved_for_local_fastmcp_decorated_tool() -> None:
+    server = FastMCP("test")
+
+    @server.tool()
+    @handle_robin_stocks_errors
+    async def decorated_tool(symbol: str, span: str = "day") -> dict[str, str]:
+        return {"symbol": symbol, "span": span}
+
+    tools = await server.list_tools()
+    target = next(tool for tool in tools if tool.name == "decorated_tool")
+    assert "symbol" in target.inputSchema.get("properties", {})
+    assert "span" in target.inputSchema.get("properties", {})
+
+
+@pytest.mark.asyncio
+async def test_production_stock_price_schema_has_symbol_property() -> None:
+    tools = await production_mcp.list_tools()
+    stock_price_tool = next(tool for tool in tools if tool.name == "stock_price")
+    assert "symbol" in stock_price_tool.inputSchema.get("properties", {})
+
+
+@pytest.fixture
+def patched_retry_dependencies(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    fake_session = SimpleNamespace(
+        update_last_successful_call=Mock(),
+        should_block_auth_retries=Mock(return_value=False),
+        refresh_session=AsyncMock(return_value=True),
+    )
+    fake_rate_limiter = SimpleNamespace(acquire=AsyncMock())
+    fake_sleep = AsyncMock()
+
+    monkeypatch.setattr(
+        "open_stocks_mcp.tools.session_manager.get_session_manager",
+        lambda: fake_session,
+    )
+    monkeypatch.setattr(
+        "open_stocks_mcp.tools.rate_limiter.get_rate_limiter",
+        lambda: fake_rate_limiter,
+    )
+    monkeypatch.setattr("open_stocks_mcp.tools.retry.asyncio.sleep", fake_sleep)
+
+    return {
+        "session": fake_session,
+        "rate_limiter": fake_rate_limiter,
+        "sleep": fake_sleep,
+    }
 
 
 @pytest.mark.asyncio
@@ -211,3 +474,239 @@ async def test_execute_with_retry_uses_registry_single_flight_for_auth_refresh()
     assert results == ["ok"] * 20
     assert calls == 20
     assert registry.coordinated_refresh.await_count == 20
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_returns_value_on_first_success(
+    patched_retry_dependencies: dict[str, Any],
+) -> None:
+    async def target() -> str:
+        return "ok"
+
+    result = await execute_with_retry(target)
+    assert result == "ok"
+    patched_retry_dependencies[
+        "session"
+    ].update_last_successful_call.assert_called_once()
+    patched_retry_dependencies["sleep"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_runs_sync_func_in_executor(
+    patched_retry_dependencies: dict[str, Any],
+) -> None:
+    def add(a: int, b: int = 1) -> int:
+        return a + b
+
+    result = await execute_with_retry(add, 2, b=3)
+    assert result == 5
+    patched_retry_dependencies[
+        "session"
+    ].update_last_successful_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_retries_then_succeeds(
+    patched_retry_dependencies: dict[str, Any],
+) -> None:
+    calls = 0
+
+    async def flaky() -> str:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise RuntimeError("connection refused")
+        return "ok"
+
+    result = await execute_with_retry(
+        flaky, max_retries=3, delay=0.1, backoff_factor=2.0
+    )
+    assert result == "ok"
+    assert calls == 3
+    patched_retry_dependencies["sleep"].assert_any_await(0.1)
+    patched_retry_dependencies["sleep"].assert_any_await(0.2)
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_raises_after_max_retries(
+    patched_retry_dependencies: dict[str, Any],
+) -> None:
+    calls = 0
+
+    async def always_fail() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("connection refused")
+
+    with pytest.raises(NetworkError):
+        await execute_with_retry(always_fail, max_retries=2, delay=0.01)
+
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_does_not_retry_on_data_error(
+    patched_retry_dependencies: dict[str, Any],
+) -> None:
+    calls = 0
+
+    async def data_fail() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("json decode error")
+
+    with pytest.raises(DataError):
+        await execute_with_retry(data_fail, max_retries=3)
+
+    assert calls == 1
+    patched_retry_dependencies["sleep"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_reauth_on_authentication_error(
+    patched_retry_dependencies: dict[str, Any],
+) -> None:
+    calls = 0
+
+    async def auth_then_ok() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("unauthorized")
+        return "ok"
+
+    result = await execute_with_retry(auth_then_ok, max_retries=2)
+    assert result == "ok"
+    patched_retry_dependencies["session"].refresh_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_raises_when_reauth_fails(
+    patched_retry_dependencies: dict[str, Any],
+) -> None:
+    patched_retry_dependencies["session"].refresh_session = AsyncMock(
+        return_value=False
+    )
+
+    async def always_auth_fail() -> str:
+        raise RuntimeError("token expired")
+
+    with pytest.raises(AuthenticationError):
+        await execute_with_retry(always_auth_fail, max_retries=2)
+
+    patched_retry_dependencies["session"].refresh_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_skips_rate_limiter_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_session = SimpleNamespace(
+        update_last_successful_call=Mock(),
+        should_block_auth_retries=Mock(return_value=False),
+        refresh_session=AsyncMock(return_value=True),
+    )
+
+    rate_limiter_called = False
+
+    def fail_get_rate_limiter() -> Any:
+        nonlocal rate_limiter_called
+        rate_limiter_called = True
+        raise AssertionError("rate limiter should not be requested")
+
+    monkeypatch.setattr(
+        "open_stocks_mcp.tools.session_manager.get_session_manager",
+        lambda: fake_session,
+    )
+    monkeypatch.setattr(
+        "open_stocks_mcp.tools.rate_limiter.get_rate_limiter",
+        fail_get_rate_limiter,
+    )
+
+    async def target() -> str:
+        return "ok"
+
+    result = await execute_with_retry(target, rate_limit=False)
+    assert result == "ok"
+    assert rate_limiter_called is False
+
+
+@pytest.mark.parametrize("symbol", ["A", "AAPL", "GOOGL", "BRK", "abc", "BRK1"])
+def test_validate_symbol_valid(symbol: str) -> None:
+    assert validate_symbol(symbol) is True
+
+
+@pytest.mark.parametrize("symbol", ["", None, "TOOLONG", "BR-K", "  ", "BR.K"])
+def test_validate_symbol_invalid(symbol: str | None) -> None:
+    assert validate_symbol(cast(str, symbol)) is False
+
+
+@pytest.mark.parametrize(
+    "period", ["day", "week", "month", "3month", "year", "5year", "all"]
+)
+def test_validate_period_valid(period: str) -> None:
+    assert validate_period(period) is True
+
+
+@pytest.mark.parametrize("period", ["hour", "decade", "", "DAY"])
+def test_validate_period_invalid(period: str) -> None:
+    assert validate_period(period) is False
+
+
+@pytest.mark.parametrize(
+    "span", ["day", "week", "month", "3month", "year", "5year", "all"]
+)
+def test_validate_span_valid(span: str) -> None:
+    assert validate_span(span) is True
+
+
+@pytest.mark.parametrize("span", ["hour", "decade", "", "DAY"])
+def test_validate_span_invalid(span: str) -> None:
+    assert validate_span(span) is False
+
+
+def test_sanitize_api_response_recursive_redaction() -> None:
+    payload = {
+        "Token": "abc",
+        "user": {
+            "password": "secret",
+            "nested": [{"SSN": "123-45-6789"}, {"safe": "ok"}],
+        },
+        "value": 3,
+    }
+
+    sanitized = sanitize_api_response(payload)
+    assert sanitized["Token"] == "[REDACTED]"
+    assert sanitized["user"]["password"] == "[REDACTED]"
+    assert sanitized["user"]["nested"][0]["SSN"] == "[REDACTED]"
+    assert sanitized["user"]["nested"][1]["safe"] == "ok"
+    assert sanitized["value"] == 3
+
+
+def test_sanitize_api_response_scalars_unchanged() -> None:
+    assert sanitize_api_response("x") == "x"
+    assert sanitize_api_response(5) == 5
+    assert sanitize_api_response(None) is None
+
+
+def test_log_api_call_includes_symbol_and_excludes_sensitive(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("INFO")
+    log_api_call(
+        "stock_price",
+        symbol="AAPL",
+        password="secret",
+        token="abc",
+        key="k",
+        secret="s",
+        period="day",
+    )
+
+    message = caplog.records[-1].message
+    assert "stock_price" in message
+    assert "AAPL" in message
+    assert "password" not in message
+    assert "token" not in message
+    assert "secret" not in message
+    assert "'period': 'day'" in message


### PR DESCRIPTION
Closes #21

## Changes
- add a full `tests/unit/test_error_handling.py` suite covering all public exports from `open_stocks_mcp.tools.error_handling`
- add decorator metadata and MCP schema regression checks for wrapped tools (`__wrapped__`, signature, coroutine status, and `inputSchema` properties)
- add isolated `execute_with_retry` tests for retry/backoff, auth refresh behavior, sync executor path, non-retriable data errors, and rate-limiter bypass
- add validator, sanitization, and logging behavior tests plus response builder/exception classification assertions

## Test plan
- `uv run pytest tests/unit/test_error_handling.py -m "unit" -v`
- `uv run pytest tests/unit/test_error_handling.py --cov=src/open_stocks_mcp/tools/error_handling --cov-report=term-missing`
- `uv run pytest tests/unit/test_error_handling.py --cov=open_stocks_mcp.tools.error_handling --cov-report=term-missing`
- `uv run pytest -m "unit and journey_system" tests/unit/test_error_handling.py -v`
- `uv run ruff check tests/unit/test_error_handling.py`
- `uv run ruff format --check tests/unit/test_error_handling.py`
- `uv run mypy tests/unit/test_error_handling.py`