### PR TITLE
test: align schwab search eval args

### DIFF
--- a/tests/evals/2_mkt_schwab_search_instruments_test.json
+++ b/tests/evals/2_mkt_schwab_search_instruments_test.json
@@ -29,7 +29,7 @@
               {
                 "id": "adk-tool-use-id",
                 "args": {
-                  "query": "Apple"
+                  "query": "AAPL"
                 },
                 "name": "schwab_search_instruments"
               }


### PR DESCRIPTION
Closes #123

## Changes
- updated `tests/evals/2_mkt_schwab_search_instruments_test.json` to use `query: "AAPL"` for `schwab_search_instruments`
- left the existing Schwab price history eval file unchanged because it already matches the plan
- kept change scope to eval fixture content only

## Test plan
- `python3 -m json.tool tests/evals/2_mkt_schwab_price_history_test.json >/dev/null`
- `python3 -m json.tool tests/evals/2_mkt_schwab_search_instruments_test.json >/dev/null`
- `rg -n '"name": "schwab_price_history"|"name": "schwab_search_instruments"' tests/evals/2_mkt_schwab_price_history_test.json tests/evals/2_mkt_schwab_search_instruments_test.json`
- `adk eval examples/google_adk_agent tests/evals/2_mkt_schwab_price_history_test.json --config_file_path tests/evals/test_config.json` (fails in current env: MCP session connection/runtime error)
- `adk eval examples/google_adk_agent tests/evals/2_mkt_schwab_search_instruments_test.json --config_file_path tests/evals/test_config.json` (fails in current env: MCP session connection/runtime error)
- `git diff --check`