### PR TITLE
test: add shared broker fixture payloads

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ except ImportError:
 
 import pytest
 
+from tests.fixtures import broker_payloads
 from tests.integration.live_market_harness import (
     LIVE_MARKET_ENV_VAR,
     LIVE_MARKET_SKIP_REASON,
@@ -146,6 +147,108 @@ def sample_portfolio_data() -> dict[str, Any]:
         "total_return_today_percent": "2.61",
         "day_trade_buying_power": "0.00",
     }
+
+
+@pytest.fixture
+def robinhood_quote_payload() -> dict[str, Any]:
+    """Representative Robinhood quote payload."""
+    return broker_payloads.robinhood_quote_payload()
+
+
+@pytest.fixture
+def robinhood_fundamentals_payload() -> dict[str, Any]:
+    """Representative Robinhood fundamentals payload."""
+    return broker_payloads.robinhood_fundamentals_payload()
+
+
+@pytest.fixture
+def robinhood_instrument_payload() -> dict[str, Any]:
+    """Representative Robinhood instrument payload."""
+    return broker_payloads.robinhood_instrument_payload()
+
+
+@pytest.fixture
+def robinhood_search_payload() -> list[dict[str, Any]]:
+    """Representative Robinhood search payload."""
+    return broker_payloads.robinhood_search_payload()
+
+
+@pytest.fixture
+def robinhood_user_profile_payload() -> dict[str, Any]:
+    """Representative Robinhood user profile payload."""
+    return broker_payloads.robinhood_user_profile_payload()
+
+
+@pytest.fixture
+def robinhood_portfolio_payload() -> dict[str, Any]:
+    """Representative Robinhood portfolio payload."""
+    return broker_payloads.robinhood_portfolio_payload()
+
+
+@pytest.fixture
+def robinhood_positions_payload() -> list[dict[str, Any]]:
+    """Representative Robinhood positions payload."""
+    return broker_payloads.robinhood_positions_payload()
+
+
+@pytest.fixture
+def robinhood_phoenix_account_payload() -> dict[str, Any]:
+    """Representative Robinhood phoenix account payload."""
+    return broker_payloads.robinhood_phoenix_account_payload()
+
+
+@pytest.fixture
+def robinhood_build_holdings_payload() -> dict[str, Any]:
+    """Representative Robinhood build_holdings payload."""
+    return broker_payloads.robinhood_build_holdings_payload()
+
+
+@pytest.fixture
+def schwab_quote_payload() -> dict[str, Any]:
+    """Representative Schwab quote payload."""
+    return broker_payloads.schwab_quote_payload()
+
+
+@pytest.fixture
+def schwab_quotes_payload() -> dict[str, Any]:
+    """Representative Schwab multi-quote payload."""
+    return broker_payloads.schwab_quotes_payload()
+
+
+@pytest.fixture
+def schwab_price_history_payload() -> dict[str, Any]:
+    """Representative Schwab price-history payload."""
+    return broker_payloads.schwab_price_history_payload()
+
+
+@pytest.fixture
+def schwab_account_numbers_payload() -> list[dict[str, Any]]:
+    """Representative Schwab account-number payload."""
+    return broker_payloads.schwab_account_numbers_payload()
+
+
+@pytest.fixture
+def schwab_account_payload() -> dict[str, Any]:
+    """Representative Schwab account payload."""
+    return broker_payloads.schwab_account_payload()
+
+
+@pytest.fixture
+def schwab_accounts_payload() -> list[dict[str, Any]]:
+    """Representative Schwab accounts payload."""
+    return broker_payloads.schwab_accounts_payload()
+
+
+@pytest.fixture
+def schwab_balances_payload() -> dict[str, Any]:
+    """Representative Schwab balances payload."""
+    return broker_payloads.schwab_balances_payload()
+
+
+@pytest.fixture
+def broker_auth_error_payload() -> dict[str, Any]:
+    """Structured broker authentication error response."""
+    return broker_payloads.broker_auth_error_payload()
 
 
 # Journey-specific fixtures

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,2 @@
+"""Reusable test fixture payloads."""
+

--- a/tests/fixtures/broker_payloads.py
+++ b/tests/fixtures/broker_payloads.py
@@ -1,0 +1,370 @@
+"""Shared representative broker API payloads for unit tests."""
+
+from copy import deepcopy
+from typing import Any
+
+
+def _copy(payload: dict[str, Any]) -> dict[str, Any]:
+    return deepcopy(payload)
+
+
+def _copy_list(payload: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return deepcopy(payload)
+
+
+def robinhood_quote_payload() -> dict[str, Any]:
+    """Return a representative Robinhood quote payload."""
+    return _copy(
+        {
+            "symbol": "AAPL",
+            "previous_close": "148.50",
+            "volume": "1000000",
+            "ask_price": "150.30",
+            "bid_price": "150.20",
+            "last_trade_price": "150.25",
+            "last_extended_hours_trade_price": "150.18",
+            "previous_close_date": "2023-12-29",
+            "trading_halted": False,
+            "has_traded": True,
+            "last_trade_price_source": "consolidated",
+            "updated_at": "2023-12-30T20:59:59.000000Z",
+            "instrument": (
+                "https://robinhood.com/instruments/"
+                "450dfc6d-5510-4d40-abfb-f633b7d9be3e/"
+            ),
+        }
+    )
+
+
+def robinhood_fundamentals_payload() -> dict[str, Any]:
+    """Return representative Robinhood fundamental data."""
+    return _copy(
+        {
+            "sector": "Technology",
+            "industry": "Consumer Electronics",
+            "description": "Apple Inc. designs and manufactures smartphones",
+            "market_cap": "3000000000000",
+            "pe_ratio": "25.5",
+            "dividend_yield": "0.50",
+            "high_52_weeks": "182.94",
+            "low_52_weeks": "124.17",
+            "average_volume": "50000000",
+        }
+    )
+
+
+def robinhood_instrument_payload() -> dict[str, Any]:
+    """Return representative Robinhood instrument metadata."""
+    return _copy(
+        {
+            "symbol": "AAPL",
+            "simple_name": "Apple Inc.",
+            "name": "Apple Inc.",
+            "tradeable": True,
+            "country": "US",
+            "type": "stock",
+            "id": "450dfc6d-5510-4d40-abfb-f633b7d9be3e",
+            "url": (
+                "https://robinhood.com/instruments/"
+                "450dfc6d-5510-4d40-abfb-f633b7d9be3e/"
+            ),
+            "market": "NASDAQ",
+            "list_date": "1980-12-12",
+            "state": "active",
+            "tradability": "tradable",
+        }
+    )
+
+
+def robinhood_search_payload() -> list[dict[str, Any]]:
+    """Return representative Robinhood instrument search results."""
+    return _copy_list(
+        [
+            robinhood_instrument_payload(),
+            {
+                "symbol": "GOOGL",
+                "simple_name": "Alphabet Inc.",
+                "name": "Alphabet Inc.",
+                "tradeable": True,
+                "country": "US",
+                "type": "stock",
+                "id": "943c5009-a0bb-4665-8cf4-a95dab5874e4",
+                "url": (
+                    "https://robinhood.com/instruments/"
+                    "943c5009-a0bb-4665-8cf4-a95dab5874e4/"
+                ),
+            },
+        ]
+    )
+
+
+def robinhood_user_profile_payload() -> dict[str, Any]:
+    """Return representative Robinhood user profile data."""
+    return _copy(
+        {
+            "username": "testuser",
+            "created_at": "2023-01-01T00:00:00Z",
+        }
+    )
+
+
+def robinhood_portfolio_payload() -> dict[str, Any]:
+    """Return representative Robinhood portfolio profile data."""
+    return _copy(
+        {
+            "total_return_today": "50.00",
+            "total_return_today_percent": "2.50",
+            "market_value": "2000.00",
+            "equity": "2100.00",
+            "buying_power": "100.00",
+        }
+    )
+
+
+def robinhood_positions_payload() -> list[dict[str, Any]]:
+    """Return representative Robinhood open stock positions."""
+    return _copy_list(
+        [
+            {
+                "instrument": "https://robinhood.com/instruments/aapl123/",
+                "quantity": "10.0000",
+                "average_buy_price": "150.00",
+                "updated_at": "2023-01-01T00:00:00Z",
+            },
+            {
+                "instrument": "https://robinhood.com/instruments/googl456/",
+                "quantity": "5.0000",
+                "average_buy_price": "2500.00",
+                "updated_at": "2023-01-01T00:00:00Z",
+            },
+        ]
+    )
+
+
+def robinhood_phoenix_account_payload() -> dict[str, Any]:
+    """Return representative Robinhood phoenix account details."""
+    def currency(amount: str) -> dict[str, str]:
+        return {"amount": amount, "currency_code": "USD", "currency_id": "usd"}
+
+    return _copy(
+        {
+            "results": [
+                {
+                    "portfolio_equity": currency("2100.00"),
+                    "total_equity": currency("2100.00"),
+                    "account_buying_power": currency("1000.00"),
+                    "options_buying_power": currency("1000.00"),
+                    "crypto_buying_power": currency("1000.00"),
+                    "uninvested_cash": currency("100.00"),
+                    "withdrawable_cash": currency("100.00"),
+                    "cash_available_from_instant_deposits": currency("0.00"),
+                    "cash_held_for_orders": currency("0.00"),
+                    "near_margin_call": False,
+                }
+            ]
+        }
+    )
+
+
+def robinhood_build_holdings_payload() -> dict[str, Any]:
+    """Return representative Robinhood build_holdings output."""
+    return _copy(
+        {
+            "AAPL": {
+                "price": "150.00",
+                "quantity": "10",
+                "average_buy_price": "145.00",
+                "equity": "1500.00",
+                "percent_change": "3.45",
+                "equity_change": "50.00",
+                "type": "stock",
+                "name": "Apple Inc",
+                "pe_ratio": "25.5",
+                "percentage": "15.2",
+            },
+            "GOOGL": {
+                "price": "2800.00",
+                "quantity": "5",
+                "average_buy_price": "2700.00",
+                "equity": "14000.00",
+                "percent_change": "3.70",
+                "equity_change": "500.00",
+                "type": "stock",
+                "name": "Alphabet Inc",
+                "pe_ratio": "28.3",
+                "percentage": "84.8",
+            },
+        }
+    )
+
+
+def schwab_quote_payload() -> dict[str, Any]:
+    """Return a representative Schwab quote response."""
+    return _copy(
+        {
+            "AAPL": {
+                "assetMainType": "EQUITY",
+                "quote": {
+                    "lastPrice": 175.50,
+                    "bidPrice": 175.45,
+                    "askPrice": 175.55,
+                    "bidSize": 100,
+                    "askSize": 200,
+                    "totalVolume": 50000000,
+                    "openPrice": 174.00,
+                    "highPrice": 176.00,
+                    "lowPrice": 173.50,
+                    "closePrice": 174.50,
+                    "netChange": 1.00,
+                    "netPercentChange": 0.57,
+                    "52WkHigh": 200.00,
+                    "52WkLow": 125.00,
+                    "marketCap": 3000000000000,
+                    "peRatio": 25.5,
+                    "divYield": 0.5,
+                },
+                "reference": {
+                    "description": "Apple Inc",
+                    "exchange": "Q",
+                    "exchangeName": "NASDAQ",
+                    "cusip": "037833100",
+                },
+            }
+        }
+    )
+
+
+def schwab_quotes_payload() -> dict[str, Any]:
+    """Return representative Schwab multi-quote data."""
+    quotes = schwab_quote_payload()
+    quotes["GOOGL"] = {
+        "assetMainType": "EQUITY",
+        "quote": {
+            "lastPrice": 140.25,
+            "netChange": -2.50,
+            "netPercentChange": -1.75,
+            "totalVolume": 25000000,
+            "bidPrice": 140.20,
+            "askPrice": 140.30,
+        },
+        "reference": {
+            "description": "Alphabet Inc",
+            "exchange": "Q",
+            "exchangeName": "NASDAQ",
+            "cusip": "02079K305",
+        },
+    }
+    return quotes
+
+
+def schwab_price_history_payload() -> dict[str, Any]:
+    """Return representative Schwab price-history data."""
+    return _copy(
+        {
+            "candles": [
+                {
+                    "open": 174.00,
+                    "high": 175.00,
+                    "low": 173.50,
+                    "close": 174.50,
+                    "volume": 1000000,
+                    "datetime": 1672531200000,
+                },
+                {
+                    "open": 174.50,
+                    "high": 176.00,
+                    "low": 174.00,
+                    "close": 175.50,
+                    "volume": 1500000,
+                    "datetime": 1672534800000,
+                },
+            ],
+            "empty": False,
+        }
+    )
+
+
+def schwab_account_numbers_payload() -> list[dict[str, Any]]:
+    """Return representative Schwab account-number hashes."""
+    return _copy_list(
+        [
+            {"accountNumber": "12345678", "hashValue": "abc123def456"},
+            {"accountNumber": "87654321", "hashValue": "xyz789uvw012"},
+        ]
+    )
+
+
+def schwab_account_payload() -> dict[str, Any]:
+    """Return representative Schwab account data with positions."""
+    return _copy(
+        {
+            "securitiesAccount": {
+                "accountNumber": "12345678",
+                "type": "MARGIN",
+                "roundTrips": 0,
+                "isDayTrader": False,
+                "isClosingOnlyRestricted": False,
+                "positions": [
+                    {
+                        "shortQuantity": 0.0,
+                        "averagePrice": 150.0,
+                        "currentDayProfitLoss": 50.0,
+                        "currentDayProfitLossPercentage": 2.5,
+                        "longQuantity": 10.0,
+                        "settledLongQuantity": 10.0,
+                        "settledShortQuantity": 0.0,
+                        "instrument": {
+                            "assetType": "EQUITY",
+                            "cusip": "037833100",
+                            "symbol": "AAPL",
+                        },
+                        "marketValue": 1500.0,
+                    }
+                ],
+            }
+        }
+    )
+
+
+def schwab_accounts_payload() -> list[dict[str, Any]]:
+    """Return representative Schwab accounts list data."""
+    accounts = [schwab_account_payload()]
+    second = schwab_account_payload()
+    second["securitiesAccount"]["accountNumber"] = "87654321"
+    second["securitiesAccount"]["type"] = "CASH"
+    accounts.append(second)
+    return accounts
+
+
+def schwab_balances_payload() -> dict[str, Any]:
+    """Return representative Schwab account balance data."""
+    return _copy(
+        {
+            "securitiesAccount": {
+                "accountNumber": "12345678",
+                "type": "MARGIN",
+                "currentBalances": {
+                    "liquidationValue": 50000.0,
+                    "cashBalance": 10000.0,
+                    "buyingPower": 25000.0,
+                    "availableFunds": 24000.0,
+                    "longMarketValue": 40000.0,
+                    "shortMarketValue": 0.0,
+                },
+                "initialBalances": {
+                    "accountValue": 48000.0,
+                    "cashBalance": 9500.0,
+                },
+            }
+        }
+    )
+
+
+def broker_auth_error_payload() -> dict[str, Any]:
+    """Return a structured broker authentication error response."""
+    return _copy({"result": {"error": "Not authenticated", "status": "error"}})
+
+
+def broker_api_error_payload() -> dict[str, Any]:
+    """Return a structured broker API error response."""
+    return _copy({"result": {"error": "API Error", "status": "error"}})

--- a/tests/unit/test_account_tools.py
+++ b/tests/unit/test_account_tools.py
@@ -41,12 +41,11 @@ class TestAccountTools:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.robinhood_account_tools.rh.load_user_profile")
     @pytest.mark.asyncio
-    async def test_get_account_info_success(self, mock_profile: Any) -> None:
+    async def test_get_account_info_success(
+        self, mock_profile: Any, robinhood_user_profile_payload: dict[str, Any]
+    ) -> None:
         """Test successful account info retrieval."""
-        mock_profile.return_value = {
-            "username": "testuser",
-            "created_at": "2023-01-01T00:00:00Z",
-        }
+        mock_profile.return_value = robinhood_user_profile_payload
 
         result = await get_account_info()
 
@@ -73,14 +72,12 @@ class TestAccountTools:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.robinhood_account_tools.rh.load_portfolio_profile")
     @pytest.mark.asyncio
-    async def test_get_portfolio_success(self, mock_portfolio: Any) -> None:
+    async def test_get_portfolio_success(
+        self, mock_portfolio: Any, robinhood_portfolio_payload: dict[str, Any]
+    ) -> None:
         """Test successful portfolio retrieval."""
         clear_all_caches()
-        mock_portfolio.return_value = {
-            "total_return_today": "50.00",
-            "total_return_today_percent": "2.50",
-            "market_value": "2000.00",
-        }
+        mock_portfolio.return_value = robinhood_portfolio_payload
 
         result = await get_portfolio()
 
@@ -143,23 +140,13 @@ class TestAccountTools:
     @patch("open_stocks_mcp.tools.robinhood_account_tools.rh.get_open_stock_positions")
     @pytest.mark.asyncio
     async def test_get_positions_success(
-        self, mock_positions: Any, mock_symbol: Any
+        self,
+        mock_positions: Any,
+        mock_symbol: Any,
+        robinhood_positions_payload: list[dict[str, Any]],
     ) -> None:
         """Test successful positions retrieval."""
-        mock_positions.return_value = [
-            {
-                "instrument": "https://robinhood.com/instruments/aapl123/",
-                "quantity": "10.0000",
-                "average_buy_price": "150.00",
-                "updated_at": "2023-01-01T00:00:00Z",
-            },
-            {
-                "instrument": "https://robinhood.com/instruments/googl456/",
-                "quantity": "5.0000",
-                "average_buy_price": "2500.00",
-                "updated_at": "2023-01-01T00:00:00Z",
-            },
-        ]
+        mock_positions.return_value = robinhood_positions_payload
 
         # Mock symbol lookup for each instrument URL
         mock_symbol.side_effect = ["AAPL", "GOOGL"]
@@ -177,12 +164,11 @@ class TestAccountTools:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.robinhood_account_tools.rh.load_phoenix_account")
     @pytest.mark.asyncio
-    async def test_get_account_details_success(self, mock_account: Any) -> None:
+    async def test_get_account_details_success(
+        self, mock_account: Any, robinhood_phoenix_account_payload: dict[str, Any]
+    ) -> None:
         """Test successful account details retrieval."""
-        mock_account.return_value = {
-            "account_number": "123456789",
-            "buying_power": "1000.00",
-        }
+        mock_account.return_value = robinhood_phoenix_account_payload
 
         result = await get_account_details()
 
@@ -193,34 +179,11 @@ class TestAccountTools:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.robinhood_advanced_portfolio_tools.rh.build_holdings")
     @pytest.mark.asyncio
-    async def test_get_build_holdings_success(self, mock_holdings: Any) -> None:
+    async def test_get_build_holdings_success(
+        self, mock_holdings: Any, robinhood_build_holdings_payload: dict[str, Any]
+    ) -> None:
         """Test successful build holdings retrieval."""
-        mock_holdings.return_value = {
-            "AAPL": {
-                "price": "150.00",
-                "quantity": "10",
-                "average_buy_price": "145.00",
-                "equity": "1500.00",
-                "percent_change": "3.45",
-                "equity_change": "50.00",
-                "type": "stock",
-                "name": "Apple Inc",
-                "pe_ratio": "25.5",
-                "percentage": "15.2",
-            },
-            "GOOGL": {
-                "price": "2800.00",
-                "quantity": "5",
-                "average_buy_price": "2700.00",
-                "equity": "14000.00",
-                "percent_change": "3.70",
-                "equity_change": "500.00",
-                "type": "stock",
-                "name": "Alphabet Inc",
-                "pe_ratio": "28.3",
-                "percentage": "84.8",
-            },
-        }
+        mock_holdings.return_value = robinhood_build_holdings_payload
 
         result = await get_build_holdings()
 

--- a/tests/unit/test_broker_fixture_payloads.py
+++ b/tests/unit/test_broker_fixture_payloads.py
@@ -1,0 +1,101 @@
+"""Schema checks for shared broker API fixture payloads."""
+
+from typing import Any
+
+from tests.fixtures import broker_payloads
+
+
+def test_robinhood_quote_payload_contains_stock_price_fields() -> None:
+    payload = broker_payloads.robinhood_quote_payload()
+
+    assert {
+        "previous_close",
+        "volume",
+        "ask_price",
+        "bid_price",
+        "last_trade_price",
+    }.issubset(payload)
+
+
+def test_robinhood_account_payloads_contain_consumed_fields() -> None:
+    profile = broker_payloads.robinhood_user_profile_payload()
+    portfolio = broker_payloads.robinhood_portfolio_payload()
+    positions = broker_payloads.robinhood_positions_payload()
+    phoenix = broker_payloads.robinhood_phoenix_account_payload()
+    holdings = broker_payloads.robinhood_build_holdings_payload()
+
+    assert {"username", "created_at"}.issubset(profile)
+    assert {"market_value", "equity", "buying_power"}.issubset(portfolio)
+    assert {"instrument", "quantity", "average_buy_price", "updated_at"}.issubset(
+        positions[0]
+    )
+    assert "results" in phoenix
+    assert {"portfolio_equity", "total_equity", "account_buying_power"}.issubset(
+        phoenix["results"][0]
+    )
+    assert {"price", "quantity", "equity", "type", "name"}.issubset(
+        holdings["AAPL"]
+    )
+
+
+def test_schwab_market_payloads_contain_consumed_fields() -> None:
+    quote = broker_payloads.schwab_quote_payload()
+    price_history = broker_payloads.schwab_price_history_payload()
+
+    quote_fields = quote["AAPL"]["quote"]
+    assert {
+        "lastPrice",
+        "bidPrice",
+        "askPrice",
+        "totalVolume",
+        "openPrice",
+        "highPrice",
+        "lowPrice",
+        "closePrice",
+        "netChange",
+        "netPercentChange",
+    }.issubset(quote_fields)
+    assert {"assetMainType", "reference"}.issubset(quote["AAPL"])
+    assert {"description", "exchange", "exchangeName", "cusip"}.issubset(
+        quote["AAPL"]["reference"]
+    )
+    assert "candles" in price_history
+    assert {"open", "high", "low", "close", "volume", "datetime"}.issubset(
+        price_history["candles"][0]
+    )
+
+
+def test_schwab_account_payloads_contain_consumed_fields() -> None:
+    numbers = broker_payloads.schwab_account_numbers_payload()
+    account = broker_payloads.schwab_account_payload()
+    balances = broker_payloads.schwab_balances_payload()
+
+    assert {"accountNumber", "hashValue"}.issubset(numbers[0])
+    securities_account: dict[str, Any] = account["securitiesAccount"]
+    assert {"accountNumber", "type", "positions"}.issubset(securities_account)
+    assert {
+        "instrument",
+        "longQuantity",
+        "shortQuantity",
+        "averagePrice",
+        "marketValue",
+    }.issubset(securities_account["positions"][0])
+    assert {"currentBalances", "initialBalances"}.issubset(
+        balances["securitiesAccount"]
+    )
+
+
+def test_broker_error_payloads_are_structured_and_copy_safe() -> None:
+    first_error = broker_payloads.broker_auth_error_payload()
+    second_error = broker_payloads.broker_auth_error_payload()
+    first_quote = broker_payloads.robinhood_quote_payload()
+    second_quote = broker_payloads.robinhood_quote_payload()
+
+    assert first_error["result"]["status"] == "error"
+    assert "error" in first_error["result"]
+
+    first_error["result"]["status"] = "mutated"
+    first_quote["symbol"] = "MSFT"
+
+    assert second_error["result"]["status"] == "error"
+    assert second_quote["symbol"] == "AAPL"

--- a/tests/unit/test_schwab_account_tools.py
+++ b/tests/unit/test_schwab_account_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for Schwab account tools."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -24,30 +25,20 @@ class TestSchwabAccountTools:
     )
     @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     async def test_get_account_numbers_success(
-        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_account_numbers_payload: list[dict[str, Any]],
     ) -> None:
         """Test successful account numbers retrieval."""
         # Mock broker
         mock_broker = MagicMock()
         mock_response = MagicMock()
-        mock_response.json.return_value = [
-            {
-                "accountNumber": "12345678",
-                "hashValue": "abc123def456",
-            },
-            {
-                "accountNumber": "87654321",
-                "hashValue": "xyz789uvw012",
-            },
-        ]
+        mock_response.json.return_value = schwab_account_numbers_payload
         mock_broker.client.get_account_numbers.return_value = mock_response
         mock_get_broker.return_value = (mock_broker, None)
 
-        # Mock asyncio.to_thread
-        mock_to_thread.return_value = [
-            {"accountNumber": "12345678", "hashValue": "abc123def456"},
-            {"accountNumber": "87654321", "hashValue": "xyz789uvw012"},
-        ]
+        mock_to_thread.return_value = schwab_account_numbers_payload
 
         result = await get_schwab_account_numbers()
 
@@ -64,16 +55,16 @@ class TestSchwabAccountTools:
         "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
     )
     async def test_get_account_numbers_auth_error(
-        self, mock_get_broker: AsyncMock
+        self,
+        mock_get_broker: AsyncMock,
+        broker_auth_error_payload: dict[str, Any],
     ) -> None:
         """Test account numbers when authentication fails."""
-        # Mock authentication error
-        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
-        mock_get_broker.return_value = (None, error_response)
+        mock_get_broker.return_value = (None, broker_auth_error_payload)
 
         result = await get_schwab_account_numbers()
 
-        assert result == error_response
+        assert result == broker_auth_error_payload
 
     @pytest.mark.journey_account
     @pytest.mark.unit
@@ -88,6 +79,7 @@ class TestSchwabAccountTools:
         mock_client: MagicMock,
         mock_to_thread: AsyncMock,
         mock_get_broker: AsyncMock,
+        schwab_account_payload: dict[str, Any],
     ) -> None:
         """Test successful account retrieval."""
         # Mock broker
@@ -97,17 +89,7 @@ class TestSchwabAccountTools:
         # Mock Client.Account.Fields
         mock_client.Account.Fields.POSITIONS = "positions"
 
-        # Mock response
-        mock_to_thread.return_value = {
-            "securitiesAccount": {
-                "accountNumber": "12345678",
-                "type": "MARGIN",
-                "roundTrips": 0,
-                "isDayTrader": False,
-                "isClosingOnlyRestricted": False,
-                "positions": [],
-            }
-        }
+        mock_to_thread.return_value = schwab_account_payload
 
         result = await get_schwab_account("abc123")
 
@@ -123,28 +105,17 @@ class TestSchwabAccountTools:
     )
     @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
     async def test_get_accounts_success(
-        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_accounts_payload: list[dict[str, Any]],
     ) -> None:
         """Test successful accounts retrieval."""
         # Mock broker
         mock_broker = MagicMock()
         mock_get_broker.return_value = (mock_broker, None)
 
-        # Mock response
-        mock_to_thread.return_value = [
-            {
-                "securitiesAccount": {
-                    "accountNumber": "12345678",
-                    "type": "MARGIN",
-                }
-            },
-            {
-                "securitiesAccount": {
-                    "accountNumber": "87654321",
-                    "type": "CASH",
-                }
-            },
-        ]
+        mock_to_thread.return_value = schwab_accounts_payload
 
         result = await get_schwab_accounts()
 
@@ -166,6 +137,7 @@ class TestSchwabAccountTools:
         mock_client: MagicMock,
         mock_to_thread: AsyncMock,
         mock_get_broker: AsyncMock,
+        schwab_account_payload: dict[str, Any],
     ) -> None:
         """Test successful portfolio retrieval."""
         # Mock broker
@@ -175,28 +147,7 @@ class TestSchwabAccountTools:
         # Mock Client.Account.Fields
         mock_client.Account.Fields.POSITIONS = "positions"
 
-        # Mock response with positions
-        mock_to_thread.return_value = {
-            "securitiesAccount": {
-                "positions": [
-                    {
-                        "shortQuantity": 0.0,
-                        "averagePrice": 150.0,
-                        "currentDayProfitLoss": 50.0,
-                        "currentDayProfitLossPercentage": 2.5,
-                        "longQuantity": 10.0,
-                        "settledLongQuantity": 10.0,
-                        "settledShortQuantity": 0.0,
-                        "instrument": {
-                            "assetType": "EQUITY",
-                            "cusip": "037833100",
-                            "symbol": "AAPL",
-                        },
-                        "marketValue": 1500.0,
-                    }
-                ]
-            }
-        }
+        mock_to_thread.return_value = schwab_account_payload
 
         result = await get_schwab_portfolio("abc123")
 
@@ -219,26 +170,14 @@ class TestSchwabAccountTools:
         mock_client: MagicMock,
         mock_to_thread: AsyncMock,
         mock_get_broker: AsyncMock,
+        schwab_balances_payload: dict[str, Any],
     ) -> None:
         """Test successful account balances retrieval."""
         # Mock broker
         mock_broker = MagicMock()
         mock_get_broker.return_value = (mock_broker, None)
 
-        # Mock response with balances
-        mock_to_thread.return_value = {
-            "securitiesAccount": {
-                "currentBalances": {
-                    "liquidationValue": 50000.0,
-                    "cashBalance": 10000.0,
-                    "longMarketValue": 40000.0,
-                    "shortMarketValue": 0.0,
-                },
-                "initialBalances": {
-                    "accountValue": 48000.0,
-                },
-            }
-        }
+        mock_to_thread.return_value = schwab_balances_payload
 
         result = await get_schwab_account_balances("abc123")
 

--- a/tests/unit/test_schwab_market_tools.py
+++ b/tests/unit/test_schwab_market_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for Schwab market data tools."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -24,34 +25,17 @@ class TestSchwabMarketTools:
     )
     @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_get_quote_success(
-        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_quote_payload: dict[str, Any],
     ) -> None:
         """Test successful stock quote retrieval."""
         # Mock broker
         mock_broker = MagicMock()
         mock_get_broker.return_value = (mock_broker, None)
 
-        # Mock response
-        mock_to_thread.return_value = {
-            "AAPL": {
-                "quote": {
-                    "lastPrice": 175.50,
-                    "bidPrice": 175.45,
-                    "askPrice": 175.55,
-                    "bidSize": 100,
-                    "askSize": 200,
-                    "totalVolume": 50000000,
-                    "openPrice": 174.00,
-                    "highPrice": 176.00,
-                    "lowPrice": 173.50,
-                    "closePrice": 174.50,
-                    "netChange": 1.00,
-                    "netPercentChange": 0.57,
-                    "52WkHigh": 200.00,
-                    "52WkLow": 125.00,
-                }
-            }
-        }
+        mock_to_thread.return_value = schwab_quote_payload
 
         result = await get_schwab_quote("AAPL")
 
@@ -67,15 +51,17 @@ class TestSchwabMarketTools:
     @patch(
         "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
     )
-    async def test_get_quote_auth_error(self, mock_get_broker: AsyncMock) -> None:
+    async def test_get_quote_auth_error(
+        self,
+        mock_get_broker: AsyncMock,
+        broker_auth_error_payload: dict[str, Any],
+    ) -> None:
         """Test quote retrieval when authentication fails."""
-        # Mock authentication error
-        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
-        mock_get_broker.return_value = (None, error_response)
+        mock_get_broker.return_value = (None, broker_auth_error_payload)
 
         result = await get_schwab_quote("AAPL")
 
-        assert result == error_response
+        assert result == broker_auth_error_payload
 
     @pytest.mark.journey_market_data
     @pytest.mark.unit
@@ -85,36 +71,17 @@ class TestSchwabMarketTools:
     )
     @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_get_quotes_success(
-        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_quotes_payload: dict[str, Any],
     ) -> None:
         """Test successful multiple quotes retrieval."""
         # Mock broker
         mock_broker = MagicMock()
         mock_get_broker.return_value = (mock_broker, None)
 
-        # Mock response
-        mock_to_thread.return_value = {
-            "AAPL": {
-                "quote": {
-                    "lastPrice": 175.50,
-                    "netChange": 1.00,
-                    "netPercentChange": 0.57,
-                    "totalVolume": 50000000,
-                    "bidPrice": 175.45,
-                    "askPrice": 175.55,
-                }
-            },
-            "GOOGL": {
-                "quote": {
-                    "lastPrice": 140.25,
-                    "netChange": -2.50,
-                    "netPercentChange": -1.75,
-                    "totalVolume": 25000000,
-                    "bidPrice": 140.20,
-                    "askPrice": 140.30,
-                }
-            },
-        }
+        mock_to_thread.return_value = schwab_quotes_payload
 
         result = await get_schwab_quotes(["AAPL", "GOOGL"])
 
@@ -135,8 +102,9 @@ class TestSchwabMarketTools:
     async def test_get_price_history_success(
         self,
         mock_client: MagicMock,
-        mock_to_thread: MagicMock,
-        mock_get_broker: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_price_history_payload: dict[str, Any],
     ) -> None:
         """Test successful price history retrieval."""
         # Mock broker
@@ -147,28 +115,7 @@ class TestSchwabMarketTools:
         mock_client.PriceHistory.PeriodType.DAY = "day"
         mock_client.PriceHistory.FrequencyType.MINUTE = "minute"
 
-        # Mock response
-        mock_to_thread.return_value = {
-            "candles": [
-                {
-                    "open": 174.00,
-                    "high": 175.00,
-                    "low": 173.50,
-                    "close": 174.50,
-                    "volume": 1000000,
-                    "datetime": 1672531200000,
-                },
-                {
-                    "open": 174.50,
-                    "high": 176.00,
-                    "low": 174.00,
-                    "close": 175.50,
-                    "volume": 1500000,
-                    "datetime": 1672534800000,
-                },
-            ],
-            "empty": False,
-        }
+        mock_to_thread.return_value = schwab_price_history_payload
 
         result = await get_schwab_price_history("AAPL", "day", 1, "minute", 1)
 
@@ -208,25 +155,17 @@ class TestSchwabMarketTools:
     )
     @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_get_instrument_success(
-        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_quote_payload: dict[str, Any],
     ) -> None:
         """Test successful instrument retrieval."""
         # Mock broker
         mock_broker = MagicMock()
         mock_get_broker.return_value = (mock_broker, None)
 
-        # Mock response
-        mock_to_thread.return_value = {
-            "AAPL": {
-                "assetMainType": "EQUITY",
-                "reference": {
-                    "description": "Apple Inc",
-                    "exchange": "Q",
-                    "exchangeName": "NASDAQ",
-                    "cusip": "037833100",
-                },
-            }
-        }
+        mock_to_thread.return_value = schwab_quote_payload
 
         result = await get_schwab_instrument("AAPL")
 
@@ -243,23 +182,17 @@ class TestSchwabMarketTools:
     )
     @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
     async def test_search_instruments_success(
-        self, mock_to_thread: AsyncMock, mock_get_broker: AsyncMock
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_quote_payload: dict[str, Any],
     ) -> None:
         """Test successful instrument search."""
         # Mock broker
         mock_broker = MagicMock()
         mock_get_broker.return_value = (mock_broker, None)
 
-        # Mock response
-        mock_to_thread.return_value = {
-            "AAPL": {
-                "assetMainType": "EQUITY",
-                "reference": {
-                    "description": "Apple Inc",
-                    "exchangeName": "NASDAQ",
-                },
-            }
-        }
+        mock_to_thread.return_value = schwab_quote_payload
 
         result = await search_schwab_instruments("AAPL")
 

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -40,20 +40,15 @@ class TestStockMarketTools:
     @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_latest_price")
     @pytest.mark.asyncio
     async def test_get_stock_price_success(
-        self, mock_latest_price: Any, mock_quotes: Any
+        self,
+        mock_latest_price: Any,
+        mock_quotes: Any,
+        robinhood_quote_payload: dict[str, Any],
     ) -> None:
         """Test successful stock price retrieval."""
         clear_all_caches()
-        mock_latest_price.return_value = ["150.25"]
-        mock_quotes.return_value = [
-            {
-                "previous_close": "148.50",
-                "volume": "1000000",
-                "ask_price": "150.30",
-                "bid_price": "150.20",
-                "last_trade_price": "150.25",
-            }
-        ]
+        mock_latest_price.return_value = [robinhood_quote_payload["last_trade_price"]]
+        mock_quotes.return_value = [robinhood_quote_payload]
 
         result = await get_stock_price("AAPL")
 
@@ -173,23 +168,16 @@ class TestStockMarketTools:
     @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_fundamentals")
     @pytest.mark.asyncio
     async def test_get_stock_info_success(
-        self, mock_fundamentals: Any, mock_instruments: Any, mock_name: Any
+        self,
+        mock_fundamentals: Any,
+        mock_instruments: Any,
+        mock_name: Any,
+        robinhood_fundamentals_payload: dict[str, Any],
+        robinhood_instrument_payload: dict[str, Any],
     ) -> None:
         """Test successful stock info retrieval."""
-        mock_fundamentals.return_value = [
-            {
-                "sector": "Technology",
-                "industry": "Consumer Electronics",
-                "description": "Apple Inc. designs and manufactures smartphones",
-                "market_cap": "3000000000000",
-                "pe_ratio": "25.5",
-                "dividend_yield": "0.50",
-                "high_52_weeks": "182.94",
-                "low_52_weeks": "124.17",
-                "average_volume": "50000000",
-            }
-        ]
-        mock_instruments.return_value = [{"simple_name": "Apple", "tradeable": True}]
+        mock_fundamentals.return_value = [robinhood_fundamentals_payload]
+        mock_instruments.return_value = [robinhood_instrument_payload]
         mock_name.return_value = "Apple Inc."
 
         result = await get_stock_info("AAPL")
@@ -228,24 +216,13 @@ class TestStockMarketTools:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.find_instrument_data")
     @pytest.mark.asyncio
-    async def test_search_stocks_success(self, mock_find_instrument: Any) -> None:
+    async def test_search_stocks_success(
+        self,
+        mock_find_instrument: Any,
+        robinhood_search_payload: list[dict[str, Any]],
+    ) -> None:
         """Test successful stock search."""
-        mock_find_instrument.return_value = [
-            {
-                "symbol": "AAPL",
-                "simple_name": "Apple Inc.",
-                "tradeable": True,
-                "country": "US",
-                "type": "stock",
-            },
-            {
-                "symbol": "GOOGL",
-                "simple_name": "Alphabet Inc.",
-                "tradeable": True,
-                "country": "US",
-                "type": "stock",
-            },
-        ]
+        mock_find_instrument.return_value = robinhood_search_payload
 
         result = await search_stocks("Apple")
 


### PR DESCRIPTION
Closes #148

## Changes
- Added shared Robinhood and Schwab broker API payload builders under `tests/fixtures/` with copy-safe helper returns.
- Exposed named pytest fixtures through `tests/conftest.py` for quote, account, portfolio, positions, history, and auth-error payloads.
- Refactored representative Robinhood and Schwab unit tests to consume the shared fixtures instead of inline response dictionaries.
- Added schema/copy-safety tests for the shared broker fixture library.

## Test plan
- `uv run pytest tests/unit/test_broker_fixture_payloads.py -q`
- `uv run pytest tests/unit -k 'mock or fixture or schwab or robinhood'`
- `uv run ruff check src tests`
- `git diff --check`

## Notes
- The implementation plan's broad consumer command `uv run pytest tests/unit/test_stock_market_tools.py tests/unit/test_account_tools.py tests/unit/test_schwab_market_tools.py tests/unit/test_schwab_account_tools.py -k 'success or auth_error' -q` also selects an unrelated existing `TestServerTools::test_health_check_success` case, which currently returns `unhealthy` instead of the test's expected `success`. I used explicit refactored consumer node IDs plus the issue-requested broker/mock selector for validation.