### PR TITLE
feat: add broker-call circuit breaker protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ The `/metrics` endpoint exposes:
 - `open_stocks_mcp_tool_calls_per_minute` (gauge by tool)
 - `open_stocks_mcp_tool_latency_ms` (gauge by tool and quantile: `0.50`, `0.95`, `0.99`)
 
+### Operational Circuit Breaker Defaults
+
+Broker call protection is enabled by default and reports state in MCP `health_check`,
+MCP `rate_limit_status`, HTTP `/health`, and HTTP `/status`.
+
+- `OPEN_STOCKS_MCP_CIRCUIT_BREAKER_ENABLED` (default: `true`)
+- `OPEN_STOCKS_MCP_CIRCUIT_BREAKER_FAILURE_THRESHOLD` (default: `5`)
+- `OPEN_STOCKS_MCP_CIRCUIT_BREAKER_COOLDOWN_SECONDS` (default: `60`)
+
+State meanings:
+- `closed`: requests flow normally.
+- `open`: broker calls fail fast until cooldown expires.
+- `half_open`: one probe call is allowed; success resets to `closed`, failure returns to `open`.
+
 ## Docker Deployment
 
 **Production Docker Setup:**

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -123,6 +123,15 @@ class TimeoutConfig:
 
 
 @dataclass
+class CircuitBreakerConfig:
+    """Configuration for broker-call circuit breaker behavior."""
+
+    enabled: bool = True
+    failure_threshold: int = 5
+    cooldown_seconds: float = 60.0
+
+
+@dataclass
 class OtelConfig:
     """OpenTelemetry tracing configuration"""
 
@@ -141,6 +150,7 @@ class ServerConfig:
     cache: CacheConfig = field(default_factory=CacheConfig)
     retry: RetryConfig | None = None
     timeout: TimeoutConfig | None = None
+    circuit_breaker: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
     otel: OtelConfig = field(default_factory=OtelConfig)
 
     def __post_init__(self) -> None:
@@ -193,6 +203,15 @@ def load_config() -> ServerConfig:
             request_timeout_seconds=_env_float(
                 "OPEN_STOCKS_MCP_HTTP_REQUEST_TIMEOUT_SECONDS", 120.0
             )
+        ),
+        circuit_breaker=CircuitBreakerConfig(
+            enabled=_env_bool("OPEN_STOCKS_MCP_CIRCUIT_BREAKER_ENABLED", True),
+            failure_threshold=_env_int(
+                "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5
+            ),
+            cooldown_seconds=_env_float(
+                "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_COOLDOWN_SECONDS", 60.0
+            ),
         ),
         otel=OtelConfig(
             enabled=otel_enabled,

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -10,10 +10,10 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 from open_stocks_mcp.config import ServerConfig, load_config
-from open_stocks_mcp.health import get_health_service
 from open_stocks_mcp.logging_config import logger, setup_logging
 from open_stocks_mcp.server.tool_helpers import (
     get_broker_status_data,
+    get_health_check_data,
     get_list_brokers_data,
     get_list_tools_data,
     get_metrics_summary_data,
@@ -294,8 +294,7 @@ async def metrics_summary() -> dict[str, Any]:
 @mcp.tool()
 async def health_check() -> dict[str, Any]:
     """Gets health status of the MCP server."""
-    health_status = await get_health_service().get_status()
-    return {"result": health_status}
+    return await get_health_check_data()
 
 
 # Market Data Tools

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -19,6 +19,7 @@ from open_stocks_mcp.config import load_config
 from open_stocks_mcp.health import get_health_service
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.monitoring import get_metrics_collector
+from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 from open_stocks_mcp.tools.session_manager import get_session_manager
 
@@ -320,6 +321,7 @@ def create_http_server(
             return {
                 "status": health_status["status"],
                 "components": health_status["components"],
+                "circuit_breaker": get_broker_circuit_breaker().snapshot(),
                 "timestamp": health_status.get("timestamp", time.time()),
                 "version": __version__,
                 "transport": "http",
@@ -352,6 +354,7 @@ def create_http_server(
                 },
                 "session": session_info,
                 "rate_limiting": rate_stats,
+                "circuit_breaker": get_broker_circuit_breaker().snapshot(),
                 "metrics": metrics,
             }
         except HTTPException:

--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -13,6 +13,7 @@ from open_stocks_mcp.brokers.registry import get_broker_registry
 from open_stocks_mcp.health import get_health_service
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.monitoring import get_metrics_collector
+from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 from open_stocks_mcp.tools.robinhood_tools import list_available_tools
 from open_stocks_mcp.tools.session_manager import get_session_manager
@@ -28,7 +29,13 @@ async def get_session_status_data() -> dict[str, Any]:
     session_manager = get_session_manager()
     session_info = session_manager.get_session_info()
 
-    return {"result": {**session_info, "status": "success"}}
+    return {
+        "result": {
+            **session_info,
+            "circuit_breaker": get_broker_circuit_breaker().snapshot(),
+            "status": "success",
+        }
+    }
 
 
 async def get_broker_status_data() -> dict[str, Any]:
@@ -99,7 +106,13 @@ async def get_rate_limit_status_data() -> dict[str, Any]:
     rate_limiter = get_rate_limiter()
     stats = rate_limiter.get_stats()
 
-    return {"result": {**stats, "status": "success"}}
+    return {
+        "result": {
+            **stats,
+            "circuit_breaker": get_broker_circuit_breaker().snapshot(),
+            "status": "success",
+        }
+    }
 
 
 async def get_metrics_summary_data() -> dict[str, Any]:
@@ -113,4 +126,11 @@ async def get_metrics_summary_data() -> dict[str, Any]:
 async def get_health_check_data() -> dict[str, Any]:
     """Return health status of the MCP server."""
     health_status = await get_health_service().get_status()
-    return {"result": {**health_status, "health_status": health_status["status"], "status": "success"}}
+    return {
+        "result": {
+            **health_status,
+            "circuit_breaker": get_broker_circuit_breaker().snapshot(),
+            "health_status": health_status["status"],
+            "status": "success",
+        }
+    }

--- a/src/open_stocks_mcp/tools/circuit_breaker.py
+++ b/src/open_stocks_mcp/tools/circuit_breaker.py
@@ -1,0 +1,139 @@
+"""Circuit breaker protections around broker-call execution paths."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from open_stocks_mcp.config import get_config
+from open_stocks_mcp.tools.exceptions import CircuitBreakerError
+
+
+@dataclass
+class CircuitBreakerConfig:
+    """Circuit breaker runtime configuration."""
+
+    enabled: bool = True
+    failure_threshold: int = 5
+    cooldown_seconds: float = 60.0
+
+
+class BrokerCircuitBreaker:
+    """Asyncio-safe state machine for broker-call protections."""
+
+    def __init__(
+        self,
+        config: CircuitBreakerConfig,
+        *,
+        monotonic_fn: Any = None,
+        time_fn: Any = None,
+    ) -> None:
+        self._config = config
+        self._state = "closed"
+        self._failure_count = 0
+        self._opened_at: float | None = None
+        self._next_retry_at: float | None = None
+        self._half_open_probe_in_flight = False
+        self._lock = asyncio.Lock()
+        self._monotonic = monotonic_fn or time.monotonic
+        self._time = time_fn or time.time
+        self._next_retry_monotonic: float | None = None
+
+    async def before_request(self) -> None:
+        """Raise when breaker is open and cooldown has not elapsed."""
+        if not self._config.enabled:
+            return
+        async with self._lock:
+            now_m = float(self._monotonic())
+            if self._state == "open":
+                if (
+                    self._next_retry_monotonic is not None
+                    and now_m >= self._next_retry_monotonic
+                ):
+                    self._state = "half_open"
+                    self._half_open_probe_in_flight = False
+                else:
+                    raise CircuitBreakerError("Broker circuit breaker is open")
+
+            if self._state == "half_open":
+                if self._half_open_probe_in_flight:
+                    raise CircuitBreakerError("Broker circuit breaker is open")
+                self._half_open_probe_in_flight = True
+
+    async def record_success(self) -> None:
+        """Record successful execution and reset from open/half-open paths."""
+        if not self._config.enabled:
+            return
+        async with self._lock:
+            self._state = "closed"
+            self._failure_count = 0
+            self._opened_at = None
+            self._next_retry_at = None
+            self._next_retry_monotonic = None
+            self._half_open_probe_in_flight = False
+
+    async def record_failure(self, error_type: str) -> None:
+        """Record broker failure and trip the breaker when threshold is reached."""
+        if not self._config.enabled:
+            return
+        if error_type not in {"authentication", "network", "rate_limit", "api"}:
+            return
+        async with self._lock:
+            if self._state == "half_open":
+                self._open_locked()
+                return
+            if self._state == "open":
+                self._open_locked()
+                return
+
+            self._failure_count += 1
+            if self._failure_count >= self._config.failure_threshold:
+                self._open_locked()
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return breaker state for status and health surfaces."""
+        return {
+            "enabled": self._config.enabled,
+            "state": self._state,
+            "failure_count": self._failure_count,
+            "failure_threshold": self._config.failure_threshold,
+            "cooldown_seconds": self._config.cooldown_seconds,
+            "opened_at": self._opened_at,
+            "next_retry_at": self._next_retry_at,
+        }
+
+    def _open_locked(self) -> None:
+        now_wall = float(self._time())
+        now_m = float(self._monotonic())
+        self._state = "open"
+        self._failure_count = self._config.failure_threshold
+        self._opened_at = now_wall
+        self._next_retry_at = now_wall + self._config.cooldown_seconds
+        self._next_retry_monotonic = now_m + self._config.cooldown_seconds
+        self._half_open_probe_in_flight = False
+
+
+_breaker: BrokerCircuitBreaker | None = None
+
+
+def get_broker_circuit_breaker() -> BrokerCircuitBreaker:
+    """Get process-global broker circuit breaker."""
+    global _breaker
+    if _breaker is None:
+        cfg = get_config().circuit_breaker
+        _breaker = BrokerCircuitBreaker(
+            CircuitBreakerConfig(
+                enabled=cfg.enabled,
+                failure_threshold=cfg.failure_threshold,
+                cooldown_seconds=cfg.cooldown_seconds,
+            )
+        )
+    return _breaker
+
+
+def reset_broker_circuit_breaker() -> None:
+    """Reset process-global circuit breaker instance."""
+    global _breaker
+    _breaker = None

--- a/src/open_stocks_mcp/tools/error_handling.py
+++ b/src/open_stocks_mcp/tools/error_handling.py
@@ -7,6 +7,7 @@ across focused modules.
 from open_stocks_mcp.tools.exceptions import (
     APIError,
     AuthenticationError,
+    CircuitBreakerError,
     DataError,
     NetworkError,
     RateLimitError,
@@ -33,6 +34,7 @@ from open_stocks_mcp.tools.validation import (
 __all__ = [
     "APIError",
     "AuthenticationError",
+    "CircuitBreakerError",
     "DataError",
     "NetworkError",
     "RateLimitError",

--- a/src/open_stocks_mcp/tools/exceptions.py
+++ b/src/open_stocks_mcp/tools/exceptions.py
@@ -65,6 +65,17 @@ class APIError(RobinStocksError):
         super().__init__(message, "api", original_error)
 
 
+class CircuitBreakerError(RobinStocksError):
+    """Raised when circuit breaker blocks broker calls."""
+
+    def __init__(
+        self,
+        message: str = "Circuit breaker open",
+        original_error: Exception | None = None,
+    ):
+        super().__init__(message, "circuit_breaker", original_error)
+
+
 def classify_error(error: Exception) -> RobinStocksError:
     """Classify an exception into a specific Robin Stocks error type."""
     error_str = str(error).lower()

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -9,6 +9,7 @@ from open_stocks_mcp.config import load_config
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.exceptions import (
     AuthenticationError,
+    CircuitBreakerError,
     DataError,
     classify_error,
 )
@@ -26,6 +27,7 @@ async def execute_with_retry(
     **kwargs: Any,
 ) -> Any:
     """Execute a function with retry logic for transient errors."""
+    from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
     from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
     from open_stocks_mcp.tools.session_manager import get_session_manager
 
@@ -41,6 +43,7 @@ async def execute_with_retry(
         retry_config.backoff_factor if backoff_factor is None else backoff_factor
     )
     session_manager = get_session_manager()
+    circuit_breaker = get_broker_circuit_breaker()
     rate_limiter = get_rate_limiter() if rate_limit else None
     auth_retry_count = 0
     max_auth_retries = retry_config.auth_max_retries
@@ -48,6 +51,7 @@ async def execute_with_retry(
     attempt = 0
     while attempt <= configured_max_retries:
         try:
+            await circuit_breaker.before_request()
             if rate_limiter:
                 await rate_limiter.acquire(endpoint)
 
@@ -59,9 +63,12 @@ async def execute_with_retry(
                 result = await loop.run_in_executor(None, bound_func)
 
             session_manager.update_last_successful_call()
+            await circuit_breaker.record_success()
             return result
 
         except Exception as e:
+            if isinstance(e, CircuitBreakerError):
+                raise
             last_exception = e
             classified_error = classify_error(e)
             if max_retries is None:
@@ -91,12 +98,19 @@ async def execute_with_retry(
                             )
                             continue
                         logger.error("Re-authentication failed")
+                        await circuit_breaker.record_failure(
+                            classified_error.error_type
+                        )
                         raise classified_error
                     except Exception as reauth_error:
                         logger.error(f"Re-authentication error: {reauth_error}")
+                        await circuit_breaker.record_failure(
+                            classified_error.error_type
+                        )
                         raise classified_error from reauth_error
                 else:
                     logger.error(f"Authentication error after re-auth attempts: {e}")
+                    await circuit_breaker.record_failure(classified_error.error_type)
                     raise classified_error from e
 
             if isinstance(classified_error, DataError):
@@ -112,6 +126,7 @@ async def execute_with_retry(
                 attempt += 1
             else:
                 logger.error(f"All {configured_max_retries + 1} attempts failed: {e}")
+                await circuit_breaker.record_failure(classified_error.error_type)
                 raise classified_error from e
 
     if last_exception:

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -293,6 +293,8 @@ class TestHTTPEndpoints:
         assert data["status"] == "healthy"
         assert data["components"]["metrics"]["status"] == "healthy"
         assert data["components"]["metrics"]["detail"] == "monitoring disabled"
+        assert "circuit_breaker" in data
+        assert "state" in data["circuit_breaker"]
         assert data["version"] == __version__
         assert data["transport"] == "http"
         assert "timestamp" in data
@@ -306,6 +308,8 @@ class TestHTTPEndpoints:
         assert "server" in data
         assert "session" in data
         assert "rate_limiting" in data
+        assert "circuit_breaker" in data
+        assert "state" in data["circuit_breaker"]
         assert data["server"]["status"] == "running"
 
     async def test_list_tools_endpoint(self, http_client: httpx.AsyncClient) -> None:

--- a/tests/unit/test_analytics_tools.py
+++ b/tests/unit/test_analytics_tools.py
@@ -511,60 +511,67 @@ class TestServerMetrics:
         assert result["result"]["session_refreshes"] == 1
         assert result["result"]["status"] == "success"
 
-    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_broker_circuit_breaker")
+    @patch("open_stocks_mcp.server.tool_helpers.get_health_service")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_health_check_healthy(self, mock_get_metrics_collector: Any) -> None:
+    async def test_health_check_healthy(
+        self,
+        mock_get_health_service: Any,
+        mock_get_breaker: Any,
+    ) -> None:
         """Test health check with healthy status."""
         from open_stocks_mcp.server.app import health_check
 
-        mock_metrics_collector = AsyncMock()
-        mock_metrics_collector.get_health_status.return_value = {
-            "health_status": "healthy",
-            "issues": [],
-            "metrics_summary": {
-                "error_rate_percent": 1.5,
-                "avg_response_time_ms": 200.0,
-                "calls_last_hour": 100,
-            },
+        mock_health_service = AsyncMock()
+        mock_health_service.get_status.return_value = {
+            "status": "healthy",
+            "components": {},
+            "timestamp": 123.0,
         }
-        mock_get_metrics_collector.return_value = mock_metrics_collector
+        mock_get_health_service.return_value = mock_health_service
+        mock_get_breaker.return_value.snapshot.return_value = {
+            "state": "closed",
+            "failure_count": 0,
+        }
 
         result = await health_check()
 
         assert "result" in result
         assert result["result"]["status"] == "success"
         assert result["result"]["health_status"] == "healthy"
-        assert result["result"]["issues"] == []
-        assert result["result"]["metrics_summary"]["error_rate_percent"] == 1.5
-        assert result["result"]["metrics_summary"]["avg_response_time_ms"] == 200.0
+        assert result["result"]["circuit_breaker"]["state"] == "closed"
 
-    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_broker_circuit_breaker")
+    @patch("open_stocks_mcp.server.tool_helpers.get_health_service")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_health_check_degraded(self, mock_get_metrics_collector: Any) -> None:
+    async def test_health_check_degraded(
+        self,
+        mock_get_health_service: Any,
+        mock_get_breaker: Any,
+    ) -> None:
         """Test health check with degraded status."""
         from open_stocks_mcp.server.app import health_check
 
-        mock_metrics_collector = AsyncMock()
-        mock_metrics_collector.get_health_status.return_value = {
-            "health_status": "degraded",
-            "issues": ["High error rate: 15.0%", "Slow response times"],
-            "metrics_summary": {
-                "error_rate_percent": 15.0,
-                "avg_response_time_ms": 6000.0,
-                "calls_last_hour": 50,
-            },
+        mock_health_service = AsyncMock()
+        mock_health_service.get_status.return_value = {
+            "status": "degraded",
+            "components": {"session": {"status": "degraded"}},
+            "timestamp": 123.0,
         }
-        mock_get_metrics_collector.return_value = mock_metrics_collector
+        mock_get_health_service.return_value = mock_health_service
+        mock_get_breaker.return_value.snapshot.return_value = {
+            "state": "open",
+            "failure_count": 5,
+        }
 
         result = await health_check()
 
         assert "result" in result
         assert result["result"]["status"] == "success"
         assert result["result"]["health_status"] == "degraded"
-        assert "High error rate: 15.0%" in result["result"]["issues"]
-        assert "Slow response times" in result["result"]["issues"]
-        assert result["result"]["metrics_summary"]["error_rate_percent"] == 15.0
+        assert result["result"]["components"]["session"]["status"] == "degraded"
+        assert result["result"]["circuit_breaker"]["state"] == "open"

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -1,0 +1,128 @@
+"""Unit tests for broker-call circuit breaker behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.circuit_breaker import (
+    BrokerCircuitBreaker,
+    CircuitBreakerConfig,
+)
+from open_stocks_mcp.tools.error_handling import CircuitBreakerError, execute_with_retry
+from open_stocks_mcp.tools.exceptions import NetworkError
+
+
+@pytest.mark.asyncio
+async def test_breaker_trips_after_threshold_and_blocks() -> None:
+    state = {"mono": 100.0, "wall": 1_000.0}
+    breaker = BrokerCircuitBreaker(
+        CircuitBreakerConfig(enabled=True, failure_threshold=2, cooldown_seconds=5.0),
+        monotonic_fn=lambda: state["mono"],
+        time_fn=lambda: state["wall"],
+    )
+
+    await breaker.before_request()
+    await breaker.record_failure("network")
+    assert breaker.snapshot()["state"] == "closed"
+
+    await breaker.before_request()
+    await breaker.record_failure("network")
+    snap = breaker.snapshot()
+    assert snap["state"] == "open"
+    assert snap["failure_count"] == 2
+
+    with pytest.raises(CircuitBreakerError):
+        await breaker.before_request()
+
+
+@pytest.mark.asyncio
+async def test_half_open_probe_success_resets() -> None:
+    state = {"mono": 100.0, "wall": 1_000.0}
+    breaker = BrokerCircuitBreaker(
+        CircuitBreakerConfig(enabled=True, failure_threshold=1, cooldown_seconds=5.0),
+        monotonic_fn=lambda: state["mono"],
+        time_fn=lambda: state["wall"],
+    )
+    await breaker.before_request()
+    await breaker.record_failure("network")
+    state["mono"] += 6.0
+    state["wall"] += 6.0
+    await breaker.before_request()
+    await breaker.record_success()
+    assert breaker.snapshot()["state"] == "closed"
+    assert breaker.snapshot()["failure_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_half_open_probe_failure_reopens() -> None:
+    state = {"mono": 100.0, "wall": 1_000.0}
+    breaker = BrokerCircuitBreaker(
+        CircuitBreakerConfig(enabled=True, failure_threshold=1, cooldown_seconds=5.0),
+        monotonic_fn=lambda: state["mono"],
+        time_fn=lambda: state["wall"],
+    )
+    await breaker.before_request()
+    await breaker.record_failure("network")
+    state["mono"] += 6.0
+    state["wall"] += 6.0
+    await breaker.before_request()
+    await breaker.record_failure("network")
+    assert breaker.snapshot()["state"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_disabled_breaker_never_blocks() -> None:
+    breaker = BrokerCircuitBreaker(
+        CircuitBreakerConfig(enabled=False, failure_threshold=1, cooldown_seconds=1.0)
+    )
+    await breaker.before_request()
+    await breaker.record_failure("network")
+    await breaker.before_request()
+    assert breaker.snapshot()["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_records_failures_and_blocks_fast() -> None:
+    mock_session_manager = Mock()
+    mock_session_manager.update_last_successful_call = Mock()
+    mock_session_manager.should_block_auth_retries = Mock(return_value=False)
+    mock_session_manager.refresh_session = AsyncMock(return_value=False)
+
+    def always_fail() -> None:
+        raise RuntimeError("connection timeout")
+
+    shared_breaker = BrokerCircuitBreaker(
+        CircuitBreakerConfig(enabled=True, failure_threshold=1, cooldown_seconds=60.0),
+        monotonic_fn=lambda: 10.0,
+        time_fn=lambda: 100.0,
+    )
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.get_session_manager",
+            return_value=mock_session_manager,
+        ),
+        patch("open_stocks_mcp.tools.rate_limiter.get_rate_limiter", return_value=None),
+        patch(
+            "open_stocks_mcp.tools.circuit_breaker.get_broker_circuit_breaker",
+            return_value=shared_breaker,
+        ),
+        pytest.raises(NetworkError),
+    ):
+        await execute_with_retry(always_fail, max_retries=0)
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.get_session_manager",
+            return_value=mock_session_manager,
+        ),
+        patch("open_stocks_mcp.tools.rate_limiter.get_rate_limiter", return_value=None),
+        patch(
+            "open_stocks_mcp.tools.circuit_breaker.get_broker_circuit_breaker",
+            return_value=shared_breaker,
+        ),
+        pytest.raises(CircuitBreakerError),
+    ):
+        await execute_with_retry(always_fail, max_retries=0)

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -524,60 +524,59 @@ class TestServerTools:
 
     @pytest.mark.journey_system
     @pytest.mark.unit
-    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_broker_circuit_breaker")
+    @patch("open_stocks_mcp.server.tool_helpers.get_health_service")
     @pytest.mark.asyncio
-    async def test_health_check_success(self, mock_get_metrics_collector: Any) -> None:
+    async def test_health_check_success(
+        self, mock_get_health_service: Any, mock_get_breaker: Any
+    ) -> None:
         """Test successful health check."""
         from open_stocks_mcp.server.app import health_check
 
-        mock_metrics_collector = AsyncMock()
-        mock_metrics_collector.get_health_status.return_value = {
-            "health_status": "healthy",  # Different key to avoid status override
-            "issues": [],
-            "metrics_summary": {
-                "error_rate_percent": 1.5,
-                "avg_response_time_ms": 200.0,
-                "calls_last_hour": 100,
-            },
+        mock_health_service = AsyncMock()
+        mock_health_service.get_status.return_value = {
+            "status": "healthy",
+            "components": {"session": {"status": "healthy"}},
+            "timestamp": 123.0,
         }
-        mock_get_metrics_collector.return_value = mock_metrics_collector
+        mock_get_health_service.return_value = mock_health_service
+        mock_get_breaker.return_value.snapshot.return_value = {"state": "closed"}
 
         result = await health_check()
 
         assert "result" in result
-        assert result["result"]["status"] == "success"  # Server adds this status
+        assert result["result"]["status"] == "success"
         assert result["result"]["health_status"] == "healthy"
-        assert result["result"]["issues"] == []
-        assert result["result"]["metrics_summary"]["error_rate_percent"] == 1.5
-        assert result["result"]["metrics_summary"]["avg_response_time_ms"] == 200.0
+        assert result["result"]["components"]["session"]["status"] == "healthy"
+        assert result["result"]["circuit_breaker"]["state"] == "closed"
 
     @pytest.mark.journey_system
     @pytest.mark.unit
-    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
+    @patch("open_stocks_mcp.server.tool_helpers.get_broker_circuit_breaker")
+    @patch("open_stocks_mcp.server.tool_helpers.get_health_service")
     @pytest.mark.asyncio
-    async def test_health_check_degraded(self, mock_get_metrics_collector: Any) -> None:
+    async def test_health_check_degraded(
+        self, mock_get_health_service: Any, mock_get_breaker: Any
+    ) -> None:
         """Test health check with degraded status."""
         from open_stocks_mcp.server.app import health_check
 
-        mock_metrics_collector = AsyncMock()
-        mock_metrics_collector.get_health_status.return_value = {
-            "health_status": "degraded",  # Different key to avoid status override
-            "issues": ["High error rate: 15.0%"],
-            "metrics_summary": {
-                "error_rate_percent": 15.0,
-                "avg_response_time_ms": 6000.0,
-                "calls_last_hour": 50,
-            },
+        mock_health_service = AsyncMock()
+        mock_health_service.get_status.return_value = {
+            "status": "degraded",
+            "components": {"session": {"status": "degraded"}},
+            "timestamp": 123.0,
         }
-        mock_get_metrics_collector.return_value = mock_metrics_collector
+        mock_get_health_service.return_value = mock_health_service
+        mock_get_breaker.return_value.snapshot.return_value = {"state": "open"}
 
         result = await health_check()
 
         assert "result" in result
-        assert result["result"]["status"] == "success"  # Server adds this status
+        assert result["result"]["status"] == "success"
         assert result["result"]["health_status"] == "degraded"
-        assert "High error rate: 15.0%" in result["result"]["issues"]
-        assert result["result"]["metrics_summary"]["error_rate_percent"] == 15.0
+        assert result["result"]["components"]["session"]["status"] == "degraded"
+        assert result["result"]["circuit_breaker"]["state"] == "open"
 
 
 class TestAdvancedInstrumentTools:


### PR DESCRIPTION
Closes #145

## Changes
- add `BrokerCircuitBreaker` state machine with configurable enabled/threshold/cooldown defaults and process-global accessor
- integrate breaker checks into `execute_with_retry()` with fail-fast blocking, retry-exhausted failure accounting, and success reset behavior
- add `CircuitBreakerError` type and export it through the stable `error_handling` facade
- expose `circuit_breaker` state on MCP `session_status`/`rate_limit_status`/`health_check` and HTTP `/health` + `/status`
- document circuit-breaker defaults, overrides, and state semantics in `README.md`
- add unit and HTTP tests for breaker state transitions, retry integration, and health/status visibility

## Test plan
- `uv run pytest tests/unit/test_circuit_breaker.py -q`
- `uv run pytest tests/unit/test_analytics_tools.py tests/http_transport/test_http_server.py -k 'circuit or health_check or server_status' -q`
- `uv run pytest tests/unit -k 'circuit or rate_limit or session_manager or health_check' -q`
- `uv run ruff check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/circuit_breaker.py src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_helpers.py tests/unit/test_circuit_breaker.py tests/unit/test_analytics_tools.py tests/http_transport/test_http_server.py tests/unit/test_stock_market_tools.py`
- `uv run ruff format --check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/circuit_breaker.py src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_helpers.py tests/unit/test_circuit_breaker.py tests/unit/test_analytics_tools.py tests/http_transport/test_http_server.py tests/unit/test_stock_market_tools.py`
- `uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/circuit_breaker.py src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_helpers.py`
