### PR TITLE
feat: add schwab transaction history tools

### DIFF
--- a/src/open_stocks_mcp/brokers/schwab.py
+++ b/src/open_stocks_mcp/brokers/schwab.py
@@ -1,5 +1,6 @@
 """Schwab broker implementation using schwab-py library."""
 
+import asyncio
 import os
 from datetime import datetime
 from pathlib import Path
@@ -304,5 +305,38 @@ class SchwabBroker(BaseBroker):
             "result": {
                 "error": "Not yet implemented in Schwab broker adapter",
                 "status": "not_implemented",
+            }
+        }
+
+    async def get_transactions(
+        self,
+        account_hash: str,
+        *,
+        start_date: Any = None,
+        end_date: Any = None,
+        transaction_types: list[str] | None = None,
+        symbol: str | None = None,
+    ) -> dict[str, Any]:
+        """Get Schwab transactions for an account with optional filters."""
+        if not self.is_available():
+            return self.create_unavailable_response("get_transactions")
+        if self.client is None:
+            return self.create_unavailable_response("get_transactions")
+
+        transactions = await asyncio.to_thread(
+            self.client.get_transactions,
+            account_hash,
+            start_date=start_date,
+            end_date=end_date,
+            transaction_types=transaction_types,
+            symbol=symbol,
+        )
+        if hasattr(transactions, "json"):
+            transactions = transactions.json()
+
+        return {
+            "result": {
+                "transactions": transactions,
+                "count": len(transactions) if isinstance(transactions, list) else 1,
             }
         }

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -156,6 +156,8 @@ from open_stocks_mcp.tools.schwab_trading_tools import (
     get_schwab_orders,
     schwab_buy_limit,
     schwab_buy_market,
+    schwab_get_transactions,
+    schwab_get_transactions_by_date,
     schwab_sell_limit,
     schwab_sell_market,
 )
@@ -1268,6 +1270,34 @@ async def schwab_get_order(account_hash: str, order_id: str) -> dict[str, Any]:
         order_id: Order ID to retrieve
     """
     return await get_schwab_order_by_id(account_hash, order_id)
+
+
+@mcp.tool()
+async def schwab_transactions(
+    account_hash: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    transaction_types: list[str] | None = None,
+    symbol: str | None = None,
+) -> dict[str, Any]:
+    """Get Schwab transactions with optional date/type/symbol filters."""
+    return await schwab_get_transactions(
+        account_hash, start_date, end_date, transaction_types, symbol
+    )
+
+
+@mcp.tool()
+async def schwab_transactions_by_date(
+    account_hash: str,
+    start_date: str,
+    end_date: str,
+    transaction_types: list[str] | None = None,
+    symbol: str | None = None,
+) -> dict[str, Any]:
+    """Get Schwab transactions constrained by required start and end dates."""
+    return await schwab_get_transactions_by_date(
+        account_hash, start_date, end_date, transaction_types, symbol
+    )
 
 
 # Schwab Options Tools

--- a/src/open_stocks_mcp/tools/schwab_trading_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_trading_tools.py
@@ -1,6 +1,7 @@
 """Schwab trading MCP tools using schwab-py library."""
 
 import asyncio
+import datetime
 from typing import Any
 
 from schwab.orders.equities import (
@@ -417,3 +418,66 @@ async def get_schwab_order_by_id(account_hash: str, order_id: str) -> dict[str, 
     except Exception as e:
         logger.error(f"Error getting Schwab order {order_id}: {e}")
         return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_transactions(
+    account_hash: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    transaction_types: list[str] | None = None,
+    symbol: str | None = None,
+) -> dict[str, Any]:
+    """Get transactions for a Schwab account with optional filters."""
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get transactions for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+        parsed_start_date = (
+            datetime.date.fromisoformat(start_date) if start_date is not None else None
+        )
+        parsed_end_date = (
+            datetime.date.fromisoformat(end_date) if end_date is not None else None
+        )
+
+        response = await asyncio.to_thread(
+            broker.client.get_transactions,
+            account_hash,
+            start_date=parsed_start_date,
+            end_date=parsed_end_date,
+            transaction_types=transaction_types,
+            symbol=symbol,
+        )
+        transactions_data = response.json() if hasattr(response, "json") else response
+        return create_success_response(
+            {
+                "transactions": transactions_data,
+                "count": len(transactions_data)
+                if isinstance(transactions_data, list)
+                else 1,
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error getting Schwab transactions: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_transactions_by_date(
+    account_hash: str,
+    start_date: str,
+    end_date: str,
+    transaction_types: list[str] | None = None,
+    symbol: str | None = None,
+) -> dict[str, Any]:
+    """Get transactions for a Schwab account within a required date range."""
+    return await schwab_get_transactions(
+        account_hash,
+        start_date=start_date,
+        end_date=end_date,
+        transaction_types=transaction_types,
+        symbol=symbol,
+    )

--- a/tests/unit/test_schwab_trading_tools.py
+++ b/tests/unit/test_schwab_trading_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for Schwab trading tools."""
 
+import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,6 +12,8 @@ from open_stocks_mcp.tools.schwab_trading_tools import (
     place_schwab_order,
     schwab_buy_limit,
     schwab_buy_market,
+    schwab_get_transactions,
+    schwab_get_transactions_by_date,
     schwab_sell_limit,
     schwab_sell_market,
 )
@@ -274,6 +277,133 @@ class TestSchwabTradingTools:
         assert "result" in result
         assert result["result"]["orderId"] == 12345
         assert result["result"]["status"] == "FILLED"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    async def test_get_transactions_success(
+        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test successful transactions retrieval."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_to_thread.return_value = [
+            {"transactionId": 1, "symbol": "AAPL"},
+            {"transactionId": 2, "symbol": "MSFT"},
+        ]
+
+        result = await schwab_get_transactions("abc123")
+
+        assert result["result"]["transactions"] == [
+            {"transactionId": 1, "symbol": "AAPL"},
+            {"transactionId": 2, "symbol": "MSFT"},
+        ]
+        assert result["result"]["count"] == 2
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    async def test_get_transactions_empty(
+        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test empty transactions list."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_to_thread.return_value = []
+
+        result = await schwab_get_transactions("abc123")
+
+        assert result["result"]["transactions"] == []
+        assert result["result"]["count"] == 0
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_transactions_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test auth error passthrough for transactions."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        result = await schwab_get_transactions("abc123")
+        assert result == error_response
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    async def test_get_transactions_with_filters(
+        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test filters are passed through to Schwab client."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_to_thread.return_value = [{"transactionId": 1, "symbol": "AAPL"}]
+
+        await schwab_get_transactions(
+            "abc123",
+            start_date="2026-04-01",
+            end_date="2026-04-30",
+            transaction_types=["TRADE"],
+            symbol="AAPL",
+        )
+
+        call_args = mock_to_thread.call_args
+        assert call_args is not None
+        args, kwargs = call_args
+        assert args[0] is mock_broker.client.get_transactions
+        assert args[1] == "abc123"
+        assert kwargs["start_date"] == datetime.date(2026, 4, 1)
+        assert kwargs["end_date"] == datetime.date(2026, 4, 30)
+        assert kwargs["transaction_types"] == ["TRADE"]
+        assert kwargs["symbol"] == "AAPL"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    async def test_get_transactions_by_date_success(
+        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test date-scoped transactions retrieval."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_to_thread.return_value = [{"transactionId": 1}, {"transactionId": 2}]
+
+        result = await schwab_get_transactions_by_date(
+            "abc123", "2026-04-01", "2026-04-30"
+        )
+
+        assert result["result"]["transactions"] == [
+            {"transactionId": 1},
+            {"transactionId": 2},
+        ]
+        assert result["result"]["count"] == 2
+        call_args = mock_to_thread.call_args
+        assert call_args is not None
+        args, kwargs = call_args
+        assert args[0] is mock_broker.client.get_transactions
+        assert args[1] == "abc123"
+        assert kwargs["start_date"] == datetime.date(2026, 4, 1)
+        assert kwargs["end_date"] == datetime.date(2026, 4, 30)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit


### PR DESCRIPTION
Closes #130

## Changes
- add  with unavailable-guard and normalized transaction/count result shape
- add  and  trading tools with ISO date parsing and filter passthrough
- register new Schwab transaction tools in MCP server app
- add unit tests for success, empty, auth-error, filter passthrough, and date-range transaction retrieval paths

## Test plan
- uv run pytest tests/unit/test_schwab_trading_tools.py::TestSchwabTradingTools::test_get_transactions_success tests/unit/test_schwab_trading_tools.py::TestSchwabTradingTools::test_get_transactions_empty tests/unit/test_schwab_trading_tools.py::TestSchwabTradingTools::test_get_transactions_auth_error tests/unit/test_schwab_trading_tools.py::TestSchwabTradingTools::test_get_transactions_with_filters
- uv run pytest tests/unit/test_schwab_trading_tools.py::TestSchwabTradingTools::test_get_transactions_by_date_success
- uv run pytest tests/unit/test_schwab_trading_tools.py
- uv run pytest -m "journey_trading and unit"
- uv run ruff check src/open_stocks_mcp/brokers/schwab.py src/open_stocks_mcp/tools/schwab_trading_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_schwab_trading_tools.py
- uv run mypy src/open_stocks_mcp/tools/schwab_trading_tools.py src/open_stocks_mcp/brokers/schwab.py src/open_stocks_mcp/server/app.py