### PR TITLE
feat: implement unified watchlist capabilities across brokers (#116)

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -160,6 +160,12 @@ from open_stocks_mcp.tools.schwab_trading_tools import (
     schwab_sell_market,
 )
 from open_stocks_mcp.tools.session_manager import get_session_manager
+from open_stocks_mcp.tools.unified_watchlist_tools import (
+    add_symbols_to_unified_watchlist,
+    get_unified_watchlist_by_name,
+    get_unified_watchlists,
+    remove_symbols_from_unified_watchlist,
+)
 from open_stocks_mcp.tracing import setup_tracing, trace_tool_call
 
 # Load environment variables from .env file
@@ -652,6 +658,58 @@ async def watchlist_performance(watchlist_name: str) -> dict[str, Any]:
         watchlist_name: Name of the watchlist to analyze
     """
     return await get_watchlist_performance(watchlist_name)
+
+
+# Unified Watchlist Tools
+@mcp.tool()
+async def unified_watchlists(brokers: list[str] | None = None) -> dict[str, Any]:
+    """Gets all watchlists aggregated across supported brokers.
+
+    Args:
+        brokers: Optional list of broker names to include (e.g., ["robinhood", "schwab"])
+    """
+    return await get_unified_watchlists(brokers)
+
+
+@mcp.tool()
+async def unified_watchlist_by_name(
+    watchlist_name: str, brokers: list[str] | None = None
+) -> dict[str, Any]:
+    """Gets a specific watchlist by name across supported brokers.
+
+    Args:
+        watchlist_name: Name of the watchlist
+        brokers: Optional list of broker names to include
+    """
+    return await get_unified_watchlist_by_name(watchlist_name, brokers)
+
+
+@mcp.tool()
+async def unified_add_to_watchlist(
+    watchlist_name: str, symbols: list[str], brokers: list[str] | None = None
+) -> dict[str, Any]:
+    """Adds symbols to a watchlist across supported brokers.
+
+    Args:
+        watchlist_name: Name of the watchlist
+        symbols: List of stock symbols to add
+        brokers: Optional list of broker names to target
+    """
+    return await add_symbols_to_unified_watchlist(watchlist_name, symbols, brokers)
+
+
+@mcp.tool()
+async def unified_remove_from_watchlist(
+    watchlist_name: str, symbols: list[str], brokers: list[str] | None = None
+) -> dict[str, Any]:
+    """Removes symbols from a watchlist across supported brokers.
+
+    Args:
+        watchlist_name: Name of the watchlist
+        symbols: List of stock symbols to remove
+        brokers: Optional list of broker names to target
+    """
+    return await remove_symbols_from_unified_watchlist(watchlist_name, symbols, brokers)
 
 
 # Phase 3: Account Features & Notifications Tools

--- a/src/open_stocks_mcp/tools/unified_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/unified_watchlist_tools.py
@@ -1,0 +1,236 @@
+"""Unified Watchlist Tools for multi-broker support."""
+
+from typing import Any
+
+from open_stocks_mcp.brokers.registry import get_broker_registry
+from open_stocks_mcp.tools.responses import create_success_response
+from open_stocks_mcp.tools.robinhood_watchlist_tools import (
+    add_symbols_to_watchlist as add_rh_symbols,
+)
+from open_stocks_mcp.tools.robinhood_watchlist_tools import (
+    get_all_watchlists as get_rh_watchlists,
+)
+from open_stocks_mcp.tools.robinhood_watchlist_tools import (
+    get_watchlist_by_name as get_rh_watchlist_by_name,
+)
+from open_stocks_mcp.tools.robinhood_watchlist_tools import (
+    remove_symbols_from_watchlist as remove_rh_symbols,
+)
+
+
+def _normalize_symbols(symbols: list[str]) -> list[str]:
+    """Uppercase and de-duplicate symbols."""
+    normalized = []
+    seen = set()
+    for s in symbols:
+        if isinstance(s, str):
+            clean = s.upper().strip()
+            if clean and clean not in seen:
+                normalized.append(clean)
+                seen.add(clean)
+    return normalized
+
+async def get_unified_watchlists(brokers: list[str] | None = None) -> dict[str, Any]:
+    """Get all watchlists across supported brokers."""
+    registry = await get_broker_registry()
+    all_broker_names = registry.list_brokers()
+    broker_names = brokers if brokers is not None else all_broker_names
+    
+    brokers_out = {}
+    unified_watchlists = []
+    warnings = []
+    partial_failure = False
+    
+    for name in broker_names:
+        if name not in all_broker_names:
+            brokers_out[name] = {"status": "error", "message": "Broker not registered"}
+            partial_failure = True
+            continue
+            
+        broker = registry.get_broker(name)
+        if name == "robinhood":
+            if broker and broker.is_available():
+                rh_res = await get_rh_watchlists()
+                rh_data = rh_res.get("result", {})
+                if rh_data.get("status") == "success":
+                    brokers_out[name] = {
+                        "status": "success",
+                        "watchlist_count": rh_data.get("total_watchlists", 0)
+                    }
+                    for wl in rh_data.get("watchlists", []):
+                        unified_watchlists.append({
+                            "name": wl.get("name"),
+                            "symbols": wl.get("symbols", []),
+                            "symbol_count": wl.get("symbol_count", 0),
+                            "brokers": ["robinhood"]
+                        })
+                else:
+                    brokers_out[name] = {"status": "error", "message": rh_data.get("message", "Error fetching watchlists")}
+                    partial_failure = True
+            else:
+                brokers_out[name] = {"status": "unavailable"}
+                partial_failure = True
+        elif name == "schwab":
+            brokers_out[name] = {
+                "status": "unsupported",
+                "message": "Schwab does not currently expose a watchlist API."
+            }
+            warnings.append({"broker": "schwab", "message": "Watchlists are not supported on Schwab."})
+        else:
+            brokers_out[name] = {"status": "unsupported"}
+            
+    status = "success"
+    if partial_failure:
+        status = "partial_success"
+        
+    return create_success_response({
+        "watchlists": unified_watchlists,
+        "total_watchlists": len(unified_watchlists),
+        "brokers": brokers_out,
+        "warnings": warnings,
+        "status": status
+    })
+
+async def get_unified_watchlist_by_name(watchlist_name: str, brokers: list[str] | None = None) -> dict[str, Any]:
+    """Get a specific watchlist by name across supported brokers."""
+    registry = await get_broker_registry()
+    all_broker_names = registry.list_brokers()
+    broker_names = brokers if brokers is not None else all_broker_names
+    
+    per_broker = {}
+    combined_symbols = set()
+    warnings = []
+    found_any = False
+    
+    for name in broker_names:
+        if name not in all_broker_names:
+            per_broker[name] = {"status": "error", "message": "Broker not registered"}
+            continue
+
+        broker = registry.get_broker(name)
+        if name == "robinhood":
+            if broker and broker.is_available():
+                rh_res = await get_rh_watchlist_by_name(watchlist_name)
+                rh_data = rh_res.get("result", {})
+                if rh_data.get("status") == "success":
+                    per_broker[name] = {
+                        "status": "success",
+                        "symbols": rh_data.get("symbols", [])
+                    }
+                    combined_symbols.update(rh_data.get("symbols", []))
+                    found_any = True
+                elif rh_data.get("status") == "not_found":
+                    per_broker[name] = {"status": "not_found"}
+                else:
+                    per_broker[name] = {"status": "error", "message": rh_data.get("message", "Error")}
+            else:
+                per_broker[name] = {"status": "unavailable"}
+        elif name == "schwab":
+            per_broker[name] = {"status": "unsupported"}
+            warnings.append({"broker": "schwab", "message": "Watchlists are not supported on Schwab."})
+            
+    symbols = sorted(combined_symbols)
+    return create_success_response({
+        "watchlist_name": watchlist_name,
+        "symbols": symbols,
+        "symbol_count": len(symbols),
+        "brokers": list(per_broker.keys()),
+        "per_broker": per_broker,
+        "warnings": warnings,
+        "status": "success" if found_any else "not_found"
+    })
+
+async def add_symbols_to_unified_watchlist(watchlist_name: str, symbols: list[str], brokers: list[str] | None = None) -> dict[str, Any]:
+    """Add symbols to a watchlist across supported brokers."""
+    registry = await get_broker_registry()
+    all_broker_names = registry.list_brokers()
+    broker_names = brokers if brokers is not None else all_broker_names
+    
+    normalized = _normalize_symbols(symbols)
+    per_broker = {}
+    warnings = []
+    
+    for name in broker_names:
+        if name not in all_broker_names:
+            per_broker[name] = {"status": "error", "success": False, "message": "Broker not registered"}
+            continue
+
+        broker = registry.get_broker(name)
+        if name == "robinhood":
+            if broker and broker.is_available():
+                res = await add_rh_symbols(watchlist_name, normalized)
+                data = res.get("result", {})
+                per_broker[name] = data
+            else:
+                per_broker[name] = {"status": "unavailable", "success": False}
+        elif name == "schwab":
+            per_broker[name] = {
+                "status": "unsupported",
+                "success": False,
+                "message": "Schwab does not support watchlist mutations via API."
+            }
+            warnings.append({"broker": "schwab", "message": "Add operation ignored for Schwab."})
+            
+    # Determine overall status
+    success_count = sum(1 for b in per_broker.values() if b.get("status") == "success")
+    if success_count == len(per_broker) and len(per_broker) > 0:
+        status = "success"
+    elif success_count > 0:
+        status = "partial_success"
+    else:
+        status = "error"
+        
+    return create_success_response({
+        "watchlist_name": watchlist_name,
+        "symbols_added": normalized,
+        "per_broker": per_broker,
+        "warnings": warnings,
+        "status": status
+    })
+
+async def remove_symbols_from_unified_watchlist(watchlist_name: str, symbols: list[str], brokers: list[str] | None = None) -> dict[str, Any]:
+    """Remove symbols from a watchlist across supported brokers."""
+    registry = await get_broker_registry()
+    all_broker_names = registry.list_brokers()
+    broker_names = brokers if brokers is not None else all_broker_names
+    
+    normalized = _normalize_symbols(symbols)
+    per_broker = {}
+    warnings = []
+    
+    for name in broker_names:
+        if name not in all_broker_names:
+            per_broker[name] = {"status": "error", "success": False, "message": "Broker not registered"}
+            continue
+
+        broker = registry.get_broker(name)
+        if name == "robinhood":
+            if broker and broker.is_available():
+                res = await remove_rh_symbols(watchlist_name, normalized)
+                data = res.get("result", {})
+                per_broker[name] = data
+            else:
+                per_broker[name] = {"status": "unavailable", "success": False}
+        elif name == "schwab":
+            per_broker[name] = {
+                "status": "unsupported",
+                "success": False,
+                "message": "Schwab does not support watchlist mutations via API."
+            }
+            warnings.append({"broker": "schwab", "message": "Remove operation ignored for Schwab."})
+            
+    success_count = sum(1 for b in per_broker.values() if b.get("status") == "success")
+    if success_count == len(per_broker) and len(per_broker) > 0:
+        status = "success"
+    elif success_count > 0:
+        status = "partial_success"
+    else:
+        status = "error"
+        
+    return create_success_response({
+        "watchlist_name": watchlist_name,
+        "symbols_removed": normalized,
+        "per_broker": per_broker,
+        "warnings": warnings,
+        "status": status
+    })

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -27,7 +27,9 @@ class TestServerApp:
             patch("open_stocks_mcp.server.app.load_config") as mock_config,
             patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
         ):
-            mock_config.return_value = MagicMock()
+            mock_cfg = MagicMock()
+            mock_cfg.otel.enabled = False
+            mock_config.return_value = mock_cfg
             result = create_mcp_server()
 
             assert result is mcp
@@ -37,6 +39,7 @@ class TestServerApp:
     def test_create_mcp_server_with_config(self) -> None:
         """Test create_mcp_server with provided config."""
         mock_config = MagicMock()
+        mock_config.otel.enabled = False
 
         with patch("open_stocks_mcp.server.app.setup_logging") as mock_logging:
             result = create_mcp_server(mock_config)
@@ -143,6 +146,10 @@ class TestToolRegistration:
             "account_info",
             "account_details",
             "positions",
+            "unified_watchlists",
+            "unified_watchlist_by_name",
+            "unified_add_to_watchlist",
+            "unified_remove_from_watchlist",
         ]
 
         for tool_name in expected_tools:

--- a/tests/unit/test_unified_watchlist_tools.py
+++ b/tests/unit/test_unified_watchlist_tools.py
@@ -1,0 +1,133 @@
+"""Unit tests for unified watchlist tools."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.unified_watchlist_tools import (
+    add_symbols_to_unified_watchlist,
+    get_unified_watchlist_by_name,
+    get_unified_watchlists,
+    remove_symbols_from_unified_watchlist,
+)
+
+
+@pytest.fixture
+def mock_registry():
+    with patch("open_stocks_mcp.tools.unified_watchlist_tools.get_broker_registry") as mock:
+        registry = MagicMock()
+        mock.return_value = registry
+        yield registry
+
+@pytest.fixture
+def mock_robinhood():
+    broker = MagicMock()
+    broker.name = "robinhood"
+    broker.is_available.return_value = True
+    return broker
+
+@pytest.fixture
+def mock_schwab():
+    broker = MagicMock()
+    broker.name = "schwab"
+    broker.is_available.return_value = True
+    return broker
+
+@pytest.mark.asyncio
+async def test_get_unified_watchlists_success(mock_registry, mock_robinhood, mock_schwab):
+    """Test normalized response for all watchlists across brokers."""
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_registry.get_broker.side_effect = lambda name: mock_robinhood if name == "robinhood" else mock_schwab
+
+    rh_watchlists = {
+        "result": {
+            "watchlists": [
+                {"name": "Tech", "symbols": ["AAPL", "MSFT"], "symbol_count": 2}
+            ],
+            "status": "success"
+        }
+    }
+
+    with patch("open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists", return_value=rh_watchlists):
+        result = await get_unified_watchlists()
+
+    assert result["result"]["status"] in ["success", "partial_success"]
+    assert "robinhood" in result["result"]["brokers"]
+    assert "schwab" in result["result"]["brokers"]
+    assert result["result"]["brokers"]["schwab"]["status"] == "unsupported"
+    
+    # Check aggregation
+    watchlists = result["result"]["watchlists"]
+    assert len(watchlists) >= 1
+    tech = next(w for w in watchlists if w["name"] == "Tech")
+    assert "robinhood" in tech["brokers"]
+    assert tech["symbols"] == ["AAPL", "MSFT"]
+
+@pytest.mark.asyncio
+async def test_get_unified_watchlist_by_name_success(mock_registry, mock_robinhood, mock_schwab):
+    """Test normalized response for a single watchlist by name."""
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_registry.get_broker.side_effect = lambda name: mock_robinhood if name == "robinhood" else mock_schwab
+
+    rh_watchlist = {
+        "result": {
+            "name": "Tech",
+            "symbols": ["AAPL", "MSFT"],
+            "symbol_count": 2,
+            "status": "success"
+        }
+    }
+
+    with patch("open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name", return_value=rh_watchlist):
+        result = await get_unified_watchlist_by_name("Tech")
+
+    assert result["result"]["status"] in ["success", "partial_success"]
+    assert result["result"]["watchlist_name"] == "Tech"
+    assert result["result"]["symbols"] == ["AAPL", "MSFT"]
+    assert "robinhood" in result["result"]["brokers"]
+    assert "schwab" in result["result"]["brokers"]
+    assert result["result"]["per_broker"]["schwab"]["status"] == "unsupported"
+
+@pytest.mark.asyncio
+async def test_add_symbols_to_unified_watchlist_partial_success(mock_registry, mock_robinhood, mock_schwab):
+    """Test partial success when adding symbols (RH success, Schwab unsupported)."""
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_registry.get_broker.side_effect = lambda name: mock_robinhood if name == "robinhood" else mock_schwab
+
+    rh_result = {
+        "result": {
+            "success": True,
+            "symbols_added": ["AAPL"],
+            "status": "success"
+        }
+    }
+
+    with patch("open_stocks_mcp.tools.unified_watchlist_tools.add_rh_symbols", return_value=rh_result):
+        result = await add_symbols_to_unified_watchlist("Tech", ["aapl", "AAPL "])
+
+    assert result["result"]["status"] == "partial_success"
+    assert "AAPL" in result["result"]["symbols_added"]
+    assert len(result["result"]["symbols_added"]) == 1 # De-duplicated and uppercased
+    assert result["result"]["per_broker"]["robinhood"]["status"] == "success"
+    assert result["result"]["per_broker"]["schwab"]["status"] == "unsupported"
+
+@pytest.mark.asyncio
+async def test_remove_symbols_from_unified_watchlist_success(mock_registry, mock_robinhood, mock_schwab):
+    """Test success when removing symbols from Robinhood."""
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_registry.get_broker.side_effect = lambda name: mock_robinhood if name == "robinhood" else mock_schwab
+
+    rh_result = {
+        "result": {
+            "success": True,
+            "symbols_removed": ["AAPL"],
+            "status": "success"
+        }
+    }
+
+    with patch("open_stocks_mcp.tools.unified_watchlist_tools.remove_rh_symbols", return_value=rh_result):
+        result = await remove_symbols_from_unified_watchlist("Tech", ["AAPL"])
+
+    assert result["result"]["status"] == "partial_success" # Because Schwab is unsupported
+    assert result["result"]["symbols_removed"] == ["AAPL"]
+    assert result["result"]["per_broker"]["robinhood"]["status"] == "success"


### PR DESCRIPTION
Closes #116

## Changes
- Implemented `unified_watchlist_tools.py` with normalized cross-broker read/write helpers.
- Registered new unified MCP tools in `app.py`: `unified_watchlists`, `unified_watchlist_by_name`, `unified_add_to_watchlist`, and `unified_remove_from_watchlist`.
- Modeled Schwab watchlist operations as structured unsupported responses to maintain consistency without blocking other brokers.
- Added comprehensive unit tests in `test_unified_watchlist_tools.py`.
- Updated `test_server_app.py` to verify tool registration and fixed pre-existing OpenTelemetry mock issue.

## Test plan
- Run unit tests: `uv run pytest tests/unit/test_unified_watchlist_tools.py tests/server/test_server_app.py`
- Run journey tests: `uv run pytest -m "journey_watchlists" -q`
- Verify linting and typing: `uv run ruff check . && uv run mypy .`