### PR TITLE
test: add failure-mode regression tests and performance smoke suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ RUN_RATE_LIMITED=1 pytest                                 # Include rate-limited
 
 # READ ONLY journeys (perfect for ADK evaluations)
 pytest -m "journey_account or journey_portfolio or journey_market_data or journey_research or journey_notifications or journey_system"
+
+# Failure-mode regression tests (network/auth failures, no live credentials needed)
+uv run pytest tests/unit/test_error_handling.py tests/unit/test_auth_coordinator.py -k 'retry or timeout or connection or auth_failed' -q
+
+# Performance/load smoke tests (mocked, CI-safe, no credentials needed)
+uv run pytest tests/performance -k smoke -q
 ```
 
 **Journey Categories:**

--- a/src/open_stocks_mcp/tools/exceptions.py
+++ b/src/open_stocks_mcp/tools/exceptions.py
@@ -78,6 +78,12 @@ class CircuitBreakerError(RobinStocksError):
 
 def classify_error(error: Exception) -> RobinStocksError:
     """Classify an exception into a specific Robin Stocks error type."""
+    # Check Python built-in network exception types first (before string matching)
+    if isinstance(error, TimeoutError):
+        return NetworkError("Network connectivity issue", error)
+    if isinstance(error, ConnectionError):
+        return NetworkError("Network connectivity issue", error)
+
     error_str = str(error).lower()
 
     if any(

--- a/tests/performance/test_tool_performance.py
+++ b/tests/performance/test_tool_performance.py
@@ -1,0 +1,112 @@
+"""CI-safe performance smoke tests for representative MCP tool calls.
+
+All broker/API dependencies are mocked so these tests run without credentials
+or live network access. Timing assertions use conservative thresholds (0.5s per
+call) to catch pathological regressions without depending on machine speed.
+
+Run with:
+    uv run pytest tests/performance -k smoke -q
+"""
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_MOCK_QUOTE_DATA = [
+    {
+        "last_trade_price": "150.22",
+        "bid_price": "150.20",
+        "ask_price": "150.25",
+        "previous_close": "148.50",
+        "volume": "50000000",
+    }
+]
+_MOCK_PRICE_DATA = ["150.25"]
+_MOCK_ACCOUNT_DATA = {"username": "test_user", "created_at": "2024-01-01T00:00:00Z"}
+
+
+def _make_schwab_quote_response(symbol: str) -> dict[str, Any]:
+    return {
+        symbol.upper(): {
+            "quote": {
+                "lastPrice": 150.22,
+                "bidPrice": 150.20,
+                "askPrice": 150.25,
+                "totalVolume": 50000000,
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_stock_price_smoke_performance() -> None:
+    """get_stock_price completes under 0.5 s with mocked broker dependencies."""
+    call_results = iter([_MOCK_PRICE_DATA, _MOCK_QUOTE_DATA])
+
+    async def mock_execute_with_retry(fn: Any, *args: Any, **kwargs: Any) -> Any:
+        return next(call_results)
+
+    with patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.execute_with_retry",
+        side_effect=mock_execute_with_retry,
+    ):
+        from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+
+        start = time.perf_counter()
+        result = await get_stock_price("AAPL")
+        elapsed = time.perf_counter() - start
+
+    assert "result" in result
+    assert result["result"]["symbol"] == "AAPL"
+    assert elapsed < 0.5, f"get_stock_price took {elapsed:.3f}s (limit 0.5s)"
+
+
+@pytest.mark.asyncio
+async def test_get_account_info_smoke_performance() -> None:
+    """get_account_info completes under 0.5 s with mocked broker dependencies."""
+
+    async def mock_execute_with_retry(fn: Any, *args: Any, **kwargs: Any) -> Any:
+        return _MOCK_ACCOUNT_DATA
+
+    with patch(
+        "open_stocks_mcp.tools.robinhood_account_tools.execute_with_retry",
+        side_effect=mock_execute_with_retry,
+    ):
+        from open_stocks_mcp.tools.robinhood_account_tools import get_account_info
+
+        start = time.perf_counter()
+        result = await get_account_info()
+        elapsed = time.perf_counter() - start
+
+    assert "result" in result
+    assert result["result"]["username"] == "test_user"
+    assert elapsed < 0.5, f"get_account_info took {elapsed:.3f}s (limit 0.5s)"
+
+
+@pytest.mark.asyncio
+async def test_get_schwab_quote_smoke_performance() -> None:
+    """get_schwab_quote completes under 0.5 s with mocked broker/client."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = _make_schwab_quote_response("AAPL")
+
+    mock_broker = MagicMock()
+    mock_broker.client.get_quote.return_value = mock_response
+
+    async def mock_get_broker(*args: Any, **kwargs: Any) -> tuple[Any, None]:
+        return mock_broker, None
+
+    with patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error",
+        side_effect=mock_get_broker,
+    ):
+        from open_stocks_mcp.tools.schwab_market_tools import get_schwab_quote
+
+        start = time.perf_counter()
+        result = await get_schwab_quote("AAPL")
+        elapsed = time.perf_counter() - start
+
+    assert "result" in result
+    assert result["result"]["symbol"] == "AAPL"
+    assert elapsed < 0.5, f"get_schwab_quote took {elapsed:.3f}s (limit 0.5s)"

--- a/tests/unit/test_auth_coordinator.py
+++ b/tests/unit/test_auth_coordinator.py
@@ -506,3 +506,50 @@ class TestAuthenticationIntegrationScenarios:
         assert successful == 0
         assert total == 0
         assert failed == []
+
+
+class TestAuthFailedStructuredResponse:
+    """Tests that auth failure produces structured broker_unavailable responses."""
+
+    @pytest.mark.asyncio
+    async def test_get_broker_or_error_returns_auth_failed_status(self, fresh_registry):
+        """Broker with AUTH_FAILED status returns structured response with auth_status='auth_failed'."""
+        broker = MockBroker("test", should_auth_succeed=False)
+        fresh_registry.register(broker)
+        await broker.authenticate()  # sets AUTH_FAILED
+
+        with patch(
+            "open_stocks_mcp.brokers.auth_coordinator.get_broker_registry",
+            return_value=fresh_registry,
+        ):
+            result_broker, error = await get_authenticated_broker_or_error(
+                "test", "get quote"
+            )
+
+        assert result_broker is None
+        assert error is not None
+        result = error["result"]
+        assert result["status"] == "broker_unavailable"
+        assert result["auth_status"] == "auth_failed"
+        assert result["broker"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_invalid_credentials_produces_structured_error(self, fresh_registry):
+        """Broker whose authenticate() returns False gives a structured, non-raising error."""
+        broker = MockBroker("robinhood", should_auth_succeed=False)
+        fresh_registry.register(broker)
+        await broker.authenticate()
+
+        with patch(
+            "open_stocks_mcp.brokers.auth_coordinator.get_broker_registry",
+            return_value=fresh_registry,
+        ):
+            _, error = await get_authenticated_broker_or_error(
+                "robinhood", "get account info"
+            )
+
+        assert error is not None
+        result = error["result"]
+        assert "error" in result
+        assert "robinhood" in result["error"].lower()
+        assert result["auth_status"] == "auth_failed"

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -685,3 +685,54 @@ def test_log_api_call_excludes_sensitive_kwargs(
     assert "AAPL" in message
     assert "token" not in message
     assert "include_extended_hours" in message
+
+
+# --- Failure-mode regression tests ---
+
+
+def test_classify_timeout_error_as_network_error() -> None:
+    """TimeoutError should classify as NetworkError."""
+    error = classify_error(TimeoutError("request timed out"))
+    assert isinstance(error, NetworkError)
+
+
+def test_classify_connection_refused_as_network_error() -> None:
+    """ConnectionError 'connection refused' should classify as NetworkError."""
+    error = classify_error(ConnectionError("connection refused"))
+    assert isinstance(error, NetworkError)
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_succeeds_after_transient_network_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single transient network failure should be retried and succeed."""
+    _patch_retry_dependencies(monkeypatch)
+
+    call_count = 0
+
+    def flaky_fn() -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ConnectionError("connection refused")
+        return "ok"
+
+    result = await execute_with_retry(flaky_fn, max_retries=1, delay=0)
+
+    assert result == "ok"
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_raises_network_error_on_repeated_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated TimeoutError should exhaust retries and raise NetworkError."""
+    _patch_retry_dependencies(monkeypatch)
+
+    def always_timeout() -> None:
+        raise TimeoutError("connect timeout")
+
+    with pytest.raises(NetworkError):
+        await execute_with_retry(always_timeout, max_retries=1, delay=0)


### PR DESCRIPTION
Closes #149

## Changes
- Extended `classify_error` in `exceptions.py` to recognize Python built-in `TimeoutError` and `ConnectionError` by type, not just string matching — this ensures these common OS-level network errors are always classified as `NetworkError`
- Added 4 failure-mode regression tests to `test_error_handling.py`: `TimeoutError` → `NetworkError`, `ConnectionError("connection refused")` → `NetworkError`, transient failure + retry success, repeated `TimeoutError` exhausts retries
- Added 2 auth failure structured-response tests to `test_auth_coordinator.py`: verifies `get_authenticated_broker_or_error` returns `auth_status == "auth_failed"` and structured `broker_unavailable` response for failed brokers
- Created `tests/performance/` package with `test_tool_performance.py`: CI-safe mocked smoke tests for `get_stock_price`, `get_account_info`, and `get_schwab_quote`, each asserting `"result"` is present and elapsed time < 0.5s
- Updated `CLAUDE.md` with exact commands for both test suites

## Test plan
- `uv run pytest tests/unit/test_error_handling.py tests/unit/test_auth_coordinator.py -k 'retry or timeout or connection or auth_failed' -q` → 10 passed
- `uv run pytest tests/performance -m performance -q` → 3 passed
- `uv run ruff check src tests` → all checks passed
- `uv run mypy src` → no issues found in 48 source files