### PR TITLE
test: add live market integration harness with safety controls

### DIFF
--- a/tests/TRADING_TEST_SAFETY.md
+++ b/tests/TRADING_TEST_SAFETY.md
@@ -67,6 +67,53 @@ async def test_order_buy_market_api_error(mock_order):
     assert result["result"]["status"] == "error"
 ```
 
+## Live Market Integration Harness
+
+### Opt-In Invocation
+Live market tests are **skipped by default** in all local and CI runs.  To execute them:
+
+```bash
+OPEN_STOCKS_RUN_LIVE_MARKET=1 uv run pytest tests/integration -m live_market \
+    --run-live-market --maxfail=1
+```
+
+Both the `--run-live-market` CLI flag **and** the `OPEN_STOCKS_RUN_LIVE_MARKET=1`
+environment variable must be set simultaneously.  Either alone is insufficient.
+
+### Required Environment Variables
+| Variable | Purpose |
+|---|---|
+| `OPEN_STOCKS_RUN_LIVE_MARKET` | Set to `1` to allow live network calls |
+| `ROBINHOOD_USERNAME` | Robinhood account email |
+| `ROBINHOOD_PASSWORD` | Robinhood account password |
+
+### Read-Only Rule
+Live market tests **must only call read-only operations**.  The harness enforces this
+via `assert_live_market_read_only(tool_name)`, which raises `ValueError` for any tool
+name beginning with `order_` or `cancel_`.
+
+```python
+from tests.integration.live_market_harness import assert_live_market_read_only
+
+assert_live_market_read_only("get_stock_price")  # OK
+assert_live_market_read_only("order_buy_market")  # raises ValueError
+```
+
+### Expected Skip Behavior
+Without the opt-in flag and env var, running the validation command is safe:
+
+```bash
+uv run pytest tests/integration -m live_market --maxfail=1
+# All live_market tests are collected but skipped — no network or auth code runs
+```
+
+### Harness Helpers (`tests/integration/live_market_harness.py`)
+- `require_live_market_preflight(pytestconfig)` — call at the top of any live test to enforce opt-in + credential checks
+- `live_robinhood_session` — module-scoped pytest fixture that logs in and out of Robinhood
+- `assert_live_market_read_only(tool_name)` — guard that rejects `order_*` and `cancel_*` tool names
+
+---
+
 ## ✅ ALLOWED READ-ONLY TESTS
 
 These are safe because they only retrieve data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,11 @@ except ImportError:
 
 import pytest
 
+from tests.integration.live_market_harness import (
+    LIVE_MARKET_ENV_VAR,
+    LIVE_MARKET_SKIP_REASON,
+)
+
 RATE_LIMITED_SKIP_REASON = (
     "rate_limited test; set RUN_RATE_LIMITED=1 or pass '-m rate_limited' to enable"
 )
@@ -76,16 +81,36 @@ def pytest_configure(config: Any) -> None:
     )
 
 
-def pytest_collection_modifyitems(config: Any, items: list[Any]) -> None:
-    """Skip rate-limited tests unless the run explicitly opts into them."""
-    markexpr = config.option.markexpr or ""
-    if "rate_limited" in markexpr or os.environ.get("RUN_RATE_LIMITED"):
-        return
+def pytest_addoption(parser: Any) -> None:
+    """Register the --run-live-market CLI option."""
+    parser.addoption(
+        "--run-live-market",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable live-market tests. Also requires "
+            "OPEN_STOCKS_RUN_LIVE_MARKET=1 and valid Robinhood credentials."
+        ),
+    )
 
-    skip_rate_limited = pytest.mark.skip(reason=RATE_LIMITED_SKIP_REASON)
-    for item in items:
-        if list(item.iter_markers(name="rate_limited")):
-            item.add_marker(skip_rate_limited)
+
+def pytest_collection_modifyitems(config: Any, items: list[Any]) -> None:
+    """Skip rate-limited and live-market tests unless explicitly opted in."""
+    markexpr = config.option.markexpr or ""
+
+    if "rate_limited" not in markexpr and not os.environ.get("RUN_RATE_LIMITED"):
+        skip_rate_limited = pytest.mark.skip(reason=RATE_LIMITED_SKIP_REASON)
+        for item in items:
+            if list(item.iter_markers(name="rate_limited")):
+                item.add_marker(skip_rate_limited)
+
+    run_live = config.getoption("--run-live-market", default=False)
+    env_live = bool(os.environ.get(LIVE_MARKET_ENV_VAR))
+    if not (run_live and env_live):
+        skip_live = pytest.mark.skip(reason=LIVE_MARKET_SKIP_REASON)
+        for item in items:
+            if list(item.iter_markers(name="live_market")):
+                item.add_marker(skip_live)
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,3 @@
+"""Integration test configuration: register live_market_harness fixtures."""
+
+pytest_plugins = ["tests.integration.live_market_harness"]

--- a/tests/integration/live_market_harness.py
+++ b/tests/integration/live_market_harness.py
@@ -1,0 +1,87 @@
+"""Live market test harness: opt-in controls, credential preflight, and safety guards.
+
+Live tests require both the --run-live-market CLI flag and the OPEN_STOCKS_RUN_LIVE_MARKET=1
+environment variable.  Credentials (ROBINHOOD_USERNAME, ROBINHOOD_PASSWORD) must also be
+present before any broker session or network call is attempted.
+
+Usage:
+    OPEN_STOCKS_RUN_LIVE_MARKET=1 uv run pytest tests/integration -m live_market \\
+        --run-live-market --maxfail=1
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+LIVE_MARKET_ENV_VAR = "OPEN_STOCKS_RUN_LIVE_MARKET"
+
+LIVE_MARKET_SKIP_REASON = (
+    "live_market test; set OPEN_STOCKS_RUN_LIVE_MARKET=1 and pass "
+    "--run-live-market to enable"
+)
+_CRED_SKIP_REASON = (
+    "live_market test requires ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD"
+)
+
+_PROHIBITED_PREFIXES = ("order_", "cancel_")
+
+
+def require_live_market_preflight(pytestconfig: Any) -> None:
+    """Skip the calling test unless the live-market opt-in is fully satisfied.
+
+    Checks (in order):
+    1. --run-live-market CLI flag is set.
+    2. OPEN_STOCKS_RUN_LIVE_MARKET env var is set to a truthy value.
+    3. ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD are both present.
+
+    Raises pytest.skip.Exception if any condition is not met.
+    """
+    if not pytestconfig.getoption("--run-live-market", default=False):
+        pytest.skip(LIVE_MARKET_SKIP_REASON)
+
+    if not os.environ.get(LIVE_MARKET_ENV_VAR):
+        pytest.skip(LIVE_MARKET_SKIP_REASON)
+
+    username = os.environ.get("ROBINHOOD_USERNAME")
+    password = os.environ.get("ROBINHOOD_PASSWORD")
+    if not username or not password:
+        pytest.skip(_CRED_SKIP_REASON)
+
+
+def assert_live_market_read_only(tool_name: str) -> None:
+    """Raise ValueError if tool_name is a prohibited trading or cancellation helper.
+
+    Trading and cancellation tools are financially unsafe in automated tests.
+    Any tool name beginning with ``order_`` or ``cancel_`` is rejected.
+    """
+    for prefix in _PROHIBITED_PREFIXES:
+        if tool_name.startswith(prefix):
+            raise ValueError(
+                f"Live market tests may not call '{tool_name}': "
+                f"tools beginning with '{prefix}' are prohibited in automated runs. "
+                "Use manual testing only for order placement and cancellation."
+            )
+
+
+@pytest.fixture(scope="module")
+def live_robinhood_session(request: Any) -> Any:  # type: ignore[misc]
+    """Module-scoped fixture that opens a real Robinhood session.
+
+    Skips the test module when the live-market opt-in is absent or credentials
+    are missing.  Logs out automatically after all tests in the module complete.
+    """
+    require_live_market_preflight(request.config)
+
+    username = os.environ["ROBINHOOD_USERNAME"]
+    password = os.environ["ROBINHOOD_PASSWORD"]
+
+    import robin_stocks.robinhood as rh
+
+    login_result = rh.login(username, password)
+    if not login_result:
+        pytest.skip("Robinhood login failed — check credentials")
+
+    yield
+
+    rh.logout()

--- a/tests/integration/test_live_market_entrypoint.py
+++ b/tests/integration/test_live_market_entrypoint.py
@@ -1,0 +1,30 @@
+"""Read-only live market entrypoint test.
+
+This module provides the first live-market integration test using a low-risk
+market-data call.  It requires explicit opt-in (see live_market_harness.py).
+"""
+
+import pytest
+
+from tests.integration.live_market_harness import (
+    assert_live_market_read_only,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_market_data
+def test_get_stock_price_aapl(live_robinhood_session: object) -> None:
+    """Verify that get_stock_price('AAPL') returns a result dict over a live session."""
+    import asyncio
+
+    assert_live_market_read_only("get_stock_price")
+
+    from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+
+    result = asyncio.get_event_loop().run_until_complete(get_stock_price("AAPL"))
+    assert isinstance(result, dict), "Response must be a dict"
+    assert "result" in result, "Response must contain a 'result' key"
+    assert isinstance(result["result"], dict), "'result' value must be a dict"

--- a/tests/integration/test_live_market_harness.py
+++ b/tests/integration/test_live_market_harness.py
@@ -1,0 +1,101 @@
+"""Tests for the live market harness preflight and safety helpers.
+
+These tests verify harness behavior without live network access or real credentials.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.integration.live_market_harness import (
+    LIVE_MARKET_ENV_VAR,
+    LIVE_MARKET_SKIP_REASON,
+    assert_live_market_read_only,
+    require_live_market_preflight,
+)
+
+
+class TestDefaultOptInRejection:
+    """Harness rejects live-market execution when opt-in is missing."""
+
+    def test_skips_without_run_live_market_flag(self) -> None:
+        """Skip when --run-live-market CLI flag is absent."""
+        config = MagicMock()
+        config.getoption.return_value = False
+        with pytest.raises(pytest.skip.Exception) as exc_info:
+            require_live_market_preflight(config)
+        assert "run-live-market" in str(exc_info.value).lower() or LIVE_MARKET_SKIP_REASON in str(exc_info.value)
+
+    def test_skips_without_env_var(self, monkeypatch: Any) -> None:
+        """Skip when OPEN_STOCKS_RUN_LIVE_MARKET env var is absent."""
+        monkeypatch.delenv(LIVE_MARKET_ENV_VAR, raising=False)
+        config = MagicMock()
+        config.getoption.return_value = True
+        with pytest.raises(pytest.skip.Exception):
+            require_live_market_preflight(config)
+
+    def test_skips_without_username(self, monkeypatch: Any) -> None:
+        """Skip when ROBINHOOD_USERNAME is absent."""
+        monkeypatch.setenv(LIVE_MARKET_ENV_VAR, "1")
+        monkeypatch.delenv("ROBINHOOD_USERNAME", raising=False)
+        monkeypatch.setenv("ROBINHOOD_PASSWORD", "secret")
+        config = MagicMock()
+        config.getoption.return_value = True
+        with pytest.raises(pytest.skip.Exception):
+            require_live_market_preflight(config)
+
+    def test_skips_without_password(self, monkeypatch: Any) -> None:
+        """Skip when ROBINHOOD_PASSWORD is absent."""
+        monkeypatch.setenv(LIVE_MARKET_ENV_VAR, "1")
+        monkeypatch.setenv("ROBINHOOD_USERNAME", "user@example.com")
+        monkeypatch.delenv("ROBINHOOD_PASSWORD", raising=False)
+        config = MagicMock()
+        config.getoption.return_value = True
+        with pytest.raises(pytest.skip.Exception):
+            require_live_market_preflight(config)
+
+
+class TestAcceptedPreflight:
+    """Harness proceeds when all opt-in conditions are satisfied."""
+
+    def test_passes_when_all_inputs_present(self, monkeypatch: Any) -> None:
+        """No skip raised when flag, env var, and credentials are all set."""
+        monkeypatch.setenv(LIVE_MARKET_ENV_VAR, "1")
+        monkeypatch.setenv("ROBINHOOD_USERNAME", "user@example.com")
+        monkeypatch.setenv("ROBINHOOD_PASSWORD", "secret")
+        config = MagicMock()
+        config.getoption.return_value = True
+        require_live_market_preflight(config)
+
+
+class TestReadOnlyGuard:
+    """assert_live_market_read_only blocks trading and cancellation tool names."""
+
+    def test_allows_read_only_tool(self) -> None:
+        """Read-only tool names pass without error."""
+        assert_live_market_read_only("get_stock_price")
+
+    def test_allows_get_prefix(self) -> None:
+        """Tools starting with get_ are safe."""
+        assert_live_market_read_only("get_positions")
+
+    def test_rejects_order_prefix(self) -> None:
+        """Tool names beginning with order_ are prohibited."""
+        with pytest.raises(ValueError, match="order_"):
+            assert_live_market_read_only("order_buy_market")
+
+    def test_rejects_cancel_prefix(self) -> None:
+        """Tool names beginning with cancel_ are prohibited."""
+        with pytest.raises(ValueError, match="cancel_"):
+            assert_live_market_read_only("cancel_stock_order")
+
+    def test_rejects_order_sell(self) -> None:
+        """order_sell_market is also prohibited."""
+        with pytest.raises(ValueError):
+            assert_live_market_read_only("order_sell_market")
+
+    def test_rejects_cancel_all(self) -> None:
+        """cancel_all_stock_orders is also prohibited."""
+        with pytest.raises(ValueError):
+            assert_live_market_read_only("cancel_all_stock_orders")


### PR DESCRIPTION
Closes #147

## Changes
- Add `tests/integration/live_market_harness.py` with `require_live_market_preflight()`, `live_robinhood_session` fixture, and `assert_live_market_read_only()` guard
- Add `tests/integration/conftest.py` registering the harness as a pytest plugin
- Add `tests/integration/test_live_market_harness.py` with 11 unit tests covering all preflight and safety behaviors (no live network calls)
- Add `tests/integration/test_live_market_entrypoint.py` with a read-only `live_market` test for `get_stock_price("AAPL")`
- Update `tests/conftest.py` with `--run-live-market` CLI option and `live_market` skip logic in `pytest_collection_modifyitems`
- Update `tests/TRADING_TEST_SAFETY.md` to document harness invocation, required env vars, read-only rule, and expected skip behavior

## Test plan
- `uv run pytest tests/integration/test_live_market_harness.py -q` → 11 passed, no credentials or network needed
- `uv run pytest tests/integration -m live_market --maxfail=1` → safely skips without opt-in (issue validation command)
- `uv run pytest tests/integration/test_live_market_entrypoint.py -m live_market --run-live-market --maxfail=1` → skips without `OPEN_STOCKS_RUN_LIVE_MARKET=1`
- `uv run ruff check src tests` → all checks passed