### PR TITLE
test: add ADK evaluations for Schwab market history and search

### DIFF
--- a/tests/evals/2_mkt_schwab_price_history_test.json
+++ b/tests/evals/2_mkt_schwab_price_history_test.json
@@ -1,0 +1,52 @@
+{
+  "eval_set_id": "schwab_price_history_test_set",
+  "name": "Schwab Price History Test",
+  "description": "Test case for retrieving historical price data from Schwab through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_price_history_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-price-history-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Get the AAPL intraday Schwab price history for 1 day with 1 minute frequency."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the intraday price history for Apple (AAPL) from Schwab for the last 1 day at 1-minute intervals:\n\n**Symbol:** AAPL\n**Period:** 1 day\n**Frequency:** 1 minute\n\n(Note: The actual historical data would be presented here in a table or list format, showing open, high, low, close, and volume for each 1-minute candle.)"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "period_type": "day",
+                  "period": 1,
+                  "frequency_type": "minute",
+                  "frequency": 1
+                },
+                "name": "schwab_price_history"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_schwab_search_instruments_test.json
+++ b/tests/evals/2_mkt_schwab_search_instruments_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "schwab_search_instruments_test_set",
+  "name": "Schwab Search Instruments Test",
+  "description": "Test case for searching instruments through Schwab through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_search_instruments_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-search-instruments-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Use Schwab to search for Apple or AAPL instruments."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I searched Schwab for instruments matching \"AAPL\" and found the following results:\n\n*   **Apple Inc. (AAPL)** - NASDAQ | Equity\n*   **AAPL** - Various Option Contracts\n\nI can provide more details on any of these instruments if you'd like."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "query": "AAPL"
+                },
+                "name": "schwab_search_instruments"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #123

## Changes
- Created `tests/evals/2_mkt_schwab_price_history_test.json` for `schwab_price_history` tool.
- Created `tests/evals/2_mkt_schwab_search_instruments_test.json` for `schwab_search_instruments` tool.
- Validated JSON structure and tool name targeting.

## Test plan
- Verified JSON validity with `python3 -m json.tool`.
- Verified tool names with `grep`.
- Verified no whitespace errors with `git diff --check`.