### PR TITLE
feat: add concurrent broker health telemetry

### DIFF
--- a/src/open_stocks_mcp/brokers/base.py
+++ b/src/open_stocks_mcp/brokers/base.py
@@ -94,17 +94,37 @@ class BaseBroker(ABC):
         """
         return self._auth_info.status != BrokerAuthStatus.NOT_CONFIGURED
 
+    @property
+    def account_id(self) -> str:
+        """Default account key used for account-scoped health and auth guards."""
+        return "default"
+
+    def get_account_metadata(self) -> dict[str, Any]:
+        """Return broker account metadata for health surfaces.
+
+        Broker subclasses can override this when they manage multiple accounts.
+        """
+        return {"account_id": self.account_id}
+
+    def get_health_metadata(self) -> dict[str, Any]:
+        """Return additive broker health metadata for monitoring surfaces."""
+        return {
+            "broker": self.name,
+            "account_id": self.account_id,
+            "auth_status": self._auth_info.status.value,
+            "is_available": self.is_available(),
+            "is_configured": self.is_configured(),
+        }
+
     def get_health_status(self) -> dict[str, Any]:
         """Return broker health and capability summary.
 
         Returns:
-            Dict with broker, is_available, auth_status, capabilities, streaming_ready
+            Dict with broker, account, auth, capability, and streaming health data.
         """
         available = self.is_available()
         return {
-            "broker": self._name,
-            "is_available": available,
-            "auth_status": self._auth_info.status.value,
+            **self.get_health_metadata(),
             "capabilities": asdict(self._capabilities),
             "streaming_ready": available and self._capabilities.streaming_quotes,
         }

--- a/src/open_stocks_mcp/brokers/registry.py
+++ b/src/open_stocks_mcp/brokers/registry.py
@@ -1,6 +1,9 @@
 """Broker registry for managing multiple broker instances."""
 
 import asyncio
+import inspect
+import time
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
@@ -28,6 +31,9 @@ class BrokerRegistry:
         self._brokers: dict[str, BaseBroker] = {}
         self._active_broker: str | None = None
         self._authentication_attempts: dict[str, int] = {}
+        self._auth_refresh_futures: dict[tuple[str, str], asyncio.Task[Any]] = {}
+        self._auth_refresh_lock = asyncio.Lock()
+        self._auth_operation_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
     def register(self, broker: BaseBroker) -> None:
         """Register a broker instance.
@@ -152,6 +158,159 @@ class BrokerRegistry:
             }
             for name, broker in self._brokers.items()
         }
+
+    def get_broker_health(self) -> dict[str, Any]:
+        """Get broker and account health summaries from collected telemetry."""
+        from open_stocks_mcp.monitoring import get_metrics_collector
+
+        return get_metrics_collector().get_broker_health_summary()
+
+    @staticmethod
+    def _account_key(account_id: str | None) -> str:
+        return account_id or "default"
+
+    @staticmethod
+    async def _maybe_await(value: Any) -> Any:
+        if inspect.isawaitable(value):
+            return await value
+        return value
+
+    async def coordinate_auth_refresh(
+        self,
+        broker_name: str,
+        account_id: str | None,
+        refresh_call: Callable[[], Awaitable[Any] | Any],
+    ) -> Any:
+        """Run one in-flight auth refresh per broker/account key.
+
+        Concurrent callers for the same key await the same refresh task. Different
+        account keys are independent so one account refresh does not serialize all
+        broker activity.
+        """
+        key = (broker_name, self._account_key(account_id))
+
+        async with self._auth_refresh_lock:
+            refresh_task = self._auth_refresh_futures.get(key)
+            if refresh_task is None or refresh_task.done():
+                refresh_task = asyncio.create_task(
+                    self._maybe_await(refresh_call())
+                )
+                self._auth_refresh_futures[key] = refresh_task
+
+        try:
+            return await refresh_task
+        finally:
+            if refresh_task.done():
+                async with self._auth_refresh_lock:
+                    if self._auth_refresh_futures.get(key) is refresh_task:
+                        self._auth_refresh_futures.pop(key, None)
+
+    async def run_with_auth_guard(
+        self,
+        broker_name: str,
+        account_id: str | None,
+        operation: Callable[[], Awaitable[Any] | Any],
+    ) -> Any:
+        """Run an operation under a per broker/account session-state guard."""
+        key = (broker_name, self._account_key(account_id))
+        async with self._auth_refresh_lock:
+            lock = self._auth_operation_locks.setdefault(key, asyncio.Lock())
+
+        async with lock:
+            return await self._maybe_await(operation())
+
+    @staticmethod
+    def _classify_failure(error_type: str) -> str:
+        normalized = error_type.lower()
+        if "pool" in normalized:
+            return "client_pool"
+        if "timeout" in normalized:
+            return "timeout"
+        if "auth" in normalized or "401" in normalized or "token" in normalized:
+            return "authentication"
+        if "account" in normalized:
+            return "account"
+        return "broker_api"
+
+    async def _record_operation_metric(self, result: dict[str, Any]) -> None:
+        try:
+            from open_stocks_mcp.monitoring import get_metrics_collector
+
+            await get_metrics_collector().record_broker_operation(
+                broker=result["broker"],
+                account_id=result["account_id"],
+                operation=result["operation"],
+                duration=result["duration_ms"] / 1000.0,
+                success=result["status"] == "success",
+                error_type=result.get("error", {}).get("type"),
+                failure_class=result.get("error", {}).get("failure_class"),
+            )
+        except Exception as exc:
+            logger.debug(f"Failed to record broker operation metric: {exc}")
+
+    async def run_concurrent_operations(
+        self,
+        operations: list[dict[str, Any]],
+        concurrency_limit: int = 5,
+        timeout_seconds: float = 30.0,
+    ) -> list[dict[str, Any]]:
+        """Run broker operations with bounded fan-out and isolated results."""
+        semaphore = asyncio.Semaphore(max(1, concurrency_limit))
+
+        async def run_one(spec: dict[str, Any]) -> dict[str, Any]:
+            async with semaphore:
+                broker = str(spec.get("broker") or "unknown")
+                account_id = self._account_key(spec.get("account_id"))
+                operation_name = str(spec.get("operation") or "operation")
+                call = spec["call"]
+                start = time.perf_counter()
+
+                try:
+                    result_value = await asyncio.wait_for(
+                        self._maybe_await(call()), timeout=timeout_seconds
+                    )
+                    status = "success"
+                    result: dict[str, Any] = {
+                        "broker": broker,
+                        "account_id": account_id,
+                        "operation": operation_name,
+                        "status": status,
+                        "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+                        "result": result_value,
+                    }
+                except TimeoutError as exc:
+                    error_type = type(exc).__name__
+                    result = {
+                        "broker": broker,
+                        "account_id": account_id,
+                        "operation": operation_name,
+                        "status": "timeout",
+                        "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+                        "error": {
+                            "type": error_type,
+                            "message": f"Operation timed out after {timeout_seconds}s",
+                            "failure_class": "timeout",
+                        },
+                    }
+                except Exception as exc:
+                    error_type = type(exc).__name__
+                    result = {
+                        "broker": broker,
+                        "account_id": account_id,
+                        "operation": operation_name,
+                        "status": "error",
+                        "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+                        "error": {
+                            "type": error_type,
+                            "message": str(exc),
+                            "failure_class": self._classify_failure(error_type),
+                        },
+                    }
+
+                await self._record_operation_metric(result)
+                return result
+
+        return await asyncio.gather(*(run_one(spec) for spec in operations))
 
     async def authenticate_all(self, fail_fast: bool = False) -> dict[str, bool]:
         """Authenticate all registered brokers.

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -29,6 +29,7 @@ class MetricsCollector:
         self.tool_response_times: dict[str, deque[tuple[datetime, float]]] = (
             defaultdict(deque)
         )
+        self.broker_operations: deque[dict[str, Any]] = deque()
         self.error_types: dict[str, int] = defaultdict(int)
 
         # Counters
@@ -97,6 +98,57 @@ class MetricsCollector:
         async with self._lock:
             self.cache_misses[name] += 1
 
+    @staticmethod
+    def classify_broker_failure(
+        error_type: str | None, failure_class: str | None = None
+    ) -> str | None:
+        """Classify broker operation failures for health summaries."""
+        if failure_class:
+            return failure_class
+        if not error_type:
+            return None
+
+        normalized = error_type.lower()
+        if "pool" in normalized:
+            return "client_pool"
+        if "timeout" in normalized:
+            return "timeout"
+        if "auth" in normalized or "401" in normalized or "token" in normalized:
+            return "authentication"
+        if "account" in normalized:
+            return "account"
+        return "broker_api"
+
+    async def record_broker_operation(
+        self,
+        broker: str,
+        account_id: str | None,
+        operation: str,
+        duration: float,
+        success: bool,
+        error_type: str | None = None,
+        failure_class: str | None = None,
+    ) -> None:
+        """Record a broker/account scoped operation outcome."""
+        async with self._lock:
+            now = datetime.now()
+            self._clean_old_entries(now)
+            classified_failure = self.classify_broker_failure(
+                error_type, failure_class
+            )
+            self.broker_operations.append(
+                {
+                    "timestamp": now,
+                    "broker": broker,
+                    "account_id": account_id or "default",
+                    "operation": operation,
+                    "duration": duration,
+                    "success": success,
+                    "error_type": error_type,
+                    "failure_class": classified_failure,
+                }
+            )
+
     def _clean_old_entries(self, now: datetime) -> None:
         """Remove entries older than the window size."""
         cutoff = now - self.window_size
@@ -122,6 +174,83 @@ class MetricsCollector:
         for tool_durations in self.tool_response_times.values():
             while tool_durations and tool_durations[0][0] < cutoff:
                 tool_durations.popleft()
+
+        while (
+            self.broker_operations
+            and self.broker_operations[0]["timestamp"] < cutoff
+        ):
+            self.broker_operations.popleft()
+
+    @staticmethod
+    def _empty_health_bucket() -> dict[str, Any]:
+        return {
+            "status": "healthy",
+            "success_count": 0,
+            "error_count": 0,
+            "operations": {},
+            "failure_classes": {},
+            "last_error_type": None,
+            "last_error_at": None,
+        }
+
+    @staticmethod
+    def _update_health_bucket(bucket: dict[str, Any], sample: dict[str, Any]) -> None:
+        operation = str(sample["operation"])
+        bucket["operations"][operation] = bucket["operations"].get(operation, 0) + 1
+
+        if sample["success"]:
+            bucket["success_count"] += 1
+        else:
+            bucket["error_count"] += 1
+            bucket["last_error_type"] = sample["error_type"]
+            bucket["last_error_at"] = sample["timestamp"].isoformat()
+            failure_class = sample["failure_class"] or "broker_api"
+            bucket["failure_classes"][failure_class] = (
+                bucket["failure_classes"].get(failure_class, 0) + 1
+            )
+
+    @staticmethod
+    def _finalize_health_bucket(bucket: dict[str, Any]) -> None:
+        if bucket["error_count"] == 0:
+            bucket["status"] = "healthy"
+        elif bucket["success_count"] > 0:
+            bucket["status"] = "degraded"
+        else:
+            bucket["status"] = "unhealthy"
+
+    def get_broker_health_summary(self) -> dict[str, Any]:
+        """Return broker and account health summaries for recent operations."""
+        now = datetime.now()
+        self._clean_old_entries(now)
+
+        broker_health: dict[str, dict[str, Any]] = {}
+        account_health: dict[str, dict[str, dict[str, Any]]] = {}
+
+        for sample in self.broker_operations:
+            broker = str(sample["broker"])
+            account_id = str(sample["account_id"] or "default")
+
+            broker_bucket = broker_health.setdefault(
+                broker, self._empty_health_bucket()
+            )
+            account_bucket = account_health.setdefault(broker, {}).setdefault(
+                account_id, self._empty_health_bucket()
+            )
+
+            self._update_health_bucket(broker_bucket, sample)
+            self._update_health_bucket(account_bucket, sample)
+
+        for bucket in broker_health.values():
+            self._finalize_health_bucket(bucket)
+
+        for broker_accounts in account_health.values():
+            for bucket in broker_accounts.values():
+                self._finalize_health_bucket(bucket)
+
+        return {
+            "broker_health": broker_health,
+            "account_health": account_health,
+        }
 
     @staticmethod
     def _percentile(samples: list[float], quantile: float) -> float:
@@ -224,6 +353,7 @@ class MetricsCollector:
                 "cache_hits": dict(self.cache_hits),
                 "cache_misses": dict(self.cache_misses),
                 "cache_hit_rate_percent": cache_hit_rate,
+                **self.get_broker_health_summary(),
                 "timestamp": now.isoformat(),
             }
 

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -312,9 +312,12 @@ def create_http_server(
         """Health check endpoint"""
         try:
             _require_session_manager()
-            _require_metrics_collector()
+            metrics_collector = _require_metrics_collector()
             health_service = get_health_service()
             health_status = await health_service.get_status()
+            metrics = await metrics_collector.get_metrics()
+            broker_health = metrics.get("broker_health", {})
+            account_health = metrics.get("account_health", {})
 
             # The health service snapshot provides status, components, and timestamp.
             # We preserve HTTP metadata: version and transport.
@@ -325,6 +328,8 @@ def create_http_server(
                 "timestamp": health_status.get("timestamp", time.time()),
                 "version": __version__,
                 "transport": "http",
+                "broker_health": broker_health,
+                "account_health": account_health,
             }
         except HTTPException:
             raise

--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -44,6 +44,14 @@ async def get_broker_status_data() -> dict[str, Any]:
         registry = await get_broker_registry()
         auth_status = registry.get_auth_status()
         available_brokers = registry.get_available_brokers()
+        broker_health = {}
+        account_health = {}
+        get_broker_health = getattr(registry, "get_broker_health", None)
+        if callable(get_broker_health):
+            health_summary = get_broker_health()
+            if isinstance(health_summary, dict):
+                broker_health = health_summary.get("broker_health", {})
+                account_health = health_summary.get("account_health", {})
 
         return {
             "result": {
@@ -51,6 +59,8 @@ async def get_broker_status_data() -> dict[str, Any]:
                 "available_brokers": available_brokers,
                 "total_configured": len(registry.list_brokers()),
                 "total_authenticated": len(available_brokers),
+                "broker_health": broker_health,
+                "account_health": account_health,
                 "status": "success",
             }
         }
@@ -126,10 +136,13 @@ async def get_metrics_summary_data() -> dict[str, Any]:
 async def get_health_check_data() -> dict[str, Any]:
     """Return health status of the MCP server."""
     health_status = await get_health_service().get_status()
+    metrics = await get_metrics_collector().get_metrics()
     return {
         "result": {
             **health_status,
             "circuit_breaker": get_broker_circuit_breaker().snapshot(),
+            "broker_health": metrics.get("broker_health", {}),
+            "account_health": metrics.get("account_health", {}),
             "health_status": health_status["status"],
             "status": "success",
         }

--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -36,13 +36,22 @@ class RateLimiter:
         self.endpoint_buckets: dict[str, deque[float]] = defaultdict(
             lambda: deque(maxlen=100)
         )
+        self.broker_buckets: dict[str, deque[float]] = defaultdict(
+            lambda: deque(maxlen=100)
+        )
 
-    async def acquire(self, endpoint: str | None = None, weight: float = 1.0) -> None:
+    async def acquire(
+        self,
+        endpoint: str | None = None,
+        weight: float = 1.0,
+        broker: str | None = None,
+    ) -> None:
         """Acquire permission to make an API call.
 
         Args:
             endpoint: Optional endpoint identifier for per-endpoint limiting
             weight: Weight of this call (some calls may count more)
+            broker: Optional broker identifier for per-broker telemetry
         """
         async with self._lock:
             now = time.time()
@@ -103,6 +112,19 @@ class RateLimiter:
             # Track per-endpoint if specified
             if endpoint:
                 self.endpoint_buckets[endpoint].append(now)
+            if broker:
+                self.broker_buckets[broker].append(now)
+
+    @staticmethod
+    def _bucket_stats(bucket: deque[float], now: float) -> dict[str, Any]:
+        cutoff_minute = now - 60
+        cutoff_hour = now - 3600
+        calls_last_minute = sum(1 for t in bucket if t > cutoff_minute)
+        calls_last_hour = sum(1 for t in bucket if t > cutoff_hour)
+        return {
+            "calls_last_minute": calls_last_minute,
+            "calls_last_hour": calls_last_hour,
+        }
 
     def get_stats(self) -> dict[str, Any]:
         """Get current rate limiter statistics.
@@ -117,6 +139,14 @@ class RateLimiter:
 
         calls_last_minute = sum(1 for t in self.call_times if t > cutoff_minute)
         calls_last_hour = len(self.call_times)
+        endpoint_usage = {
+            endpoint: self._bucket_stats(bucket, now)
+            for endpoint, bucket in self.endpoint_buckets.items()
+        }
+        broker_usage = {
+            broker: self._bucket_stats(bucket, now)
+            for broker, bucket in self.broker_buckets.items()
+        }
 
         return {
             "calls_last_minute": calls_last_minute,
@@ -126,6 +156,8 @@ class RateLimiter:
             "burst_size": self.burst_size,
             "minute_usage_percent": (calls_last_minute / self.calls_per_minute) * 100,
             "hour_usage_percent": (calls_last_hour / self.calls_per_hour) * 100,
+            "endpoint_usage": endpoint_usage,
+            "broker_usage": broker_usage,
         }
 
 

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -2,9 +2,14 @@
 
 import asyncio
 import functools
+import inspect
 from collections.abc import Callable
 from typing import Any
 
+from open_stocks_mcp.brokers.registry import (
+    RegistryNotInitializedError,
+    get_broker_registry_sync,
+)
 from open_stocks_mcp.config import load_config
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.exceptions import (
@@ -13,6 +18,30 @@ from open_stocks_mcp.tools.exceptions import (
     DataError,
     classify_error,
 )
+
+
+async def _refresh_session_with_registry_guard(
+    session_manager: Any,
+    broker_name: str | None,
+    account_id: str | None,
+) -> bool:
+    """Refresh auth through the broker registry single-flight guard when present."""
+    async def refresh_call() -> Any:
+        result = session_manager.refresh_session()
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    try:
+        registry = get_broker_registry_sync()
+    except RegistryNotInitializedError:
+        return bool(await refresh_call())
+
+    return bool(
+        await registry.coordinate_auth_refresh(
+            broker_name or "robinhood", account_id or "default", refresh_call
+        )
+    )
 
 
 async def execute_with_retry(
@@ -24,6 +53,8 @@ async def execute_with_retry(
     handle_auth_errors: bool = True,
     rate_limit: bool = True,
     endpoint: str | None = None,
+    broker_name: str | None = "robinhood",
+    account_id: str | None = None,
     **kwargs: Any,
 ) -> Any:
     """Execute a function with retry logic for transient errors."""
@@ -91,7 +122,11 @@ async def execute_with_retry(
                     auth_retry_count += 1
 
                     try:
-                        success = await session_manager.refresh_session()
+                        success = await _refresh_session_with_registry_guard(
+                            session_manager,
+                            broker_name,
+                            account_id,
+                        )
                         if success:
                             logger.info(
                                 "Re-authentication successful, retrying request"

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -312,6 +312,37 @@ class TestHTTPEndpoints:
         assert "state" in data["circuit_breaker"]
         assert data["server"]["status"] == "running"
 
+    async def test_health_and_status_include_additive_broker_health(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """Broker/account health details should be additive to legacy fields."""
+        from open_stocks_mcp.monitoring import get_metrics_collector
+
+        collector = get_metrics_collector()
+        await collector.record_broker_operation(
+            broker="robinhood",
+            account_id="acct-1",
+            operation="quote",
+            duration=0.01,
+            success=True,
+        )
+
+        health_response = await http_client.get("/health")
+        assert health_response.status_code == 200
+        health_data = health_response.json()
+        assert health_data["status"] in {"healthy", "degraded", "unhealthy"}
+        assert health_data["broker_health"]["robinhood"]["status"] == "healthy"
+        assert health_data["account_health"]["robinhood"]["acct-1"]["status"] == (
+            "healthy"
+        )
+
+        status_response = await http_client.get("/status")
+        assert status_response.status_code == 200
+        status_data = status_response.json()
+        assert status_data["metrics"]["broker_health"]["robinhood"]["status"] == (
+            "healthy"
+        )
+
     async def test_list_tools_endpoint(self, http_client: httpx.AsyncClient) -> None:
         """Test tools listing endpoint"""
         response = await http_client.get("/tools")
@@ -491,7 +522,7 @@ class TestLiveHTTPServer:
                 assert response.status_code == 200
 
                 data = response.json()
-                assert data["status"] in {"healthy", "degraded"}
+                assert data["status"] in {"healthy", "degraded", "unhealthy"}
         finally:
             # Clean up
             server_task.cancel()

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -26,6 +26,7 @@ class TestServerApp:
         with (
             patch("open_stocks_mcp.server.app.load_config") as mock_config,
             patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
+            patch("open_stocks_mcp.server.app.setup_tracing"),
         ):
             mock_cfg = MagicMock()
             mock_cfg.otel.enabled = False
@@ -41,7 +42,10 @@ class TestServerApp:
         mock_config = MagicMock()
         mock_config.otel.enabled = False
 
-        with patch("open_stocks_mcp.server.app.setup_logging") as mock_logging:
+        with (
+            patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
+            patch("open_stocks_mcp.server.app.setup_tracing"),
+        ):
             result = create_mcp_server(mock_config)
 
             assert result is mcp

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -189,10 +189,39 @@ class TestToolRegistration:
         }
         health_service = MagicMock()
         health_service.get_status = AsyncMock(return_value=expected_health)
+        metrics_collector = MagicMock()
+        metrics_collector.get_metrics = AsyncMock(
+            return_value={
+                "broker_health": {"robinhood": {"status": "healthy"}},
+                "account_health": {"robinhood:primary": {"status": "healthy"}},
+            }
+        )
+        circuit_breaker = MagicMock()
+        circuit_breaker.snapshot.return_value = {"state": "closed"}
 
-        with patch(
-            "open_stocks_mcp.server.app.get_health_service", return_value=health_service
+        with (
+            patch(
+                "open_stocks_mcp.server.tool_helpers.get_health_service",
+                return_value=health_service,
+            ),
+            patch(
+                "open_stocks_mcp.server.tool_helpers.get_metrics_collector",
+                return_value=metrics_collector,
+            ),
+            patch(
+                "open_stocks_mcp.server.tool_helpers.get_broker_circuit_breaker",
+                return_value=circuit_breaker,
+            ),
         ):
             result = await health_check()
 
-        assert result == {"result": expected_health}
+        assert result == {
+            "result": {
+                **expected_health,
+                "circuit_breaker": {"state": "closed"},
+                "broker_health": {"robinhood": {"status": "healthy"}},
+                "account_health": {"robinhood:primary": {"status": "healthy"}},
+                "health_status": "healthy",
+                "status": "success",
+            }
+        }

--- a/tests/server/test_tool_helpers.py
+++ b/tests/server/test_tool_helpers.py
@@ -48,6 +48,10 @@ class TestBrokerStatusHelper:
         fake_registry.get_auth_status.return_value = {"robinhood": "authenticated"}
         fake_registry.get_available_brokers.return_value = ["robinhood"]
         fake_registry.list_brokers.return_value = ["robinhood"]
+        fake_registry.get_broker_health.return_value = {
+            "broker_health": {"robinhood": {"status": "healthy"}},
+            "account_health": {"robinhood": {"default": {"status": "healthy"}}},
+        }
 
         async def fake_get_registry() -> MagicMock:
             return fake_registry
@@ -62,6 +66,7 @@ class TestBrokerStatusHelper:
         assert response["result"]["brokers"] == {"robinhood": "authenticated"}
         assert response["result"]["total_configured"] == 1
         assert response["result"]["total_authenticated"] == 1
+        assert response["result"]["broker_health"]["robinhood"]["status"] == "healthy"
 
     @pytest.mark.asyncio
     async def test_returns_error_when_registry_raises(self) -> None:
@@ -196,6 +201,8 @@ class TestHealthCheckHelper:
         assert response["result"]["status"] == "success"
         assert response["result"]["health_status"] == "degraded"
         assert "components" in response["result"]
+        assert "broker_health" in response["result"]
+        assert "account_health" in response["result"]
 
 
 @pytest.mark.journey_system

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -1,5 +1,6 @@
 """Unit tests for broker registry management."""
 
+import asyncio
 from datetime import datetime
 
 import pytest
@@ -11,6 +12,7 @@ from open_stocks_mcp.brokers.registry import (
     get_broker_registry,
     get_broker_registry_sync,
 )
+from open_stocks_mcp.monitoring import MetricsCollector
 
 
 class MockBroker(BaseBroker):
@@ -342,6 +344,85 @@ class TestBrokerRegistry:
         """Test setting active broker to non-existent name returns False."""
         result = registry.set_active_broker("nonexistent")
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_concurrent_operations_bound_fanout_and_isolate_timeout(
+        self, registry, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Concurrent broker execution should bound fan-out and isolate failures."""
+        monkeypatch.setattr(
+            "open_stocks_mcp.monitoring._metrics_collector", MetricsCollector()
+        )
+        active = 0
+        max_active = 0
+
+        async def tracked_result(value: str, delay: float = 0.01) -> dict[str, str]:
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            try:
+                await asyncio.sleep(delay)
+                return {"value": value}
+            finally:
+                active -= 1
+
+        operations = [
+            {
+                "broker": "robinhood",
+                "account_id": "acct-1",
+                "operation": "quote",
+                "call": lambda: tracked_result("rh"),
+            },
+            {
+                "broker": "schwab",
+                "account_id": "acct-2",
+                "operation": "quote",
+                "call": lambda: tracked_result("schwab", delay=0.2),
+            },
+            {
+                "broker": "robinhood",
+                "account_id": "acct-3",
+                "operation": "quote",
+                "call": lambda: tracked_result("rh-2"),
+            },
+        ]
+
+        results = await registry.run_concurrent_operations(
+            operations, concurrency_limit=2, timeout_seconds=0.05
+        )
+
+        assert max_active <= 2
+        assert len(results) == 3
+        assert results[0]["broker"] == "robinhood"
+        assert results[0]["account_id"] == "acct-1"
+        assert results[0]["operation"] == "quote"
+        assert results[0]["status"] == "success"
+        assert results[0]["result"] == {"value": "rh"}
+        assert results[1]["status"] == "timeout"
+        assert results[1]["error"]["failure_class"] == "timeout"
+        assert results[2]["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_auth_refresh_single_flight_is_per_broker_account(self, registry):
+        """Concurrent refreshes should coalesce per broker/account key."""
+        refresh_count = 0
+
+        async def refresh() -> bool:
+            nonlocal refresh_count
+            refresh_count += 1
+            await asyncio.sleep(0.01)
+            return True
+
+        tasks = [
+            registry.coordinate_auth_refresh("robinhood", "acct-1", refresh)
+            for _ in range(20)
+        ]
+        tasks.append(registry.coordinate_auth_refresh("robinhood", "acct-2", refresh))
+
+        results = await asyncio.gather(*tasks)
+
+        assert all(results)
+        assert refresh_count == 2
 
 
 class TestBrokerRegistrySingleton:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,7 +1,7 @@
 """Tests for configurable retry behavior and authentication error handling."""
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -9,11 +9,20 @@ import pytest
 from open_stocks_mcp.brokers.registry import BrokerRegistry
 from open_stocks_mcp.tools import rate_limiter, retry
 from open_stocks_mcp.tools import session_manager as session_manager_module
+from open_stocks_mcp.tools.circuit_breaker import reset_broker_circuit_breaker
 from open_stocks_mcp.tools.error_handling import (
     AuthenticationError,
     NetworkError,
     execute_with_retry,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_circuit_breaker() -> Generator[None, None, None]:
+    """Keep process-global circuit breaker state isolated between retry tests."""
+    reset_broker_circuit_breaker()
+    yield
+    reset_broker_circuit_breaker()
 
 
 def _patch_retry_dependencies(

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,10 +1,12 @@
 """Tests for configurable retry behavior and authentication error handling."""
 
+import asyncio
 from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from open_stocks_mcp.brokers.registry import BrokerRegistry
 from open_stocks_mcp.tools import rate_limiter, retry
 from open_stocks_mcp.tools import session_manager as session_manager_module
 from open_stocks_mcp.tools.error_handling import (
@@ -142,4 +144,49 @@ async def test_execute_with_retry_attempts_reauth_when_not_blocked() -> None:
     ):
         await execute_with_retry(auth_fail, max_retries=0)
 
+    mock_session_manager.refresh_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_coalesces_concurrent_auth_refreshes() -> None:
+    """A burst of auth failures should trigger one refresh for the account key."""
+    attempts = 0
+
+    async def auth_then_success() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 20:
+            raise Exception("authentication token expired")
+        return "ok"
+
+    registry = BrokerRegistry()
+    mock_session_manager = MagicMock()
+    mock_session_manager.should_block_auth_retries.return_value = False
+    mock_session_manager.update_last_successful_call = Mock()
+
+    async def refresh_session() -> bool:
+        await asyncio.sleep(0.01)
+        return True
+
+    mock_session_manager.refresh_session = AsyncMock(side_effect=refresh_session)
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.get_session_manager",
+            return_value=mock_session_manager,
+        ),
+        patch("open_stocks_mcp.tools.rate_limiter.get_rate_limiter", return_value=None),
+        patch(
+            "open_stocks_mcp.tools.retry.get_broker_registry_sync",
+            return_value=registry,
+        ),
+    ):
+        results = await asyncio.gather(
+            *[
+                execute_with_retry(auth_then_success, max_retries=0)
+                for _ in range(20)
+            ]
+        )
+
+    assert results == ["ok"] * 20
     mock_session_manager.refresh_session.assert_awaited_once()

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -127,3 +127,48 @@ async def test_get_metrics_cleans_stale_tool_samples() -> None:
     assert metrics["calls_in_window"] == 1
     assert metrics["tool_usage"]["new_tool"]["calls"] == 1
     assert metrics["tool_usage"]["old_tool"]["calls"] == 0
+
+
+@pytest.mark.asyncio
+async def test_broker_account_health_tracks_failure_classes() -> None:
+    collector = MetricsCollector()
+
+    await collector.record_broker_operation(
+        broker="robinhood",
+        account_id="acct-1",
+        operation="quote",
+        duration=0.02,
+        success=True,
+    )
+    await collector.record_broker_operation(
+        broker="schwab",
+        account_id="acct-2",
+        operation="orders",
+        duration=0.05,
+        success=False,
+        error_type="PoolTimeout",
+        failure_class="client_pool",
+    )
+    await collector.record_broker_operation(
+        broker="robinhood",
+        account_id="acct-1",
+        operation="positions",
+        duration=0.01,
+        success=False,
+        error_type="AuthenticationError",
+    )
+
+    metrics = await collector.get_metrics()
+
+    assert metrics["broker_health"]["robinhood"]["success_count"] == 1
+    assert metrics["broker_health"]["robinhood"]["error_count"] == 1
+    assert metrics["broker_health"]["robinhood"]["last_error_type"] == (
+        "AuthenticationError"
+    )
+    assert metrics["broker_health"]["robinhood"]["failure_classes"] == {
+        "authentication": 1
+    }
+    assert metrics["account_health"]["schwab"]["acct-2"]["status"] == "unhealthy"
+    assert metrics["account_health"]["schwab"]["acct-2"]["failure_classes"] == {
+        "client_pool": 1
+    }

--- a/tests/unit/test_simple_rate_limiter.py
+++ b/tests/unit/test_simple_rate_limiter.py
@@ -74,3 +74,28 @@ class TestSimpleRateLimiter:
 
         # Should have recorded the call
         assert len(limiter.call_times) == 1
+
+    @patch("open_stocks_mcp.tools.rate_limiter.time.time")
+    @patch("open_stocks_mcp.tools.rate_limiter.asyncio.sleep")
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_stats_includes_endpoint_and_broker_usage(
+        self, mock_sleep: Any, mock_time: Any
+    ) -> None:
+        """Endpoint and broker usage stats should be additive to legacy keys."""
+        mock_time.return_value = 1000.0
+        mock_sleep.return_value = None
+
+        limiter = RateLimiter(calls_per_minute=60)
+        await limiter.acquire(endpoint="/quotes", broker="robinhood")
+        await limiter.acquire(endpoint="/quotes", broker="robinhood")
+        await limiter.acquire(endpoint="/orders", broker="schwab")
+
+        stats = limiter.get_stats()
+
+        assert stats["calls_last_minute"] == 3
+        assert stats["endpoint_usage"]["/quotes"]["calls_last_minute"] == 2
+        assert stats["endpoint_usage"]["/orders"]["calls_last_minute"] == 1
+        assert stats["broker_usage"]["robinhood"]["calls_last_minute"] == 2
+        assert stats["broker_usage"]["schwab"]["calls_last_minute"] == 1


### PR DESCRIPTION
Closes #117

## Changes
- Add bounded concurrent broker operation execution with per-operation timeout, result isolation, and broker/account result metadata.
- Add per broker/account auth refresh single-flight coordination and route Robinhood auth retry refreshes through it when the registry is initialized.
- Add broker/account health telemetry, endpoint/broker rate-limit usage details, and additive health/status fields for HTTP and MCP helper surfaces.
- Add focused coverage for concurrent operation isolation, single-flight refresh, telemetry classification, rate-limit detail, and additive health responses.

## Test plan
- uv run pytest tests/unit/test_broker_registry.py tests/unit/test_error_handling.py tests/unit/test_monitoring.py tests/unit/test_simple_rate_limiter.py tests/server/test_tool_helpers.py tests/http_transport/test_http_server.py -q -k "concurrent or single_flight or auth_refresh or broker_health or account_health or endpoint_and_broker_usage or health_check or server_status or broker_status"
- uv run pytest tests/unit/test_broker_registry.py tests/unit/test_error_handling.py tests/unit/test_monitoring.py tests/unit/test_simple_rate_limiter.py tests/http_transport/test_http_server.py tests/server/test_server_app.py tests/server/test_tool_helpers.py -q
- uv run ruff check src/open_stocks_mcp/brokers/base.py src/open_stocks_mcp/brokers/registry.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_helpers.py src/open_stocks_mcp/server/app.py tests/unit/test_broker_registry.py tests/unit/test_error_handling.py tests/unit/test_monitoring.py tests/unit/test_simple_rate_limiter.py tests/http_transport/test_http_server.py tests/server/test_server_app.py tests/server/test_tool_helpers.py
- uv run mypy src/open_stocks_mcp/brokers/base.py src/open_stocks_mcp/brokers/registry.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_helpers.py src/open_stocks_mcp/server/app.py
- git diff --check