### PR TITLE
test: refine Schwab options ADK eval prompts and args

### DIFF
--- a/tests/evals/8_opt_schwab_option_chain_test.json
+++ b/tests/evals/8_opt_schwab_option_chain_test.json
@@ -1,7 +1,7 @@
 {
   "eval_set_id": "schwab_option_chain_test_set",
   "name": "Schwab Option Chain Test",
-  "description": "Test case for retrieving Schwab option chains through agent interaction",
+  "description": "Test case for retrieving the Schwab option chain for a symbol through agent interaction",
   "eval_cases": [
     {
       "eval_id": "schwab_option_chain_test",
@@ -11,7 +11,7 @@
           "user_content": {
             "parts": [
               {
-                "text": "Get the option chain for TSLA on Schwab with 5 strikes."
+                "text": "Show me the Schwab option chain for Apple (AAPL)."
               }
             ],
             "role": "user"
@@ -19,7 +19,7 @@
           "final_response": {
             "parts": [
               {
-                "text": "I have retrieved the option chain for TSLA from Schwab with 5 strikes."
+                "text": "I attempted to retrieve the Schwab option chain for Apple (AAPL). The option chain includes available call and put contracts across multiple expiration dates and strike prices. Note that Schwab authentication is required to access live option chain data."
               }
             ],
             "role": "model"
@@ -29,10 +29,7 @@
               {
                 "id": "adk-tool-use-id",
                 "args": {
-                  "symbol": "TSLA",
-                  "contract_type": "ALL",
-                  "strike_count": 5,
-                  "include_underlying_quote": true
+                  "symbol": "AAPL"
                 },
                 "name": "schwab_option_chain"
               }

--- a/tests/evals/8_opt_schwab_option_expirations_test.json
+++ b/tests/evals/8_opt_schwab_option_expirations_test.json
@@ -1,7 +1,7 @@
 {
   "eval_set_id": "schwab_option_expirations_test_set",
   "name": "Schwab Option Expirations Test",
-  "description": "Test case for retrieving Schwab option expirations through agent interaction",
+  "description": "Test case for retrieving available Schwab option expiration dates for a symbol through agent interaction",
   "eval_cases": [
     {
       "eval_id": "schwab_option_expirations_test",
@@ -11,7 +11,7 @@
           "user_content": {
             "parts": [
               {
-                "text": "When do options for TSLA expire on Schwab?"
+                "text": "What Schwab option expiration dates are available for Microsoft (MSFT)?"
               }
             ],
             "role": "user"
@@ -19,7 +19,7 @@
           "final_response": {
             "parts": [
               {
-                "text": "I have retrieved the option expiration dates for TSLA from Schwab."
+                "text": "I attempted to retrieve the available Schwab option expiration dates for Microsoft (MSFT). The expirations list shows the dates on which MSFT options contracts are available to trade. Note that Schwab authentication is required to access live expiration data."
               }
             ],
             "role": "model"
@@ -29,7 +29,7 @@
               {
                 "id": "adk-tool-use-id",
                 "args": {
-                  "symbol": "TSLA"
+                  "symbol": "MSFT"
                 },
                 "name": "schwab_option_expirations"
               }


### PR DESCRIPTION
Closes #124

## Changes
- Updated `tests/evals/8_opt_schwab_option_chain_test.json`: changed prompt to use AAPL, simplified `tool_uses` args to only `{"symbol": "AAPL"}` (removes implicit defaults not requested in prompt)
- Updated `tests/evals/8_opt_schwab_option_expirations_test.json`: changed prompt to use MSFT, consistent minimal args

Both files already existed on `main` from #104; this PR refines them to align with the implementation plan: simpler prompts, single required argument, and the plan-specified stock symbols (AAPL for chain, MSFT for expirations).

## Test plan
- [x] `python -m json.tool tests/evals/8_opt_schwab_option_chain_test.json` — valid JSON
- [x] `python -m json.tool tests/evals/8_opt_schwab_option_expirations_test.json` — valid JSON
- [x] `git diff --check` — no whitespace errors
- [ ] `adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_chain_test.json --config_file_path tests/evals/test_config.json` (requires Schwab auth + GOOGLE_API_KEY)
- [ ] `adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_expirations_test.json --config_file_path tests/evals/test_config.json` (requires Schwab auth + GOOGLE_API_KEY)