### PR TITLE
feat: implement Phase 6 broker comparison tools

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -20,6 +20,7 @@ from open_stocks_mcp.server.tool_helpers import (
     get_rate_limit_status_data,
     get_session_status_data,
 )
+from open_stocks_mcp.tools.broker_comparison_tools import get_broker_comparison
 
 # Cross-Broker Tools
 from open_stocks_mcp.tools.cross_broker_tools import get_aggregated_portfolio
@@ -1054,6 +1055,23 @@ async def aggregated_portfolio() -> dict[str, Any]:
         partial_failure flag, and unavailable_brokers list.
     """
     return await get_aggregated_portfolio()
+
+
+@mcp.tool()
+async def broker_comparison(
+    symbols: list[str] | None = None, include_orders: bool = True, max_orders: int = 5
+) -> dict[str, Any]:
+    """Compare normalized pricing, holdings, and orders across brokers.
+
+    Provides a side-by-side comparison of broker metrics (pricing/holdings/order context)
+    for user-facing decision support. Handles partial failures gracefully.
+
+    Args:
+        symbols: Optional list of stock symbols to compare
+        include_orders: Whether to include recent order history (default: True)
+        max_orders: Maximum number of orders to retrieve per broker (default: 5)
+    """
+    return await get_broker_comparison(symbols, include_orders, max_orders)
 
 
 # Schwab Market Data Tools

--- a/src/open_stocks_mcp/tools/broker_comparison_tools.py
+++ b/src/open_stocks_mcp/tools/broker_comparison_tools.py
@@ -1,0 +1,257 @@
+"""Broker comparison tools for side-by-side metric analysis."""
+
+from typing import Any
+
+from open_stocks_mcp.brokers.registry import get_broker_registry
+from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.responses import create_success_response
+from open_stocks_mcp.tools.robinhood_account_tools import get_portfolio, get_positions
+from open_stocks_mcp.tools.robinhood_order_tools import get_stock_orders
+from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+from open_stocks_mcp.tools.schwab_account_tools import (
+    get_schwab_account_balances,
+    get_schwab_account_numbers,
+    get_schwab_portfolio,
+)
+from open_stocks_mcp.tools.schwab_market_tools import get_schwab_quote
+from open_stocks_mcp.tools.schwab_trading_tools import get_schwab_orders
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    """Convert value to float, returning default on failure."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+async def _collect_robinhood_comparison(
+    symbols: list[str] | None, include_orders: bool, max_orders: int
+) -> dict[str, Any]:
+    """Collect and normalize Robinhood data for comparison."""
+    data: dict[str, Any] = {
+        "broker": "robinhood",
+        "source": "Robinhood API",
+        "available": True,
+        "confidence": "high",
+        "notes": None,
+        "pricing": {},
+        "holdings": {},
+        "orders": [],
+        "account": {"equity": 0.0, "buying_power": 0.0},
+    }
+
+    # 1. Pricing
+    if symbols:
+        for symbol in symbols:
+            price_resp = await get_stock_price(symbol)
+            price_data = price_resp.get("result", {})
+            if "error" not in price_data:
+                data["pricing"][symbol] = {
+                    "price": _safe_float(price_data.get("price")),
+                    "change": _safe_float(price_data.get("change")),
+                    "change_percent": _safe_float(price_data.get("change_percent")),
+                }
+
+    # 2. Holdings
+    positions_resp = await get_positions()
+    positions_data = positions_resp.get("result", {})
+    if "error" not in positions_data:
+        for pos in positions_data.get("positions", []):
+            symbol = pos.get("symbol")
+            if not symbols or symbol in symbols:
+                data["holdings"][symbol] = {
+                    "quantity": _safe_float(pos.get("quantity")),
+                    "average_buy_price": _safe_float(pos.get("average_buy_price")),
+                    "equity": _safe_float(pos.get("equity")),
+                }
+
+    # 3. Account
+    portfolio_resp = await get_portfolio()
+    portfolio_data = portfolio_resp.get("result", {})
+    if "error" not in portfolio_data:
+        data["account"]["equity"] = _safe_float(portfolio_data.get("equity"))
+        data["account"]["buying_power"] = _safe_float(portfolio_data.get("buying_power"))
+
+    # 4. Orders
+    if include_orders:
+        orders_resp = await get_stock_orders()
+        orders_data = orders_resp.get("result", [])
+        if isinstance(orders_data, list):
+            for order in orders_data[:max_orders]:
+                data["orders"].append({
+                    "symbol": order.get("symbol"),
+                    "side": order.get("side"),
+                    "state": order.get("state"),
+                    "quantity": _safe_float(order.get("quantity")),
+                    "price": _safe_float(order.get("price")),
+                    "timestamp": order.get("updated_at") or order.get("created_at"),
+                })
+
+    return data
+
+
+async def _collect_schwab_comparison(
+    symbols: list[str] | None, include_orders: bool, max_orders: int
+) -> dict[str, Any]:
+    """Collect and normalize Schwab data for comparison."""
+    data: dict[str, Any] = {
+        "broker": "schwab",
+        "source": "Schwab API",
+        "available": True,
+        "confidence": "high",
+        "notes": None,
+        "pricing": {},
+        "holdings": {},
+        "orders": [],
+        "account": {"equity": 0.0, "buying_power": 0.0},
+    }
+
+    # 0. Get account hash
+    acct_resp = await get_schwab_account_numbers()
+    acct_data = acct_resp.get("result", [])
+    if not acct_data or "error" in (acct_data[0] if isinstance(acct_data, list) else acct_data):
+        data["available"] = False
+        data["notes"] = "Failed to retrieve Schwab account numbers"
+        return data
+
+    account_hash = acct_data[0].get("hash")
+
+    # 1. Pricing
+    if symbols:
+        for symbol in symbols:
+            quote_resp = await get_schwab_quote(symbol)
+            quote_data = quote_resp.get("result", {})
+            if "error" not in quote_data:
+                data["pricing"][symbol] = {
+                    "price": _safe_float(quote_data.get("last_price")),
+                    "change": _safe_float(quote_data.get("net_change")),
+                    "change_percent": _safe_float(quote_data.get("net_change_percent")),
+                }
+
+    # 2. Holdings
+    portfolio_resp = await get_schwab_portfolio(account_hash)
+    portfolio_data = portfolio_resp.get("result", {})
+    if "error" not in portfolio_data:
+        sec_account = portfolio_data.get("securitiesAccount", {})
+        for pos in sec_account.get("positions", []):
+            symbol = pos.get("instrument", {}).get("symbol")
+            if not symbols or symbol in symbols:
+                quantity = _safe_float(pos.get("longQuantity")) + _safe_float(pos.get("shortQuantity"))
+                data["holdings"][symbol] = {
+                    "quantity": quantity,
+                    "average_buy_price": _safe_float(pos.get("averagePrice")),
+                    "equity": _safe_float(pos.get("marketValue")),
+                }
+
+    # 3. Account
+    balances_resp = await get_schwab_account_balances(account_hash)
+    balances_data = balances_resp.get("result", {})
+    if "error" not in balances_data:
+        curr_balances = balances_data.get("currentBalances", {})
+        data["account"]["equity"] = _safe_float(curr_balances.get("liquidationValue"))
+        data["account"]["buying_power"] = _safe_float(curr_balances.get("buyingPower"))
+
+    # 4. Orders
+    if include_orders:
+        orders_resp = await get_schwab_orders(account_hash, max_results=max_orders)
+        orders_data = orders_resp.get("result", {}).get("orders", [])
+        if isinstance(orders_data, list):
+            for order in orders_data:
+                # Schwab orders usually have a list of orderLegCollection
+                leg = order.get("orderLegCollection", [{}])[0]
+                data["orders"].append({
+                    "symbol": leg.get("instrument", {}).get("symbol"),
+                    "side": leg.get("instruction", "").lower(),
+                    "state": order.get("status", "").lower(),
+                    "quantity": _safe_float(order.get("quantity")),
+                    "price": _safe_float(order.get("price")),
+                    "timestamp": order.get("enteredTime"),
+                })
+
+    return data
+
+
+async def get_broker_comparison(
+    symbols: list[str] | None = None, include_orders: bool = True, max_orders: int = 5
+) -> dict[str, Any]:
+    """
+    Returns broker-normalized pricing, holdings, and recent order context.
+
+    Returns:
+        Dict with result containing:
+        - brokers: per-broker normalized data
+        - comparison: symbol-indexed comparison of metrics
+        - availability_notes: list of issues encountered
+        - status: success, partial, or error
+    """
+    registry = await get_broker_registry()
+    broker_names = registry.list_brokers()
+
+    brokers_out: dict[str, Any] = {}
+    availability_notes: dict[str, str] = {}
+    
+    # Track symbols for side-by-side comparison
+    all_symbols = set(symbols) if symbols else set()
+
+    for name in broker_names:
+        broker = registry.get_broker(name)
+        if broker is None or not broker.is_available():
+            brokers_out[name] = {
+                "broker": name,
+                "available": False,
+                "notes": "Broker not authenticated or unavailable",
+            }
+            availability_notes[name] = "Not authenticated"
+            continue
+
+        try:
+            if name == "robinhood":
+                data = await _collect_robinhood_comparison(symbols, include_orders, max_orders)
+            elif name == "schwab":
+                data = await _collect_schwab_comparison(symbols, include_orders, max_orders)
+            else:
+                continue
+
+            brokers_out[name] = data
+            if not data.get("available", True):
+                availability_notes[name] = data.get("notes", "Unknown error")
+            
+            # Add any discovered symbols from holdings if symbols was None
+            if symbols is None:
+                all_symbols.update(data["holdings"].keys())
+
+        except Exception as exc:
+            logger.error(f"Error collecting comparison data for {name}: {exc}", exc_info=True)
+            brokers_out[name] = {
+                "broker": name,
+                "available": False,
+                "notes": str(exc),
+            }
+            availability_notes[name] = str(exc)
+
+    # Generate side-by-side comparison
+    comparison: dict[str, Any] = {}
+    for symbol in sorted(all_symbols):
+        symbol_comp: dict[str, Any] = {}
+        for name, data in brokers_out.items():
+            if not data.get("available"):
+                continue
+            
+            symbol_comp[name] = {
+                "price": data["pricing"].get(symbol, {}).get("price"),
+                "quantity": data["holdings"].get(symbol, {}).get("quantity", 0.0),
+                "equity": data["holdings"].get(symbol, {}).get("equity", 0.0),
+            }
+        comparison[symbol] = symbol_comp
+
+    status = "success"
+    if availability_notes:
+        status = "partial" if any(b.get("available") for b in brokers_out.values()) else "error"
+
+    return create_success_response({
+        "brokers": brokers_out,
+        "comparison": comparison,
+        "availability_notes": availability_notes,
+        "status": status,
+    })

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -27,7 +27,9 @@ class TestServerApp:
             patch("open_stocks_mcp.server.app.load_config") as mock_config,
             patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
         ):
-            mock_config.return_value = MagicMock()
+            mock_cfg = MagicMock()
+            mock_cfg.otel.enabled = False
+            mock_config.return_value = mock_cfg
             result = create_mcp_server()
 
             assert result is mcp
@@ -37,6 +39,7 @@ class TestServerApp:
     def test_create_mcp_server_with_config(self) -> None:
         """Test create_mcp_server with provided config."""
         mock_config = MagicMock()
+        mock_config.otel.enabled = False
 
         with patch("open_stocks_mcp.server.app.setup_logging") as mock_logging:
             result = create_mcp_server(mock_config)
@@ -143,6 +146,7 @@ class TestToolRegistration:
             "account_info",
             "account_details",
             "positions",
+            "broker_comparison",
         ]
 
         for tool_name in expected_tools:

--- a/tests/unit/test_broker_comparison_tools.py
+++ b/tests/unit/test_broker_comparison_tools.py
@@ -1,0 +1,109 @@
+"""Unit tests for broker comparison tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.broker_comparison_tools import get_broker_comparison
+
+
+class TestGetBrokerComparison:
+    """Tests for broker-normalized comparison data and partial failure handling."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_successful_comparison(self):
+        """Assert comparison returns normalized data from both brokers."""
+        # Mocking Robinhood responses
+        rh_price = {"result": {"price": 150.0, "symbol": "AAPL"}}
+        rh_portfolio = {"result": {"equity": 10000.0, "buying_power": 5000.0}}
+        rh_positions = {"result": {"positions": [{"symbol": "AAPL", "quantity": 10}]}}
+        rh_orders = {"result": [{"symbol": "AAPL", "side": "buy", "state": "filled", "quantity": 5, "price": 145.0}]}
+
+        # Mocking Schwab responses
+        schwab_quote = {"result": {"last_price": 151.0, "symbol": "AAPL"}}
+        schwab_account_numbers = {"result": [{"hash": "account_1"}]}
+        schwab_balances = {"result": {"currentBalances": {"liquidationValue": 8000.0, "buyingPower": 2000.0}}}
+        schwab_portfolio = {"result": {"securitiesAccount": {"positions": [{"instrument": {"symbol": "AAPL"}, "longQuantity": 5, "marketValue": 755.0}]}}}
+        schwab_orders = {"result": {"orders": [{"symbol": "AAPL", "orderLegCollection": [{"instruction": "BUY", "instrument": {"symbol": "AAPL"}}], "status": "FILLED", "quantity": 2, "price": 148.0}]}}
+
+        # Setup registry mock
+        mock_registry_instance = MagicMock()
+        mock_registry_instance.list_brokers.return_value = ["robinhood", "schwab"]
+        rh_broker = MagicMock()
+        rh_broker.is_available.return_value = True
+        schwab_broker = MagicMock()
+        schwab_broker.is_available.return_value = True
+        mock_registry_instance.get_broker.side_effect = lambda name: rh_broker if name == "robinhood" else schwab_broker
+
+        with (
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_stock_price", AsyncMock(return_value=rh_price)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_portfolio", AsyncMock(return_value=rh_portfolio)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_positions", AsyncMock(return_value=rh_positions)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_stock_orders", AsyncMock(return_value=rh_orders)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_quote", AsyncMock(return_value=schwab_quote)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_numbers", AsyncMock(return_value=schwab_account_numbers)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_balances", AsyncMock(return_value=schwab_balances)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_portfolio", AsyncMock(return_value=schwab_portfolio)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_orders", AsyncMock(return_value=schwab_orders)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_broker_registry", AsyncMock(return_value=mock_registry_instance)),
+        ):
+            result = await get_broker_comparison(symbols=["AAPL"])
+
+        assert result["result"]["status"] == "success"
+        comparison = result["result"]["comparison"]
+        assert "AAPL" in comparison
+        
+        # Verify Robinhood normalization
+        rh_data = result["result"]["brokers"]["robinhood"]
+        assert rh_data["available"] is True
+        assert rh_data["pricing"]["AAPL"]["price"] == 150.0
+        assert rh_data["holdings"]["AAPL"]["quantity"] == 10
+        assert len(rh_data["orders"]) == 1
+        assert rh_data["orders"][0]["side"] == "buy"
+
+        # Verify Schwab normalization
+        schwab_data = result["result"]["brokers"]["schwab"]
+        assert schwab_data["available"] is True
+        assert schwab_data["pricing"]["AAPL"]["price"] == 151.0
+        assert schwab_data["holdings"]["AAPL"]["quantity"] == 5
+        assert len(schwab_data["orders"]) == 1
+        assert schwab_data["orders"][0]["side"] == "buy"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_partial_failure(self):
+        """Assert comparison remains present for Robinhood when Schwab fails."""
+        # Robinhood success mocks
+        rh_price = {"result": {"price": 150.0, "symbol": "AAPL"}}
+        rh_portfolio = {"result": {"equity": 10000.0, "buying_power": 5000.0}}
+        rh_positions = {"result": {"positions": [{"symbol": "AAPL", "quantity": 10}]}}
+        rh_orders = {"result": []}
+
+        # Schwab failure mock
+        schwab_failure = {"result": {"status": "broker_unavailable", "error": "API Error"}}
+
+        # Setup registry mock
+        mock_registry_instance = MagicMock()
+        mock_registry_instance.list_brokers.return_value = ["robinhood", "schwab"]
+        rh_broker = MagicMock()
+        rh_broker.is_available.return_value = True
+        schwab_broker = MagicMock()
+        schwab_broker.is_available.return_value = True
+        mock_registry_instance.get_broker.side_effect = lambda name: rh_broker if name == "robinhood" else schwab_broker
+
+        with (
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_stock_price", AsyncMock(return_value=rh_price)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_portfolio", AsyncMock(return_value=rh_portfolio)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_positions", AsyncMock(return_value=rh_positions)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_stock_orders", AsyncMock(return_value=rh_orders)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_numbers", AsyncMock(return_value=schwab_failure)),
+            patch("open_stocks_mcp.tools.broker_comparison_tools.get_broker_registry", AsyncMock(return_value=mock_registry_instance)),
+        ):
+            result = await get_broker_comparison(symbols=["AAPL"])
+
+        assert result["result"]["status"] == "partial"
+        assert "robinhood" in result["result"]["brokers"]
+        assert result["result"]["brokers"]["robinhood"]["available"] is True
+        assert result["result"]["brokers"]["schwab"]["available"] is False
+        assert "schwab" in result["result"]["availability_notes"]


### PR DESCRIPTION
Closes #115

## Changes
- Added broker_comparison MCP tool.
- Implemented normalization for Robinhood and Schwab.
- Added partial failure handling.
- Registered tool in server app.
- Added unit tests.

## Test plan
- Run pytest tests/unit/test_broker_comparison_tools.py
- Run pytest tests/server/test_server_app.py
