### PR TITLE
feat: implement singleflight coalescing and bulk watchlist performance

### DIFF
--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -3,6 +3,7 @@
 import asyncio
 import time
 from collections import defaultdict, deque
+from collections.abc import Callable, Coroutine
 from typing import Any
 
 from open_stocks_mcp.logging_config import logger
@@ -153,8 +154,64 @@ class RateLimiter:
         }
 
 
+class RequestCoordinator:
+    """Asyncio-safe singleflight coordinator for deduplicating concurrent reads.
+
+    Callers that supply the same key while a request is already in-flight receive
+    the same result without triggering a second broker call. Mutating/trading paths
+    must NOT use a coalesce key so they are never deduplicated.
+    """
+
+    def __init__(self) -> None:
+        self._in_flight: dict[str, asyncio.Future[Any]] = {}
+        self._lock = asyncio.Lock()
+        self.coalesced_count: int = 0
+
+    async def execute(
+        self,
+        key: str,
+        coro_factory: Callable[[], Coroutine[Any, Any, Any]],
+    ) -> Any:
+        """Execute *coro_factory* unless a call with *key* is already in-flight.
+
+        When a duplicate key is detected the caller awaits the existing future
+        instead of launching a new coroutine, so the underlying broker call runs
+        only once regardless of how many concurrent callers arrive.
+        """
+        waiter: asyncio.Future[Any]
+        async with self._lock:
+            if key in self._in_flight:
+                self.coalesced_count += 1
+                waiter = self._in_flight[key]
+                is_new = False
+            else:
+                waiter = asyncio.get_running_loop().create_future()
+                self._in_flight[key] = waiter
+                is_new = True
+
+        if not is_new:
+            return await asyncio.shield(waiter)
+
+        try:
+            result = await coro_factory()
+            waiter.set_result(result)
+            return result
+        except BaseException as exc:
+            if isinstance(exc, asyncio.CancelledError):
+                waiter.cancel()
+            else:
+                waiter.set_exception(exc)
+            raise
+        finally:
+            async with self._lock:
+                self._in_flight.pop(key, None)
+
+
 # Global rate limiter instance
 _rate_limiter: RateLimiter | None = None
+
+# Global request coordinator instance
+_request_coordinator: RequestCoordinator | None = None
 
 
 def configure_global_rate_limiter(
@@ -193,6 +250,14 @@ def get_rate_limiter() -> RateLimiter:
             burst_size=5,  # Allow small bursts
         )
     return _rate_limiter
+
+
+def get_request_coordinator() -> RequestCoordinator:
+    """Get the global request coordinator instance."""
+    global _request_coordinator
+    if _request_coordinator is None:
+        _request_coordinator = RequestCoordinator()
+    return _request_coordinator
 
 
 async def rate_limited_call(

--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -201,6 +201,7 @@ class RequestCoordinator:
                 waiter.cancel()
             else:
                 waiter.set_exception(exc)
+                waiter.exception()
             raise
         finally:
             async with self._lock:

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -26,9 +26,39 @@ async def execute_with_retry(
     endpoint: str | None = None,
     broker_name: str = "robinhood",
     account_id: str | None = None,
+    coalesce_key: str | None = None,
     **kwargs: Any,
 ) -> Any:
-    """Execute a function with retry logic for transient errors."""
+    """Execute a function with retry logic for transient errors.
+
+    When *coalesce_key* is supplied the call is wrapped in a singleflight
+    coordinator: if an identical key is already in-flight the caller shares
+    that result instead of triggering a new broker call. Only supply a key for
+    read-only operations; never use it for mutating/trading calls.
+    """
+    if coalesce_key is not None:
+        from open_stocks_mcp.tools.rate_limiter import get_request_coordinator
+
+        coordinator = get_request_coordinator()
+
+        async def _call() -> Any:
+            return await execute_with_retry(
+                func,
+                *args,
+                max_retries=max_retries,
+                delay=delay,
+                backoff_factor=backoff_factor,
+                handle_auth_errors=handle_auth_errors,
+                rate_limit=rate_limit,
+                endpoint=endpoint,
+                broker_name=broker_name,
+                account_id=account_id,
+                coalesce_key=None,
+                **kwargs,
+            )
+
+        return await coordinator.execute(coalesce_key, _call)
+
     from open_stocks_mcp.brokers.registry import get_broker_registry
     from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
     from open_stocks_mcp.tools.rate_limiter import get_rate_limiter

--- a/src/open_stocks_mcp/tools/robinhood_stock_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_stock_tools.py
@@ -47,9 +47,16 @@ async def get_stock_price(symbol: str) -> dict[str, Any]:
     symbol = symbol.strip().upper()
     log_api_call("get_stock_price", symbol=symbol)
 
-    # Get latest price and quote data with retry logic
-    price_data = await execute_with_retry(rh.get_latest_price, symbol, "ask_price")
-    quote_data = await execute_with_retry(rh.get_quotes, symbol)
+    # Get latest price and quote data with retry logic; coalesce_key deduplicates
+    # concurrent calls for the same symbol while cache is cold.
+    price_data = await execute_with_retry(
+        rh.get_latest_price, symbol, "ask_price",
+        coalesce_key=f"get_latest_price:{symbol}",
+    )
+    quote_data = await execute_with_retry(
+        rh.get_quotes, symbol,
+        coalesce_key=f"get_quotes:{symbol}",
+    )
 
     if not price_data or not quote_data:
         return create_no_data_response(

--- a/src/open_stocks_mcp/tools/robinhood_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_watchlist_tools.py
@@ -454,45 +454,62 @@ async def get_watchlist_performance(watchlist_name: str) -> dict[str, Any]:
             }
         }
 
+    symbols_list = [s for s in symbols if isinstance(s, str)]
+
     # Get current prices for all symbols
-    performance_data = []
+    performance_data: list[dict[str, Any]] = []
     gainers = 0
     losers = 0
     unchanged = 0
     total_volume = 0
     total_change_percent = 0.0
 
-    for symbol in symbols:
-        try:
-            # Get current price data for symbol
-            price_data = await execute_with_retry(
-                func=rh.get_latest_price,
-                func_name="get_latest_price",
-                max_retries=2,
-                inputSymbols=[symbol],
+    try:
+        # Bulk fetch: one call for all prices, one for all quotes
+        price_results = await execute_with_retry(rh.get_latest_price, symbols_list)
+        quote_results = await execute_with_retry(rh.get_quotes, symbols_list)
+
+        if not isinstance(price_results, list):
+            price_results = []
+        if not isinstance(quote_results, list):
+            quote_results = []
+
+        quote_by_symbol = {
+            str(quote["symbol"]).upper(): quote
+            for quote in quote_results
+            if isinstance(quote, dict) and quote.get("symbol")
+        }
+        quotes_have_symbols = bool(quote_by_symbol)
+        prices_are_aligned = len(price_results) == len(symbols_list)
+
+        for i, symbol in enumerate(symbols_list):
+            symbol_key = symbol.upper()
+            quote = quote_by_symbol.get(symbol_key)
+            if quote is None and not quotes_have_symbols:
+                maybe_quote = quote_results[i] if i < len(quote_results) else {}
+                quote = maybe_quote if isinstance(maybe_quote, dict) else {}
+            elif quote is None:
+                quote = {}
+
+            price_str = (
+                quote.get("last_trade_price")
+                or quote.get("last_extended_hours_trade_price")
+                or quote.get("ask_price")
+                or quote.get("bid_price")
             )
+            if price_str in (None, "") and prices_are_aligned and not quotes_have_symbols:
+                price_str = price_results[i]
 
-            if price_data and len(price_data) > 0:
-                current_price = price_data[0]
-
-                # Get quote for additional data
-                quote_data = await execute_with_retry(
-                    func=rh.get_quote,
-                    func_name="get_quote",
-                    max_retries=2,
-                    inputSymbols=[symbol],
-                )
-
-                if quote_data and len(quote_data) > 0:
-                    quote = quote_data[0]
+            if price_str is not None:
+                try:
+                    current_price = float(price_str)
                     previous_close = float(quote.get("previous_close", 0))
                     volume = int(quote.get("volume", 0))
 
                     if previous_close > 0:
-                        change = float(current_price) - previous_close
+                        change = current_price - previous_close
                         change_percent = (change / previous_close) * 100
 
-                        # Categorize performance
                         if change_percent > 0:
                             gainers += 1
                         elif change_percent < 0:
@@ -506,25 +523,49 @@ async def get_watchlist_performance(watchlist_name: str) -> dict[str, Any]:
                         performance_data.append(
                             {
                                 "symbol": symbol,
-                                "current_price": current_price,
+                                "current_price": price_str,
                                 "change": f"{change:+.2f}",
                                 "change_percent": f"{change_percent:+.2f}%",
                                 "volume": volume,
                             }
                         )
                     else:
+                        total_volume += volume
                         performance_data.append(
                             {
                                 "symbol": symbol,
-                                "current_price": current_price,
+                                "current_price": price_str,
                                 "change": "N/A",
                                 "change_percent": "N/A",
                                 "volume": volume,
                             }
                         )
+                except (ValueError, TypeError) as exc:
+                    logger.warning(f"Could not parse data for {symbol}: {exc}")
+                    performance_data.append(
+                        {
+                            "symbol": symbol,
+                            "current_price": "N/A",
+                            "change": "N/A",
+                            "change_percent": "N/A",
+                            "volume": 0,
+                            "error": str(exc),
+                        }
+                    )
+            else:
+                performance_data.append(
+                    {
+                        "symbol": symbol,
+                        "current_price": "N/A",
+                        "change": "N/A",
+                        "change_percent": "N/A",
+                        "volume": 0,
+                    }
+                )
 
-        except Exception as e:
-            logger.warning(f"Could not get performance data for {symbol}: {e}")
+    except Exception as exc:
+        logger.warning(f"Could not get performance data for watchlist: {exc}")
+        for symbol in symbols_list:
             performance_data.append(
                 {
                     "symbol": symbol,
@@ -532,12 +573,12 @@ async def get_watchlist_performance(watchlist_name: str) -> dict[str, Any]:
                     "change": "N/A",
                     "change_percent": "N/A",
                     "volume": 0,
-                    "error": str(e),
+                    "error": str(exc),
                 }
             )
 
     # Calculate summary metrics
-    total_symbols = len(symbols)
+    total_symbols = len(symbols_list)
     avg_change_percent = (
         total_change_percent / total_symbols if total_symbols > 0 else 0
     )

--- a/tests/unit/test_simple_rate_limiter.py
+++ b/tests/unit/test_simple_rate_limiter.py
@@ -1,5 +1,6 @@
 """Simple tests for rate limiter without time delays."""
 
+import asyncio
 from typing import Any
 from unittest.mock import patch
 
@@ -117,3 +118,143 @@ def test_configure_global_rate_limiter_updates_singleton() -> None:
     assert limiter.calls_per_hour == 222
     assert limiter.burst_size == 3
     assert get_rate_limiter() is limiter
+
+
+class TestRequestCoordinator:
+    """Test RequestCoordinator singleflight deduplication logic."""
+
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_coalesce_concurrent_same_key(self) -> None:
+        """Concurrent calls with the same key share one underlying coroutine."""
+        from open_stocks_mcp.tools.rate_limiter import RequestCoordinator
+
+        coordinator = RequestCoordinator()
+        call_count = 0
+
+        async def slow_fetch() -> str:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0)
+            return "result"
+
+        results = await asyncio.gather(
+            coordinator.execute("key-A", slow_fetch),
+            coordinator.execute("key-A", slow_fetch),
+        )
+
+        assert call_count == 1
+        assert list(results) == ["result", "result"]
+
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_coalesce_independent_keys(self) -> None:
+        """Different keys execute independently (no deduplication)."""
+        from open_stocks_mcp.tools.rate_limiter import RequestCoordinator
+
+        coordinator = RequestCoordinator()
+        call_count = 0
+
+        async def fetch() -> str:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0)
+            return "result"
+
+        results = await asyncio.gather(
+            coordinator.execute("key-A", fetch),
+            coordinator.execute("key-B", fetch),
+        )
+
+        assert call_count == 2
+        assert list(results) == ["result", "result"]
+
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_coalesce_failed_call_cleanup(self) -> None:
+        """Failed calls are cleaned up from the in-flight map so next call executes fresh."""
+        from open_stocks_mcp.tools.rate_limiter import RequestCoordinator
+
+        coordinator = RequestCoordinator()
+
+        async def failing_fetch() -> str:
+            raise ValueError("broker error")
+
+        with pytest.raises(ValueError, match="broker error"):
+            await coordinator.execute("key-A", failing_fetch)
+
+        assert "key-A" not in coordinator._in_flight
+
+        call_count = 0
+
+        async def ok_fetch() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        result = await coordinator.execute("key-A", ok_fetch)
+        assert result == "ok"
+        assert call_count == 1
+
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_initial_caller_cancellation_releases_waiters(self) -> None:
+        """Cancellation of the first caller does not leave coalesced waiters pending."""
+        from open_stocks_mcp.tools.rate_limiter import RequestCoordinator
+
+        coordinator = RequestCoordinator()
+        started = asyncio.Event()
+
+        async def slow_fetch() -> str:
+            started.set()
+            await asyncio.sleep(60)
+            return "result"
+
+        first = asyncio.create_task(coordinator.execute("key-A", slow_fetch))
+        await started.wait()
+        second = asyncio.create_task(coordinator.execute("key-A", slow_fetch))
+        await asyncio.sleep(0)
+
+        first.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(second, timeout=1)
+
+        assert "key-A" not in coordinator._in_flight
+
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_coalesced_count_increments(self) -> None:
+        """coalesced_count tracks how many calls were deduplicated."""
+        from open_stocks_mcp.tools.rate_limiter import RequestCoordinator
+
+        coordinator = RequestCoordinator()
+
+        async def slow_fetch() -> str:
+            await asyncio.sleep(0)
+            return "result"
+
+        await asyncio.gather(
+            coordinator.execute("key-A", slow_fetch),
+            coordinator.execute("key-A", slow_fetch),
+            coordinator.execute("key-A", slow_fetch),
+        )
+
+        assert coordinator.coalesced_count == 2
+
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    def test_get_request_coordinator_singleton(self) -> None:
+        """get_request_coordinator returns the same instance each time."""
+        from open_stocks_mcp.tools.rate_limiter import get_request_coordinator
+
+        c1 = get_request_coordinator()
+        c2 = get_request_coordinator()
+        assert c1 is c2

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for stock market and core tools."""
 
+import asyncio
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -127,6 +128,43 @@ class TestStockMarketTools:
         # Second call - should NOT hit cache
         await get_stock_price("AAPL")
         assert mock_latest_price.call_count == 2
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_quotes")
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_latest_price")
+    @pytest.mark.asyncio
+    async def test_get_stock_price_coalesces_concurrent_calls(
+        self, mock_latest_price: Any, mock_quotes: Any
+    ) -> None:
+        """Two concurrent get_stock_price calls for same symbol share one set of broker calls."""
+        reset_cache_config()
+        clear_all_caches()
+        from open_stocks_mcp.config import get_cache_config
+
+        get_cache_config().enabled = False
+
+        mock_latest_price.return_value = ["150.25"]
+        mock_quotes.return_value = [
+            {
+                "previous_close": "148.50",
+                "volume": "1000000",
+                "ask_price": "150.30",
+                "bid_price": "150.20",
+                "last_trade_price": "150.25",
+            }
+        ]
+
+        results = await asyncio.gather(
+            get_stock_price("AAPL"),
+            get_stock_price("AAPL"),
+        )
+
+        assert mock_latest_price.call_count == 1
+        assert mock_quotes.call_count == 1
+        assert results[0] == results[1]
+        assert results[0]["result"]["symbol"] == "AAPL"
+        assert results[0]["result"]["status"] == "success"
 
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")

--- a/tests/unit/test_watchlist_tools.py
+++ b/tests/unit/test_watchlist_tools.py
@@ -378,16 +378,50 @@ class TestRemoveSymbolsFromWatchlist:
 class TestGetWatchlistPerformance:
     """Test get watchlist performance functionality."""
 
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.execute_with_retry")
     @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.get_watchlist_by_name")
-    @pytest.mark.slow
+    @pytest.mark.journey_watchlists
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_watchlist_performance_uses_bulk_calls(
+        self, mock_get_watchlist: Any, mock_execute: Any
+    ) -> None:
+        """A three-symbol watchlist makes one bulk price call and one bulk quote call."""
+        mock_get_watchlist.return_value = {
+            "result": {
+                "name": "Tech Stocks",
+                "symbols": ["AAPL", "GOOGL", "MSFT"],
+                "status": "success",
+            }
+        }
+        mock_execute.side_effect = [
+            ["150.00", "130.00", "380.00"],
+            [
+                {"previous_close": "148.00", "volume": "1000000"},
+                {"previous_close": "128.00", "volume": "2000000"},
+                {"previous_close": "375.00", "volume": "500000"},
+            ],
+        ]
+
+        result = await get_watchlist_performance("Tech Stocks")
+
+        assert result["result"]["status"] == "success"
+        assert result["result"]["watchlist_name"] == "Tech Stocks"
+        assert len(result["result"]["symbols"]) == 3
+        assert result["result"]["summary"]["total_symbols"] == 3
+        assert result["result"]["summary"]["gainers"] == 3
+        assert result["result"]["summary"]["losers"] == 0
+        assert mock_execute.call_count == 2
+
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.execute_with_retry")
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.get_watchlist_by_name")
     @pytest.mark.journey_watchlists
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_watchlist_performance_success(
-        self, mock_get_watchlist: Any
+        self, mock_get_watchlist: Any, mock_execute: Any
     ) -> None:
-        """Test watchlist performance handling when API calls fail."""
-        # Mock watchlist data
+        """Test successful watchlist performance with properly mocked bulk calls."""
         mock_get_watchlist.return_value = {
             "result": {
                 "name": "Tech Stocks",
@@ -395,31 +429,25 @@ class TestGetWatchlistPerformance:
                 "status": "success",
             }
         }
+        mock_execute.side_effect = [
+            ["150.00", "130.00"],
+            [
+                {"previous_close": "148.00", "volume": "1000000"},
+                {"previous_close": "128.00", "volume": "2000000"},
+            ],
+        ]
 
-        # Due to source code bug (rh.get_quote doesn't exist), the function will fail
-        # Test that it handles this gracefully by returning error data
         result = await get_watchlist_performance("Tech Stocks")
 
         assert "result" in result
         assert result["result"]["watchlist_name"] == "Tech Stocks"
         assert len(result["result"]["symbols"]) == 2
+        assert result["result"]["status"] == "success"
 
-        # Check that symbols are returned but with error data
-        for symbol_data in result["result"]["symbols"]:
-            assert symbol_data["symbol"] in ["AAPL", "GOOGL"]
-            assert symbol_data["current_price"] == "N/A"
-            assert symbol_data["change"] == "N/A"
-            assert symbol_data["change_percent"] == "N/A"
-            assert "error" in symbol_data
-
-        # Check summary - no gainers/losers since all failed
         summary = result["result"]["summary"]
         assert summary["total_symbols"] == 2
-        assert summary["gainers"] == 0
+        assert summary["gainers"] == 2
         assert summary["losers"] == 0
-        assert summary["unchanged"] == 0
-        assert summary["total_volume"] == 0
-        assert result["result"]["status"] == "success"
 
     @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.get_watchlist_by_name")
     @pytest.mark.journey_watchlists
@@ -469,63 +497,148 @@ class TestGetWatchlistPerformance:
         assert result["result"]["summary"]["total_symbols"] == 0
         assert result["result"]["status"] == "no_data"
 
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.execute_with_retry")
     @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.get_watchlist_by_name")
-    @pytest.mark.slow
     @pytest.mark.journey_watchlists
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_watchlist_performance_mixed_results(
-        self, mock_get_watchlist: Any
+        self, mock_get_watchlist: Any, mock_execute: Any
     ) -> None:
-        """Test watchlist performance with multiple symbols (all will fail gracefully)."""
+        """Test watchlist performance with gainer, loser, and unchanged symbols."""
         mock_get_watchlist.return_value = {
             "result": {
                 "name": "Mixed",
-                "symbols": ["AAPL", "TSLA", "UNCHANGED"],
+                "symbols": ["AAPL", "TSLA", "MSFT"],
                 "status": "success",
             }
         }
+        mock_execute.side_effect = [
+            ["150.00", "100.00", "375.00"],
+            [
+                {"previous_close": "148.00", "volume": "1000000"},
+                {"previous_close": "102.00", "volume": "500000"},
+                {"previous_close": "375.00", "volume": "300000"},
+            ],
+        ]
 
-        # Due to source code bug (rh.get_quote doesn't exist), all symbols will fail
-        # Test that it handles this gracefully
         result = await get_watchlist_performance("Mixed")
 
         assert "result" in result
         summary = result["result"]["summary"]
         assert summary["total_symbols"] == 3
-        # All will fail so no gainers/losers/unchanged
-        assert summary["gainers"] == 0
-        assert summary["losers"] == 0
-        assert summary["unchanged"] == 0
-        assert summary["total_volume"] == 0
+        assert summary["gainers"] == 1
+        assert summary["losers"] == 1
+        assert summary["unchanged"] == 1
 
-    @pytest.mark.exception_test
-    @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.execute_with_retry")
     @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.get_watchlist_by_name")
     @pytest.mark.journey_watchlists
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_get_watchlist_performance_api_error(
-        self, mock_get_watchlist: Any
+    async def test_get_watchlist_performance_bulk_call_failure(
+        self, mock_get_watchlist: Any, mock_execute: Any
     ) -> None:
-        """Test watchlist performance when API calls fail for some symbols."""
+        """When the bulk broker call fails, all symbols get fallback error entries."""
         mock_get_watchlist.return_value = {
-            "result": {"name": "Test", "symbols": ["AAPL"], "status": "success"}
+            "result": {"name": "Test", "symbols": ["AAPL", "GOOGL"], "status": "success"}
         }
+        mock_execute.side_effect = Exception("API Error")
 
-        # Mock API error
-        with patch(
-            "open_stocks_mcp.tools.robinhood_watchlist_tools.execute_with_retry"
-        ) as mock_execute:
-            mock_execute.side_effect = Exception("API Error")
+        result = await get_watchlist_performance("Test")
 
-            result = await get_watchlist_performance("Test")
-
-            assert "result" in result
-            assert len(result["result"]["symbols"]) == 1
-            symbol_data = result["result"]["symbols"][0]
-            assert symbol_data["symbol"] == "AAPL"
+        assert "result" in result
+        assert len(result["result"]["symbols"]) == 2
+        for symbol_data in result["result"]["symbols"]:
             assert symbol_data["current_price"] == "N/A"
             assert symbol_data["change"] == "N/A"
+            assert symbol_data["change_percent"] == "N/A"
             assert "error" in symbol_data
-            assert result["result"]["status"] == "success"
+        assert result["result"]["summary"]["gainers"] == 0
+        assert result["result"]["status"] == "success"
+
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.execute_with_retry")
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.get_watchlist_by_name")
+    @pytest.mark.journey_watchlists
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_watchlist_performance_missing_price_data(
+        self, mock_get_watchlist: Any, mock_execute: Any
+    ) -> None:
+        """Symbols with no price data in bulk response get fallback entries."""
+        mock_get_watchlist.return_value = {
+            "result": {
+                "name": "Test",
+                "symbols": ["AAPL", "GOOGL", "MSFT"],
+                "status": "success",
+            }
+        }
+        mock_execute.side_effect = [
+            ["150.00", None, "380.00"],
+            [
+                {"previous_close": "148.00", "volume": "1000000"},
+                {"previous_close": "128.00", "volume": "2000000"},
+                {"previous_close": "375.00", "volume": "500000"},
+            ],
+        ]
+
+        result = await get_watchlist_performance("Test")
+
+        assert result["result"]["status"] == "success"
+        symbols = result["result"]["symbols"]
+        assert len(symbols) == 3
+
+        aapl = next(s for s in symbols if s["symbol"] == "AAPL")
+        googl = next(s for s in symbols if s["symbol"] == "GOOGL")
+        msft = next(s for s in symbols if s["symbol"] == "MSFT")
+
+        assert aapl["current_price"] == "150.00"
+        assert googl["current_price"] == "N/A"
+        assert msft["current_price"] == "380.00"
+
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.execute_with_retry")
+    @patch("open_stocks_mcp.tools.robinhood_watchlist_tools.get_watchlist_by_name")
+    @pytest.mark.journey_watchlists
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_watchlist_performance_maps_quotes_by_symbol(
+        self, mock_get_watchlist: Any, mock_execute: Any
+    ) -> None:
+        """Skipped bulk quote entries do not shift data onto later symbols."""
+        mock_get_watchlist.return_value = {
+            "result": {
+                "name": "Test",
+                "symbols": ["AAPL", "GOOGL", "MSFT"],
+                "status": "success",
+            }
+        }
+        mock_execute.side_effect = [
+            ["150.00", "380.00"],
+            [
+                {
+                    "symbol": "AAPL",
+                    "last_trade_price": "150.00",
+                    "previous_close": "148.00",
+                    "volume": "1000000",
+                },
+                {
+                    "symbol": "MSFT",
+                    "last_trade_price": "380.00",
+                    "previous_close": "375.00",
+                    "volume": "500000",
+                },
+            ],
+        ]
+
+        result = await get_watchlist_performance("Test")
+
+        symbols = result["result"]["symbols"]
+        assert len(symbols) == 3
+
+        aapl = next(s for s in symbols if s["symbol"] == "AAPL")
+        googl = next(s for s in symbols if s["symbol"] == "GOOGL")
+        msft = next(s for s in symbols if s["symbol"] == "MSFT")
+
+        assert aapl["current_price"] == "150.00"
+        assert googl["current_price"] == "N/A"
+        assert msft["current_price"] == "380.00"


### PR DESCRIPTION
Closes #144

## Changes
- **`rate_limiter.py`**: Add `RequestCoordinator` class — asyncio-safe singleflight that deduplicates concurrent read-only broker calls sharing the same key. Also adds `get_request_coordinator()` global accessor.
- **`retry.py`**: Add opt-in `coalesce_key` parameter to `execute_with_retry()`. When provided, the call is wrapped in the coordinator; all existing call sites are unaffected since the default is `None`.
- **`robinhood_stock_tools.py`**: `get_stock_price()` now passes `coalesce_key=f"get_latest_price:{symbol}"` and `coalesce_key=f"get_quotes:{symbol}"` so concurrent cold-cache parallel calls for the same symbol hit the broker only once.
- **`robinhood_watchlist_tools.py`**: `get_watchlist_performance()` replaces the per-symbol serial loop (which also had a `rh.get_quote` vs `rh.get_quotes` bug) with one bulk `rh.get_latest_price(symbols_list)` and one bulk `rh.get_quotes(symbols_list)` call, then maps results back by index. Response contract (`watchlist_name`, `symbols`, `summary`, `status`) is preserved.

## Test plan
- `TestRequestCoordinator` in `test_simple_rate_limiter.py`: same-key coalescing, independent keys run separately, failure cleanup removes key, `coalesced_count` increments, singleton accessor
- `test_get_stock_price_coalesces_concurrent_calls` in `test_stock_market_tools.py`: two concurrent calls with cache disabled share one set of broker calls
- `TestGetWatchlistPerformance` in `test_watchlist_tools.py`: bulk call assertion (`call_count == 2` not 6), gainers/losers/unchanged correctness, missing-price fallback, bulk-call-failure fallback

```
uv run pytest tests/unit/test_simple_rate_limiter.py tests/unit/test_stock_market_tools.py tests/unit/test_watchlist_tools.py -q
# 56 passed, 2 skipped (pre-existing health_check failures unrelated to this PR)
uv run ruff check src/open_stocks_mcp/tools/rate_limiter.py ... # All checks passed
uv run mypy src/... # Success: no issues found in 4 source files
```