### PR TITLE
test: add Schwab ADK eval fixtures

### DIFF
--- a/tests/evals/1_acc_schwab_account_numbers_test.json
+++ b/tests/evals/1_acc_schwab_account_numbers_test.json
@@ -1,7 +1,7 @@
 {
   "eval_set_id": "schwab_account_numbers_test_set",
   "name": "Schwab Account Numbers Test",
-  "description": "Test case for retrieving Schwab account numbers through agent interaction",
+  "description": "Test case for retrieving Schwab account numbers and hashes through agent interaction",
   "eval_cases": [
     {
       "eval_id": "schwab_account_numbers_test",
@@ -11,7 +11,7 @@
           "user_content": {
             "parts": [
               {
-                "text": "List my Schwab account numbers."
+                "text": "List my Schwab account numbers and account hash values in a bulleted list."
               }
             ],
             "role": "user"
@@ -19,7 +19,7 @@
           "final_response": {
             "parts": [
               {
-                "text": "Here are your Schwab account numbers:\n\n*   **Account Hash**: abc123def456\n*   **Account Number**: 123456789"
+                "text": "Here are your Schwab accounts in a bulleted list:\n\n* **Account Number**: 12345678\n* **Account Hash**: abc123hash\n* **Status**: success"
               }
             ],
             "role": "model"

--- a/tests/evals/2_mkt_schwab_quote_test.json
+++ b/tests/evals/2_mkt_schwab_quote_test.json
@@ -11,7 +11,7 @@
           "user_content": {
             "parts": [
               {
-                "text": "What's the current price of AAPL on Schwab?"
+                "text": "Get me a Schwab quote for AAPL."
               }
             ],
             "role": "user"
@@ -19,7 +19,7 @@
           "final_response": {
             "parts": [
               {
-                "text": "The current price of AAPL on Schwab is $150.00."
+                "text": "Here is the Schwab quote for AAPL:\n\n* **Symbol**: AAPL\n* **Last Price**: $223.09\n* **Status**: success"
               }
             ],
             "role": "model"


### PR DESCRIPTION
Closes #122

## Changes
- add tests/evals/1_acc_schwab_account_numbers_test.json covering schwab_account_numbers with {} args
- add tests/evals/2_mkt_schwab_quote_test.json covering schwab_quote with {"symbol": "AAPL"}
- update tests/evals/ADK-testing-evals.md with both new Schwab evals and run commands

## Test plan
- uv run python -m json.tool tests/evals/1_acc_schwab_account_numbers_test.json >/dev/null
- uv run python -m json.tool tests/evals/2_mkt_schwab_quote_test.json >/dev/null
- MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/1_acc_schwab_account_numbers_test.json --config_file_path tests/evals/test_config.json
- MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/2_mkt_schwab_quote_test.json --config_file_path tests/evals/test_config.json
- rg -n "1_acc_schwab_account_numbers_test|2_mkt_schwab_quote_test|schwab_account_numbers|schwab_quote" tests/evals/ADK-testing-evals.md tests/evals/*.json