### PR TITLE
feat: add broker comparison tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -20,6 +20,7 @@ from open_stocks_mcp.server.tool_helpers import (
     get_rate_limit_status_data,
     get_session_status_data,
 )
+from open_stocks_mcp.tools.broker_comparison_tools import get_broker_comparison
 
 # Cross-Broker Tools
 from open_stocks_mcp.tools.cross_broker_tools import get_aggregated_portfolio
@@ -1054,6 +1055,16 @@ async def aggregated_portfolio() -> dict[str, Any]:
         partial_failure flag, and unavailable_brokers list.
     """
     return await get_aggregated_portfolio()
+
+
+@mcp.tool()
+async def broker_comparison(
+    symbols: list[str] | None = None,
+    include_orders: bool = True,
+    max_orders: int = 5,
+) -> dict[str, Any]:
+    """Compare normalized pricing, holdings, and orders across brokers."""
+    return await get_broker_comparison(symbols, include_orders, max_orders)
 
 
 # Schwab Market Data Tools

--- a/src/open_stocks_mcp/tools/broker_comparison_tools.py
+++ b/src/open_stocks_mcp/tools/broker_comparison_tools.py
@@ -1,0 +1,268 @@
+"""Cross-broker comparison tools for side-by-side broker insights."""
+
+from typing import Any
+
+from open_stocks_mcp.tools.responses import create_success_response
+from open_stocks_mcp.tools.robinhood_account_tools import get_portfolio, get_positions
+from open_stocks_mcp.tools.robinhood_order_tools import get_stock_orders
+from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+from open_stocks_mcp.tools.schwab_account_tools import (
+    get_schwab_account_balances,
+    get_schwab_account_numbers,
+    get_schwab_portfolio,
+)
+from open_stocks_mcp.tools.schwab_market_tools import get_schwab_quote
+from open_stocks_mcp.tools.schwab_trading_tools import get_schwab_orders
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _has_error(payload: dict[str, Any]) -> bool:
+    status = str(payload.get("status", "")).lower()
+    return "error" in payload or status in {
+        "error",
+        "broker_unavailable",
+        "authentication_required",
+        "unauthorized",
+    }
+
+
+async def _build_robinhood(symbols: list[str], include_orders: bool, max_orders: int) -> dict[str, Any]:
+    portfolio = (await get_portfolio()).get("result", {})
+    positions = (await get_positions()).get("result", {})
+
+    if _has_error(portfolio) or _has_error(positions):
+        return {
+            "broker": "robinhood",
+            "source": "robinhood",
+            "available": False,
+            "confidence": "low",
+            "notes": [portfolio.get("error") or positions.get("error") or "Unavailable"],
+            "pricing": {},
+            "holdings": [],
+            "orders": [],
+        }
+
+    pricing: dict[str, Any] = {}
+    for symbol in symbols:
+        quote_result = (await get_stock_price(symbol)).get("result", {})
+        if _has_error(quote_result):
+            continue
+        pricing[symbol] = {
+            "symbol": symbol,
+            "price": _safe_float(quote_result.get("price")),
+            "change": _safe_float(quote_result.get("change")),
+            "change_percent": _safe_float(quote_result.get("change_percent")),
+        }
+
+    holdings = []
+    for position in positions.get("positions", []):
+        holdings.append(
+            {
+                "symbol": position.get("symbol"),
+                "quantity": _safe_float(position.get("quantity")),
+                "average_price": _safe_float(position.get("average_buy_price")),
+                "market_value": _safe_float(position.get("market_value")),
+            }
+        )
+
+    orders: list[dict[str, Any]] = []
+    if include_orders:
+        order_result = (await get_stock_orders()).get("result", {})
+        for order in order_result.get("orders", [])[:max_orders]:
+            orders.append(
+                {
+                    "symbol": order.get("symbol"),
+                    "side": order.get("side"),
+                    "state": order.get("state"),
+                    "quantity": _safe_float(order.get("quantity")),
+                    "price": _safe_float(order.get("average_price")),
+                }
+            )
+
+    return {
+        "broker": "robinhood",
+        "source": "robinhood",
+        "available": True,
+        "confidence": "high",
+        "notes": [],
+        "pricing": pricing,
+        "holdings": holdings,
+        "orders": orders,
+        "summary": {
+            "equity": _safe_float(portfolio.get("equity")),
+            "buying_power": _safe_float(portfolio.get("buying_power")),
+            "market_value": _safe_float(portfolio.get("market_value")),
+        },
+    }
+
+
+async def _build_schwab(symbols: list[str], include_orders: bool, max_orders: int) -> dict[str, Any]:
+    numbers = (await get_schwab_account_numbers()).get("result", {})
+    if _has_error(numbers) or not numbers.get("accounts"):
+        return {
+            "broker": "schwab",
+            "source": "schwab",
+            "available": False,
+            "confidence": "low",
+            "notes": [numbers.get("error") or "Schwab unavailable"],
+            "pricing": {},
+            "holdings": [],
+            "orders": [],
+        }
+
+    account_hash = numbers["accounts"][0].get("hash_value")
+    balances = (await get_schwab_account_balances(account_hash)).get("result", {})
+    portfolio = (await get_schwab_portfolio(account_hash)).get("result", {})
+
+    pricing: dict[str, Any] = {}
+    for symbol in symbols:
+        quote_result = (await get_schwab_quote(symbol)).get("result", {})
+        if _has_error(quote_result):
+            continue
+        pricing[symbol] = {
+            "symbol": symbol,
+            "price": _safe_float(quote_result.get("last_price")),
+            "change": _safe_float(quote_result.get("change")),
+            "change_percent": _safe_float(quote_result.get("change_percent")),
+        }
+
+    holdings = []
+    for position in portfolio.get("positions", []):
+        holdings.append(
+            {
+                "symbol": position.get("symbol"),
+                "quantity": _safe_float(position.get("quantity")),
+                "average_price": _safe_float(position.get("average_price")),
+                "market_value": _safe_float(position.get("market_value")),
+            }
+        )
+
+    orders: list[dict[str, Any]] = []
+    if include_orders:
+        order_result = (await get_schwab_orders(account_hash, max_results=max_orders)).get(
+            "result", {}
+        )
+        for order in order_result.get("orders", [])[:max_orders]:
+            leg = (order.get("orderLegCollection") or [{}])[0]
+            instrument = leg.get("instrument", {})
+            orders.append(
+                {
+                    "symbol": instrument.get("symbol"),
+                    "side": leg.get("instruction"),
+                    "state": order.get("status"),
+                    "quantity": _safe_float(leg.get("quantity")),
+                    "price": _safe_float(order.get("price")),
+                }
+            )
+
+    return {
+        "broker": "schwab",
+        "source": "schwab",
+        "available": True,
+        "confidence": "medium",
+        "notes": [],
+        "pricing": pricing,
+        "holdings": holdings,
+        "orders": orders,
+        "summary": {
+            "equity": _safe_float(
+                balances.get("current_balances", {}).get("market_value")
+            ),
+            "buying_power": _safe_float(
+                balances.get("current_balances", {}).get("buying_power")
+            ),
+            "market_value": _safe_float(
+                balances.get("current_balances", {}).get("market_value")
+            ),
+        },
+    }
+
+
+def _derive_symbols(
+    requested_symbols: list[str] | None,
+    robinhood_entry: dict[str, Any],
+    schwab_entry: dict[str, Any],
+) -> list[str]:
+    if requested_symbols:
+        return [symbol.upper() for symbol in requested_symbols]
+
+    derived: set[str] = set()
+    for entry in (robinhood_entry, schwab_entry):
+        for holding in entry.get("holdings", []):
+            symbol = holding.get("symbol")
+            if symbol:
+                derived.add(str(symbol).upper())
+    return sorted(derived)
+
+
+async def get_broker_comparison(
+    symbols: list[str] | None = None,
+    include_orders: bool = True,
+    max_orders: int = 5,
+) -> dict[str, Any]:
+    """Return side-by-side broker comparison with normalized output."""
+    requested_symbols = [symbol.upper() for symbol in symbols] if symbols else []
+
+    robinhood_entry = await _build_robinhood(requested_symbols, include_orders, max_orders)
+    schwab_entry = await _build_schwab(requested_symbols, include_orders, max_orders)
+    final_symbols = _derive_symbols(symbols, robinhood_entry, schwab_entry)
+
+    if not symbols:
+        robinhood_entry = await _build_robinhood(final_symbols, include_orders, max_orders)
+        schwab_entry = await _build_schwab(final_symbols, include_orders, max_orders)
+
+    comparison: dict[str, Any] = {}
+    for symbol in final_symbols:
+        comparison[symbol] = {
+            "robinhood": {
+                "price": robinhood_entry.get("pricing", {}).get(symbol, {}).get("price"),
+                "holding_quantity": next(
+                    (
+                        item.get("quantity")
+                        for item in robinhood_entry.get("holdings", [])
+                        if item.get("symbol") == symbol
+                    ),
+                    0.0,
+                ),
+            },
+            "schwab": {
+                "price": schwab_entry.get("pricing", {}).get(symbol, {}).get("price"),
+                "holding_quantity": next(
+                    (
+                        item.get("quantity")
+                        for item in schwab_entry.get("holdings", [])
+                        if item.get("symbol") == symbol
+                    ),
+                    0.0,
+                ),
+            },
+        }
+
+    notes: list[str] = []
+    if not robinhood_entry.get("available"):
+        notes.append(f"robinhood unavailable: {', '.join(robinhood_entry.get('notes', []))}")
+    if not schwab_entry.get("available"):
+        notes.append(f"schwab unavailable: {', '.join(schwab_entry.get('notes', []))}")
+
+    available_count = sum(
+        1 for entry in (robinhood_entry, schwab_entry) if entry.get("available")
+    )
+    status = "success" if available_count == 2 else "partial" if available_count == 1 else "error"
+
+    return create_success_response(
+        {
+            "brokers": {
+                "robinhood": robinhood_entry,
+                "schwab": schwab_entry,
+            },
+            "comparison": comparison,
+            "availability_notes": notes,
+            "status": status,
+        }
+    )

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -143,6 +143,7 @@ class TestToolRegistration:
             "account_info",
             "account_details",
             "positions",
+            "broker_comparison",
         ]
 
         for tool_name in expected_tools:

--- a/tests/unit/test_broker_comparison_tools.py
+++ b/tests/unit/test_broker_comparison_tools.py
@@ -1,0 +1,181 @@
+"""Tests for broker comparison tools."""
+
+from unittest.mock import patch
+
+import pytest
+
+from open_stocks_mcp.tools.broker_comparison_tools import get_broker_comparison
+
+
+@pytest.mark.asyncio
+async def test_broker_comparison_normalizes_data() -> None:
+    """Comparison should normalize robinhood and schwab data for side-by-side output."""
+    with (
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_portfolio",
+            return_value={
+                "result": {
+                    "equity": "1000.5",
+                    "buying_power": "250.25",
+                    "market_value": "1000.5",
+                    "status": "success",
+                }
+            },
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_positions",
+            return_value={
+                "result": {
+                    "positions": [
+                        {
+                            "symbol": "AAPL",
+                            "quantity": "2",
+                            "average_buy_price": "150",
+                        }
+                    ],
+                    "status": "success",
+                }
+            },
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_stock_orders",
+            return_value={
+                "result": {
+                    "orders": [
+                        {
+                            "symbol": "AAPL",
+                            "side": "BUY",
+                            "quantity": "1",
+                            "average_price": "151",
+                            "state": "filled",
+                        }
+                    ],
+                    "status": "success",
+                }
+            },
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_stock_price",
+            return_value={
+                "result": {
+                    "symbol": "AAPL",
+                    "price": 175.11,
+                    "status": "success",
+                }
+            },
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_numbers",
+            return_value={
+                "result": {
+                    "accounts": [{"account_id": "1", "hash_value": "hash-1"}],
+                    "status": "success",
+                }
+            },
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_balances",
+            return_value={
+                "result": {
+                    "current_balances": {
+                        "market_value": 2000.0,
+                        "buying_power": 600.0,
+                    },
+                    "status": "success",
+                }
+            },
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_portfolio",
+            return_value={
+                "result": {
+                    "positions": [
+                        {
+                            "symbol": "AAPL",
+                            "quantity": 3,
+                            "average_price": 140,
+                            "market_value": 525,
+                        }
+                    ],
+                    "status": "success",
+                }
+            },
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_orders",
+            return_value={
+                "result": {
+                    "orders": [
+                        {
+                            "orderLegCollection": [
+                                {
+                                    "instruction": "SELL",
+                                    "instrument": {"symbol": "AAPL"},
+                                    "quantity": 1,
+                                }
+                            ],
+                            "status": "FILLED",
+                            "price": 170.0,
+                        }
+                    ],
+                    "status": "success",
+                }
+            },
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_quote",
+            return_value={
+                "result": {
+                    "symbol": "AAPL",
+                    "last_price": 174.98,
+                    "status": "success",
+                }
+            },
+        ),
+    ):
+        result = await get_broker_comparison(["AAPL"], include_orders=True, max_orders=5)
+
+    payload = result["result"]
+    assert payload["status"] == "success"
+    assert payload["brokers"]["robinhood"]["source"] == "robinhood"
+    assert payload["brokers"]["schwab"]["source"] == "schwab"
+    assert payload["brokers"]["robinhood"]["confidence"] in {"high", "medium"}
+    assert payload["brokers"]["schwab"]["confidence"] in {"high", "medium"}
+    assert payload["comparison"]["AAPL"]["robinhood"]["price"] == 175.11
+    assert payload["comparison"]["AAPL"]["schwab"]["price"] == 174.98
+    assert payload["availability_notes"] == []
+
+
+@pytest.mark.asyncio
+async def test_broker_comparison_returns_partial_on_schwab_failure() -> None:
+    """One broker failure should not collapse successful broker comparison output."""
+    with (
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_portfolio",
+            return_value={"result": {"equity": "100", "status": "success"}},
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_positions",
+            return_value={"result": {"positions": [{"symbol": "AAPL", "quantity": "1"}], "status": "success"}},
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_stock_orders",
+            return_value={"result": {"orders": [], "status": "success"}},
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_stock_price",
+            return_value={"result": {"symbol": "AAPL", "price": 175.0, "status": "success"}},
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_numbers",
+            return_value={"result": {"status": "broker_unavailable", "error": "offline"}},
+        ),
+    ):
+        result = await get_broker_comparison(["AAPL"], include_orders=False)
+
+    payload = result["result"]
+    assert payload["status"] == "partial"
+    assert payload["brokers"]["robinhood"]["available"] is True
+    assert payload["brokers"]["schwab"]["available"] is False
+    assert payload["comparison"]["AAPL"]["robinhood"]["price"] == 175.0
+    assert any("schwab" in note.lower() for note in payload["availability_notes"])


### PR DESCRIPTION
Refs #109
Closes #115

## Changes
- add new broker_comparison MCP tool and get_broker_comparison() implementation
- normalize robinhood/schwab pricing, holdings, orders, source, and confidence fields
- keep partial-failure behavior so one broker outage does not collapse results
- add focused unit tests for normalization and partial status
- update server registration test to assert broker_comparison is registered

## Test plan
- uv run pytest tests/unit/test_broker_comparison_tools.py tests/server/test_server_app.py::TestToolRegistration::test_tools_are_registered -q
- uv run ruff check src/open_stocks_mcp/tools/broker_comparison_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_broker_comparison_tools.py tests/server/test_server_app.py
- uv run mypy src/open_stocks_mcp/tools/broker_comparison_tools.py src/open_stocks_mcp/server/app.py
- uv run pytest tests/unit/test_broker_comparison_tools.py tests/server/test_server_app.py -q (contains pre-existing failures in unrelated create_mcp_server tests when opentelemetry is not installed)
