### PR TITLE
feat: centralize broker request timeout/retry configuration

### DIFF
--- a/src/open_stocks_mcp/brokers/request_policy.py
+++ b/src/open_stocks_mcp/brokers/request_policy.py
@@ -1,0 +1,117 @@
+import asyncio
+import functools
+import time
+from typing import Any, Callable, TypeVar
+
+from open_stocks_mcp.logging_config import logger
+
+T = TypeVar("T")
+
+def install_robinhood_request_timeout(timeout_seconds: float, session: Any | None = None) -> None:
+    """Idempotently install a timeout policy on a requests-like session.
+    
+    This wraps the session's request method to ensure every call uses the
+    centrally configured timeout, overriding any call-site defaults provided
+    by the SDK.
+    """
+    if session is None:
+        try:
+            from robin_stocks.robinhood import helper
+            session = helper.SESSION
+        except ImportError:
+            logger.warning("robin_stocks not installed; skipping Robinhood timeout policy installation")
+            return
+
+    # Check if already installed
+    if getattr(session.request, "_is_timeout_wrapper", False) is True:
+        session._robinhood_timeout = timeout_seconds
+        return
+
+    session._robinhood_timeout = timeout_seconds
+    original_request = session.request
+
+    @functools.wraps(original_request)
+    def timeout_wrapper(*args: Any, **kwargs: Any) -> Any:
+        kwargs["timeout"] = getattr(session, "_robinhood_timeout", 16.0)
+        return original_request(*args, **kwargs)
+
+    setattr(timeout_wrapper, "_is_timeout_wrapper", True)
+    session.request = timeout_wrapper
+    logger.debug(f"Installed Robinhood request timeout policy: {timeout_seconds}s")
+
+
+async def execute_broker_request(
+    func: Callable[..., T],
+    *args: Any,
+    policy: Any | None = None,
+    retry_safe: bool = True,
+    **kwargs: Any,
+) -> T:
+    """Execute a synchronous broker SDK call with optional retries and deadline enforcement.
+
+    Args:
+        func: The synchronous broker SDK function to call.
+        policy: Optional BrokerRequestConfig override.
+        retry_safe: Whether it's safe to retry this operation (True for reads, False for mutations).
+        *args, **kwargs: Arguments passed to the SDK function.
+    """
+    if policy is None:
+        from open_stocks_mcp.config import get_config
+
+        policy = get_config().broker_requests
+
+    # max_retries: int
+    # initial_delay: float
+    # backoff_factor: float
+    # deadline: float | None
+
+    max_retries = int(policy.retry_max_retries) if retry_safe else 0
+    initial_delay = float(policy.retry_initial_delay)
+    backoff_factor = float(policy.retry_backoff_factor)
+    deadline = policy.total_deadline_seconds
+    if deadline is not None:
+        deadline = float(deadline)
+
+    start_time = time.time()
+    last_exception = None
+
+    for attempt in range(max_retries + 1):
+        if deadline is not None:
+            elapsed = time.time() - start_time
+            if elapsed >= deadline:
+                if last_exception:
+                    raise last_exception
+                raise asyncio.TimeoutError(
+                    f"Broker request exceeded deadline of {deadline}s"
+                )
+
+        try:
+            # Run sync function in thread pool to avoid blocking the event loop
+            return await asyncio.to_thread(func, *args, **kwargs)
+        except Exception as e:
+            last_exception = e
+            if attempt == max_retries:
+                raise e
+
+            # Calculate delay for next retry
+            delay = initial_delay * (backoff_factor**attempt)
+
+            # Check if next attempt would likely exceed the deadline
+            if deadline is not None:
+                elapsed = time.time() - start_time
+                if elapsed + delay >= deadline:
+                    logger.warning(
+                        f"Stopping retries for {getattr(func, '__name__', 'unknown')}: next delay ({delay:.2f}s) "
+                        f"would exceed deadline budget ({deadline - elapsed:.2f}s remaining)"
+                    )
+                    raise e
+
+            logger.info(
+                f"Retrying {getattr(func, '__name__', 'unknown')} (attempt {attempt + 1}/{max_retries}) "
+                f"after {delay:.2f}s delay due to: {e}"
+            )
+            await asyncio.sleep(delay)
+
+    if last_exception:
+        raise last_exception
+    raise RuntimeError("Unreachable")

--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from typing import Any
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
+from open_stocks_mcp.brokers.request_policy import install_robinhood_request_timeout
+from open_stocks_mcp.config import get_config
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.session_manager import SessionManager
 
@@ -30,6 +32,10 @@ class RobinhoodBroker(BaseBroker):
             session_manager: Existing SessionManager instance (optional)
         """
         super().__init__("robinhood")
+
+        # Install request timeout policy
+        config = get_config()
+        install_robinhood_request_timeout(config.broker_requests.robinhood_timeout_seconds)
 
         # Use provided session manager or create new one
         self.session_manager = session_manager or SessionManager()

--- a/src/open_stocks_mcp/brokers/schwab.py
+++ b/src/open_stocks_mcp/brokers/schwab.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
+from open_stocks_mcp.config import get_config
 from open_stocks_mcp.logging_config import logger
 
 if TYPE_CHECKING:
@@ -140,6 +141,9 @@ class SchwabBroker(BaseBroker):
                     self.client = auth.client_from_token_file(
                         self.token_path, self.api_key, self.app_secret
                     )
+                    # Apply configured timeout
+                    assert self.client is not None
+                    self.client.set_timeout(get_config().broker_requests.schwab_timeout_seconds)
                     logger.info("✓ Schwab authentication successful (existing token)")
                     self._auth_info.status = BrokerAuthStatus.AUTHENTICATED
                     self._auth_info.last_successful_auth = datetime.now()
@@ -173,6 +177,9 @@ class SchwabBroker(BaseBroker):
                 callback_url=self.callback_url,
                 token_path=self.token_path,
             )
+            # Apply configured timeout
+            assert self.client is not None
+            self.client.set_timeout(get_config().broker_requests.schwab_timeout_seconds)
 
             self._auth_info.status = BrokerAuthStatus.AUTHENTICATED
             self._auth_info.last_successful_auth = datetime.now()

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -132,6 +132,18 @@ class CircuitBreakerConfig:
 
 
 @dataclass
+class BrokerRequestConfig:
+    """Configuration for broker-specific request policies."""
+
+    robinhood_timeout_seconds: float = 16.0
+    schwab_timeout_seconds: float = 30.0
+    retry_max_retries: int = 3
+    retry_initial_delay: float = 1.0
+    retry_backoff_factor: float = 2.0
+    total_deadline_seconds: float | None = None
+
+
+@dataclass
 class OtelConfig:
     """OpenTelemetry tracing configuration"""
 
@@ -151,6 +163,7 @@ class ServerConfig:
     retry: RetryConfig | None = None
     timeout: TimeoutConfig | None = None
     circuit_breaker: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
+    broker_requests: BrokerRequestConfig = field(default_factory=BrokerRequestConfig)
     otel: OtelConfig = field(default_factory=OtelConfig)
 
     def __post_init__(self) -> None:
@@ -212,6 +225,22 @@ def load_config() -> ServerConfig:
             cooldown_seconds=_env_float(
                 "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_COOLDOWN_SECONDS", 60.0
             ),
+        ),
+        broker_requests=BrokerRequestConfig(
+            robinhood_timeout_seconds=_env_float(
+                "OPEN_STOCKS_MCP_ROBINHOOD_REQUEST_TIMEOUT_SECONDS", 16.0
+            ),
+            schwab_timeout_seconds=_env_float(
+                "OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS", 30.0
+            ),
+            retry_max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", 3),
+            retry_initial_delay=_env_float("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY", 1.0),
+            retry_backoff_factor=_env_float("OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR", 2.0),
+            total_deadline_seconds=_env_float(
+                "OPEN_STOCKS_MCP_BROKER_REQUEST_TOTAL_DEADLINE_SECONDS", 45.0
+            )
+            if os.getenv("OPEN_STOCKS_MCP_BROKER_REQUEST_TOTAL_DEADLINE_SECONDS")
+            else None,
         ),
         otel=OtelConfig(
             enabled=otel_enabled,

--- a/src/open_stocks_mcp/tools/broker_utils.py
+++ b/src/open_stocks_mcp/tools/broker_utils.py
@@ -3,6 +3,9 @@
 from typing import Any
 
 from open_stocks_mcp.brokers.registry import get_broker_registry
+from open_stocks_mcp.brokers.request_policy import execute_broker_request
+
+__all__ = ["get_authenticated_broker_or_error", "execute_broker_request"]
 
 
 async def get_authenticated_broker_or_error(
@@ -11,4 +14,7 @@ async def get_authenticated_broker_or_error(
 ) -> tuple[Any, dict[str, Any] | None]:
     """Get an authenticated broker or return an error response tuple."""
     registry = await get_broker_registry()
-    return registry.get_broker_or_error(broker_name, operation)
+    result: tuple[Any, dict[str, Any] | None] = registry.get_broker_or_error(
+        broker_name, operation
+    )
+    return result

--- a/src/open_stocks_mcp/tools/schwab_account_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_account_tools.py
@@ -1,12 +1,14 @@
 """Schwab account-related MCP tools using schwab-py library."""
 
-import asyncio
 from typing import Any
 
 from schwab.client import Client
 
 from open_stocks_mcp.logging_config import logger
-from open_stocks_mcp.tools.broker_utils import get_authenticated_broker_or_error
+from open_stocks_mcp.tools.broker_utils import (
+    execute_broker_request,
+    get_authenticated_broker_or_error,
+)
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
@@ -35,7 +37,7 @@ async def get_schwab_account_numbers() -> dict[str, Any]:
             response = broker.client.get_account_numbers()
             return response.json()
 
-        result = await asyncio.to_thread(_get_account_numbers)
+        result = await execute_broker_request(_get_account_numbers, retry_safe=True)
 
         # Extract account hashes
         accounts = []
@@ -89,7 +91,7 @@ async def get_schwab_account(
             response = broker.client.get_account(account_hash, fields=fields)
             return response.json()
 
-        account_data = await asyncio.to_thread(_get_account)
+        account_data = await execute_broker_request(_get_account, retry_safe=True)
 
         return create_success_response(account_data)
 
@@ -125,7 +127,7 @@ async def get_schwab_accounts(include_positions: bool = True) -> dict[str, Any]:
             response = broker.client.get_accounts(fields=fields)
             return response.json()
 
-        accounts_data = await asyncio.to_thread(_get_accounts)
+        accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)
 
         return create_success_response(
             {
@@ -167,7 +169,7 @@ async def get_schwab_portfolio(account_hash: str) -> dict[str, Any]:
             )
             return response.json()
 
-        account_data = await asyncio.to_thread(_get_account)
+        account_data = await execute_broker_request(_get_account, retry_safe=True)
 
         # Extract positions
         securities_account = account_data.get("securitiesAccount", {})
@@ -224,7 +226,7 @@ async def get_schwab_account_balances(account_hash: str) -> dict[str, Any]:
             response = broker.client.get_account(account_hash)
             return response.json()
 
-        account_data = await asyncio.to_thread(_get_account)
+        account_data = await execute_broker_request(_get_account, retry_safe=True)
 
         # Extract balances
         securities_account = account_data.get("securitiesAccount", {})

--- a/src/open_stocks_mcp/tools/schwab_market_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_market_tools.py
@@ -1,12 +1,14 @@
 """Schwab market data MCP tools using schwab-py library."""
 
-import asyncio
 from typing import Any
 
 from schwab.client import Client
 
 from open_stocks_mcp.logging_config import logger
-from open_stocks_mcp.tools.broker_utils import get_authenticated_broker_or_error
+from open_stocks_mcp.tools.broker_utils import (
+    execute_broker_request,
+    get_authenticated_broker_or_error,
+)
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
@@ -36,7 +38,7 @@ async def get_schwab_quote(symbol: str) -> dict[str, Any]:
             response = broker.client.get_quote(symbol.upper())
             return response.json()
 
-        quote_data = await asyncio.to_thread(_get_quote)
+        quote_data = await execute_broker_request(_get_quote, retry_safe=True)
 
         # Extract quote from response
         quote = quote_data.get(symbol.upper(), {}).get("quote", {})
@@ -93,7 +95,7 @@ async def get_schwab_quotes(symbols: list[str]) -> dict[str, Any]:
             response = broker.client.get_quotes(symbols_upper)
             return response.json()
 
-        quotes_data = await asyncio.to_thread(_get_quotes)
+        quotes_data = await execute_broker_request(_get_quotes, retry_safe=True)
 
         # Format quotes
         quotes = {}
@@ -188,7 +190,7 @@ async def get_schwab_price_history(
             )
             return response.json()
 
-        history_data = await asyncio.to_thread(_get_price_history)
+        history_data = await execute_broker_request(_get_price_history, retry_safe=True)
 
         candles = history_data.get("candles", [])
 
@@ -228,7 +230,7 @@ async def get_schwab_instrument(symbol: str) -> dict[str, Any]:
             response = broker.client.get_quote(symbol.upper())
             return response.json()
 
-        quote_data = await asyncio.to_thread(_get_quote)
+        quote_data = await execute_broker_request(_get_quote, retry_safe=True)
 
         symbol_data = quote_data.get(symbol.upper(), {})
         reference = symbol_data.get("reference", {})
@@ -274,7 +276,7 @@ async def search_schwab_instruments(query: str) -> dict[str, Any]:
             response = broker.client.get_quote(query.upper())
             return response.json()
 
-        quote_data = await asyncio.to_thread(_get_quote)
+        quote_data = await execute_broker_request(_get_quote, retry_safe=True)
 
         results = []
         for symbol, data in quote_data.items():

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -1,6 +1,5 @@
 """Schwab options MCP tools using schwab-py library."""
 
-import asyncio
 from datetime import date
 from typing import Any
 
@@ -8,7 +7,10 @@ from schwab.client import Client
 from schwab.orders.options import option_buy_to_open_market, option_sell_to_close_market
 
 from open_stocks_mcp.logging_config import logger
-from open_stocks_mcp.tools.broker_utils import get_authenticated_broker_or_error
+from open_stocks_mcp.tools.broker_utils import (
+    execute_broker_request,
+    get_authenticated_broker_or_error,
+)
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
@@ -67,7 +69,7 @@ async def get_schwab_option_chain(
             )
             return response.json()
 
-        chain_data = await asyncio.to_thread(_get_option_chain)
+        chain_data = await execute_broker_request(_get_option_chain, retry_safe=True)
 
         return create_success_response(chain_data)
 
@@ -130,7 +132,7 @@ async def get_schwab_option_chain_by_expiration(
             )
             return response.json()
 
-        chain_data = await asyncio.to_thread(_get_option_chain)
+        chain_data = await execute_broker_request(_get_option_chain, retry_safe=True)
 
         return create_success_response(chain_data)
 
@@ -161,7 +163,7 @@ async def get_schwab_option_expirations(symbol: str) -> dict[str, Any]:
             response = broker.client.get_option_expiration_chain(symbol.upper())
             return response.json()
 
-        expiration_data = await asyncio.to_thread(_get_option_chain)
+        expiration_data = await execute_broker_request(_get_option_chain, retry_safe=True)
 
         # Extract expiration dates
         expirations = expiration_data.get("expirationList", [])
@@ -203,7 +205,7 @@ async def get_schwab_options_positions(account_hash: str) -> dict[str, Any]:
             )
             return response.json()
 
-        account_data = await asyncio.to_thread(_get_account)
+        account_data = await execute_broker_request(_get_account, retry_safe=True)
 
         # Extract options positions
         securities_account = account_data.get("securitiesAccount", {})
@@ -286,7 +288,7 @@ async def schwab_option_buy_to_open(
             response = broker.client.place_order(account_hash, order_spec)
             return response
 
-        response = await asyncio.to_thread(_place_order)
+        response = await execute_broker_request(_place_order, retry_safe=False)
 
         # Check response status
         if response.status_code in (200, 201):
@@ -358,7 +360,7 @@ async def schwab_option_sell_to_close(
             response = broker.client.place_order(account_hash, order_spec)
             return response
 
-        response = await asyncio.to_thread(_place_order)
+        response = await execute_broker_request(_place_order, retry_safe=False)
 
         # Check response status
         if response.status_code in (200, 201):

--- a/src/open_stocks_mcp/tools/schwab_trading_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_trading_tools.py
@@ -12,7 +12,10 @@ from schwab.orders.equities import (
 )
 
 from open_stocks_mcp.logging_config import logger
-from open_stocks_mcp.tools.broker_utils import get_authenticated_broker_or_error
+from open_stocks_mcp.tools.broker_utils import (
+    execute_broker_request,
+    get_authenticated_broker_or_error,
+)
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
@@ -45,7 +48,7 @@ async def place_schwab_order(
             response = broker.client.place_order(account_hash, order_spec)
             return response
 
-        response = await asyncio.to_thread(_place_order)
+        response = await execute_broker_request(_place_order, retry_safe=False)
 
         # Check response status
         if response.status_code in (200, 201):
@@ -100,7 +103,7 @@ async def schwab_buy_market(
             response = broker.client.place_order(account_hash, order_spec)
             return response
 
-        response = await asyncio.to_thread(_place_order)
+        response = await execute_broker_request(_place_order, retry_safe=False)
 
         # Check response status
         if response.status_code in (200, 201):
@@ -157,7 +160,7 @@ async def schwab_sell_market(
             response = broker.client.place_order(account_hash, order_spec)
             return response
 
-        response = await asyncio.to_thread(_place_order)
+        response = await execute_broker_request(_place_order, retry_safe=False)
 
         # Check response status
         if response.status_code in (200, 201):
@@ -215,7 +218,7 @@ async def schwab_buy_limit(
             response = broker.client.place_order(account_hash, order_spec)
             return response
 
-        response = await asyncio.to_thread(_place_order)
+        response = await execute_broker_request(_place_order, retry_safe=False)
 
         # Check response status
         if response.status_code in (200, 201):
@@ -274,7 +277,7 @@ async def schwab_sell_limit(
             response = broker.client.place_order(account_hash, order_spec)
             return response
 
-        response = await asyncio.to_thread(_place_order)
+        response = await execute_broker_request(_place_order, retry_safe=False)
 
         # Check response status
         if response.status_code in (200, 201):
@@ -329,7 +332,7 @@ async def get_schwab_orders(account_hash: str, max_results: int = 50) -> dict[st
             )
             return response.json()
 
-        orders_data = await asyncio.to_thread(_get_orders)
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
 
         return create_success_response(
             {
@@ -366,7 +369,7 @@ async def cancel_schwab_order(account_hash: str, order_id: str) -> dict[str, Any
             response = broker.client.cancel_order(order_id, account_hash)
             return response
 
-        response = await asyncio.to_thread(_cancel_order)
+        response = await execute_broker_request(_cancel_order, retry_safe=False)
 
         # Check response status
         if response.status_code in (200, 204):
@@ -411,7 +414,7 @@ async def get_schwab_order_by_id(account_hash: str, order_id: str) -> dict[str, 
             response = broker.client.get_order(order_id, account_hash)
             return response.json()
 
-        order_data = await asyncio.to_thread(_get_order)
+        order_data = await execute_broker_request(_get_order, retry_safe=True)
 
         return create_success_response(order_data)
 

--- a/tests/unit/test_broker_request_policy.py
+++ b/tests/unit/test_broker_request_policy.py
@@ -1,0 +1,121 @@
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+from open_stocks_mcp.brokers.request_policy import install_robinhood_request_timeout
+
+
+class TestBrokerRequestPolicy(unittest.TestCase):
+    def test_install_robinhood_request_timeout(self):
+        # Create a mock session that behaves like requests.Session
+        import requests
+        session = requests.Session()
+        # Mock the request method directly
+        mock_request = MagicMock(return_value=MagicMock())
+        session.request = mock_request
+        
+        # Configure timeout
+        timeout = 1.0
+        
+        # Install policy
+        install_robinhood_request_timeout(timeout, session=session)
+        
+        # Call session.request directly
+        session.request("GET", "https://example.test")
+        args, kwargs = mock_request.call_args
+        self.assertEqual(kwargs.get("timeout"), timeout)
+        
+        # Call session.get
+        session.get("https://example.test")
+        # requests.Session.get calls request(method='GET', ...)
+        args, kwargs = mock_request.call_args
+        self.assertEqual(kwargs.get("timeout"), timeout)
+        
+        # Call session.post with an explicit timeout (should be overridden)
+        session.post("https://example.test", timeout=16)
+        _, kwargs = mock_request.call_args
+        self.assertEqual(kwargs.get("timeout"), timeout)
+
+    def test_install_robinhood_request_timeout_idempotent(self):
+        import requests
+        session = requests.Session()
+        original_request = session.request
+        
+        timeout = 2.0
+        
+        # Install twice
+        install_robinhood_request_timeout(timeout, session=session)
+        wrapped_once = session.request
+        install_robinhood_request_timeout(timeout, session=session)
+        wrapped_twice = session.request
+        
+        # Should be the same wrapper
+        self.assertEqual(wrapped_once, wrapped_twice)
+        self.assertNotEqual(original_request, wrapped_once)
+        self.assertTrue(hasattr(session.request, "_is_timeout_wrapper"))
+
+@pytest.mark.asyncio
+async def test_execute_broker_request_retries():
+    from open_stocks_mcp.brokers.request_policy import execute_broker_request
+    from open_stocks_mcp.config import BrokerRequestConfig
+    
+    mock_func = MagicMock()
+    # Fail twice, succeed on third
+    mock_func.side_effect = [Exception("Transient error"), Exception("Transient error"), "Success"]
+    
+    policy = BrokerRequestConfig(
+        retry_max_retries=3,
+        retry_initial_delay=0.01,
+        retry_backoff_factor=1.0
+    )
+    
+    result = await execute_broker_request(mock_func, policy=policy, retry_safe=True)
+    
+    assert result == "Success"
+    assert mock_func.call_count == 3
+
+@pytest.mark.asyncio
+async def test_execute_broker_request_no_retry_unsafe():
+    from open_stocks_mcp.brokers.request_policy import execute_broker_request
+    from open_stocks_mcp.config import BrokerRequestConfig
+    
+    mock_func = MagicMock()
+    mock_func.side_effect = Exception("Mutation error")
+    
+    policy = BrokerRequestConfig(retry_max_retries=3)
+    
+    with pytest.raises(Exception, match="Mutation error"):
+        await execute_broker_request(mock_func, policy=policy, retry_safe=False)
+    
+    assert mock_func.call_count == 1
+
+@pytest.mark.asyncio
+async def test_execute_broker_request_deadline():
+    import time
+
+    from open_stocks_mcp.brokers.request_policy import execute_broker_request
+    from open_stocks_mcp.config import BrokerRequestConfig
+    
+    mock_func = MagicMock()
+    mock_func.side_effect = Exception("Timeout error")
+    
+    # Policy with 0.1s deadline
+    policy = BrokerRequestConfig(
+        retry_max_retries=10,
+        retry_initial_delay=0.05,
+        retry_backoff_factor=2.0,
+        total_deadline_seconds=0.1
+    )
+    
+    start_time = time.time()
+    with pytest.raises(Exception, match="Timeout error"):
+        await execute_broker_request(mock_func, policy=policy, retry_safe=True)
+    
+    elapsed = time.time() - start_time
+    # Should stop before second retry (0.05 delay + 0.1 next delay > 0.1 budget)
+    # Wait, 1st call at 0s. Failed. Delay 0.05s.
+    # 2nd call at 0.05s. Failed. Delay 0.1s.
+    # Total would be 0.15s which exceeds 0.1s.
+    assert mock_func.call_count <= 3 
+    assert elapsed < 0.2

--- a/tests/unit/test_schwab_account_tools.py
+++ b/tests/unit/test_schwab_account_tools.py
@@ -22,7 +22,7 @@ class TestSchwabAccountTools:
     @patch(
         "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_account_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     async def test_get_account_numbers_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -81,7 +81,7 @@ class TestSchwabAccountTools:
     @patch(
         "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_account_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_account_tools.Client")
     async def test_get_account_success(
         self,
@@ -121,7 +121,7 @@ class TestSchwabAccountTools:
     @patch(
         "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_account_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     async def test_get_accounts_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -159,7 +159,7 @@ class TestSchwabAccountTools:
     @patch(
         "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_account_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_account_tools.Client")
     async def test_get_portfolio_success(
         self,
@@ -212,7 +212,7 @@ class TestSchwabAccountTools:
     @patch(
         "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_account_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_account_tools.Client")
     async def test_get_account_balances_success(
         self,
@@ -254,7 +254,7 @@ class TestSchwabAccountTools:
     @patch(
         "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_account_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     async def test_get_account_numbers_error(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -277,7 +277,7 @@ class TestSchwabAccountTools:
     @patch(
         "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_account_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     @pytest.mark.parametrize(
         "function,args",
         [

--- a/tests/unit/test_schwab_broker.py
+++ b/tests/unit/test_schwab_broker.py
@@ -57,6 +57,7 @@ class TestSchwabBroker:
                 assert schwab_broker._auth_info.status == BrokerAuthStatus.AUTHENTICATED
                 assert schwab_broker.client == mock_client
                 mock_client_from_token.assert_called_once()
+                mock_client.set_timeout.assert_called_once_with(30.0)
         finally:
             if token_file.exists():
                 token_file.unlink()
@@ -85,6 +86,7 @@ class TestSchwabBroker:
                 callback_url=schwab_broker.callback_url,
                 token_path=schwab_broker.token_path,
             )
+            mock_client.set_timeout.assert_called_once_with(30.0)
 
     @pytest.mark.asyncio
     async def test_authenticate_failure(self, schwab_broker: SchwabBroker) -> None:
@@ -99,6 +101,25 @@ class TestSchwabBroker:
             assert result is False
             assert schwab_broker._auth_info.status == BrokerAuthStatus.AUTH_FAILED
             assert schwab_broker.client is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_custom_timeout(
+        self, schwab_broker: SchwabBroker
+    ) -> None:
+        """Test authentication with custom timeout from environment."""
+        with (
+            patch("schwab.auth.easy_client") as mock_easy_client,
+            patch("os.isatty", return_value=True),
+            patch.dict("os.environ", {"OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS": "2.5"}),
+            patch("open_stocks_mcp.config._global_config", None), # Reset config
+        ):
+            mock_client = MagicMock()
+            mock_easy_client.return_value = mock_client
+
+            result = await schwab_broker.authenticate()
+
+            assert result is True
+            mock_client.set_timeout.assert_called_once_with(2.5)
 
     @pytest.mark.asyncio
     async def test_is_authenticated_true(self, schwab_broker: SchwabBroker) -> None:

--- a/tests/unit/test_schwab_market_tools.py
+++ b/tests/unit/test_schwab_market_tools.py
@@ -22,7 +22,7 @@ class TestSchwabMarketTools:
     @patch(
         "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_market_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_get_quote_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -83,7 +83,7 @@ class TestSchwabMarketTools:
     @patch(
         "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_market_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_get_quotes_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -130,8 +130,8 @@ class TestSchwabMarketTools:
     @patch(
         "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_market_tools.asyncio.to_thread")
-    @patch("schwab.client.Client")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.Client")
     async def test_get_price_history_success(
         self,
         mock_client: MagicMock,
@@ -206,7 +206,7 @@ class TestSchwabMarketTools:
     @patch(
         "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_market_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_get_instrument_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -241,7 +241,7 @@ class TestSchwabMarketTools:
     @patch(
         "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_market_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_search_instruments_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -275,7 +275,7 @@ class TestSchwabMarketTools:
     @patch(
         "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_market_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_get_quote_error(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -298,7 +298,7 @@ class TestSchwabMarketTools:
     @patch(
         "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_market_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     @pytest.mark.parametrize(
         "function,args",
         [

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -14,6 +14,13 @@ from open_stocks_mcp.tools.schwab_options_tools import (
 )
 
 
+def _assert_retry_safe(mock_execute_broker_request: AsyncMock, expected: bool) -> None:
+    call_args = mock_execute_broker_request.call_args
+    assert call_args is not None
+    _, kwargs = call_args
+    assert kwargs.get("retry_safe") is expected
+
+
 class TestSchwabOptionsTools:
     """Test Schwab options tools with mocked responses."""
 
@@ -23,7 +30,7 @@ class TestSchwabOptionsTools:
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_options_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
     async def test_get_option_chain_success(
         self,
@@ -112,7 +119,7 @@ class TestSchwabOptionsTools:
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_options_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
     async def test_get_option_chain_by_expiration_success(
         self,
@@ -148,7 +155,7 @@ class TestSchwabOptionsTools:
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_options_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     async def test_get_option_expirations_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -179,7 +186,7 @@ class TestSchwabOptionsTools:
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_options_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
     async def test_get_options_positions_success(
         self,
@@ -243,7 +250,7 @@ class TestSchwabOptionsTools:
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_options_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_options_tools.option_buy_to_open_market")
     async def test_option_buy_to_open_success(
         self,
@@ -274,6 +281,7 @@ class TestSchwabOptionsTools:
         assert result["result"]["action"] == "buy_to_open"
         assert result["result"]["symbol"] == "AAPL"
         assert result["result"]["option_type"] == "CALL"
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_options
     @pytest.mark.unit
@@ -281,7 +289,7 @@ class TestSchwabOptionsTools:
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_options_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_options_tools.option_sell_to_close_market")
     async def test_option_sell_to_close_success(
         self,
@@ -312,6 +320,7 @@ class TestSchwabOptionsTools:
         assert result["result"]["action"] == "sell_to_close"
         assert result["result"]["symbol"] == "AAPL"
         assert result["result"]["option_type"] == "PUT"
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_options
     @pytest.mark.unit
@@ -320,7 +329,7 @@ class TestSchwabOptionsTools:
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_options_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
     async def test_get_option_chain_error(
         self,
@@ -350,7 +359,7 @@ class TestSchwabOptionsTools:
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_options_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @pytest.mark.parametrize(
         "function,args",
         [
@@ -383,3 +392,5 @@ class TestSchwabOptionsTools:
         result = await function(*args)
         assert result["result"]["status"] == "error"
         assert "API Error" in result["result"]["error"]
+        if function in {schwab_option_buy_to_open, schwab_option_sell_to_close}:
+            _assert_retry_safe(mock_to_thread, False)

--- a/tests/unit/test_schwab_trading_tools.py
+++ b/tests/unit/test_schwab_trading_tools.py
@@ -19,6 +19,13 @@ from open_stocks_mcp.tools.schwab_trading_tools import (
 )
 
 
+def _assert_retry_safe(mock_execute_broker_request: AsyncMock, expected: bool) -> None:
+    call_args = mock_execute_broker_request.call_args
+    assert call_args is not None
+    _, kwargs = call_args
+    assert kwargs.get("retry_safe") is expected
+
+
 class TestSchwabTradingTools:
     """Test Schwab trading tools with mocked responses."""
 
@@ -28,7 +35,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_trading_tools.equity_buy_market")
     async def test_buy_market_success(
         self,
@@ -58,6 +65,7 @@ class TestSchwabTradingTools:
         assert result["result"]["symbol"] == "AAPL"
         assert result["result"]["quantity"] == 10
         assert result["result"]["order_id"] == "12345"
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -81,7 +89,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_trading_tools.equity_sell_market")
     async def test_sell_market_success(
         self,
@@ -110,6 +118,7 @@ class TestSchwabTradingTools:
         assert result["result"]["action"] == "sell"
         assert result["result"]["symbol"] == "AAPL"
         assert result["result"]["order_id"] == "67890"
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -117,7 +126,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_trading_tools.equity_buy_limit")
     async def test_buy_limit_success(
         self,
@@ -145,6 +154,7 @@ class TestSchwabTradingTools:
         assert result["result"]["status"] == "order_placed"
         assert result["result"]["order_type"] == "limit"
         assert result["result"]["limit_price"] == 175.00
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -152,7 +162,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_trading_tools.equity_sell_limit")
     async def test_sell_limit_success(
         self,
@@ -180,6 +190,7 @@ class TestSchwabTradingTools:
         assert result["result"]["status"] == "order_placed"
         assert result["result"]["order_type"] == "limit"
         assert result["result"]["limit_price"] == 180.00
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -187,7 +198,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     async def test_get_orders_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -228,7 +239,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     async def test_cancel_order_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -247,6 +258,7 @@ class TestSchwabTradingTools:
         assert "result" in result
         assert result["result"]["status"] == "order_cancelled"
         assert result["result"]["order_id"] == "12345"
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -254,7 +266,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     async def test_get_order_by_id_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -411,7 +423,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     async def test_place_order_success(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -432,6 +444,7 @@ class TestSchwabTradingTools:
         assert "result" in result
         assert result["result"]["status"] == "order_placed"
         assert result["result"]["order_id"] == "99999"
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -439,7 +452,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_trading_tools.equity_buy_market")
     async def test_buy_market_api_failure(
         self,
@@ -466,6 +479,7 @@ class TestSchwabTradingTools:
         assert "result" in result
         assert result["result"]["status"] == "error"
         assert "Invalid order" in result["result"]["error"]
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -473,7 +487,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     async def test_cancel_order_api_failure(
         self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
     ) -> None:
@@ -493,6 +507,7 @@ class TestSchwabTradingTools:
         assert "result" in result
         assert result["result"]["status"] == "error"
         assert "Order not found" in result["result"]["error"]
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -501,7 +516,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_trading_tools.equity_buy_market")
     async def test_buy_market_error(
         self,
@@ -524,6 +539,7 @@ class TestSchwabTradingTools:
 
         assert "result" in result
         assert "error" in result["result"]
+        _assert_retry_safe(mock_to_thread, False)
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -531,7 +547,7 @@ class TestSchwabTradingTools:
     @patch(
         "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
     )
-    @patch("open_stocks_mcp.tools.schwab_trading_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
     @pytest.mark.parametrize(
         "function,args",
         [
@@ -559,3 +575,10 @@ class TestSchwabTradingTools:
         result = await function(*args)
         assert result["result"]["status"] == "error"
         assert "Internal Server Error" in result["result"]["error"]
+        if function in {
+            schwab_sell_market,
+            schwab_buy_limit,
+            schwab_sell_limit,
+            place_schwab_order,
+        }:
+            _assert_retry_safe(mock_to_thread, False)


### PR DESCRIPTION
Closes #143

## Changes
- Centralized timeout and retry configuration in `src/open_stocks_mcp/config.py`.
- Implemented `install_robinhood_request_timeout` in `src/open_stocks_mcp/brokers/request_policy.py` to monkeypatch `robin_stocks` session.
- Implemented `execute_broker_request` shared async executor with retry and deadline logic.
- Updated `RobinhoodBroker` and `SchwabBroker` to consume centralized timeout settings.
- Refactored all Schwab tools (`account`, `market`, `options`, `trading`) to use the shared executor.
- Ensured non-idempotent operations (orders, cancellations) do not retry.
- Added comprehensive unit tests for the new request policy logic.
- Updated existing Schwab tool tests to verify usage of the new executor.

## Test plan
- `uv run pytest tests/unit/test_broker_request_policy.py` - new policy tests.
- `uv run pytest tests/unit/test_schwab_*.py` - updated Schwab tests.
- Verified zero MyPy errors and Ruff linting passed.