### PR TITLE
refactor: use explicit core component statuses in health aggregation (#151)

### DIFF
--- a/src/open_stocks_mcp/health.py
+++ b/src/open_stocks_mcp/health.py
@@ -159,8 +159,11 @@ class HealthService:
                 component_states.append(broker_component.status)
                 broker_states.append(broker_component.status)
 
+        # Overall status aggregation. Unhealthy if any core component (metrics/session)
+        # is unhealthy, or if all configured brokers are unhealthy.
         overall = ComponentStatus.HEALTHY
-        core_states = component_states[:2]
+        core_states = [metrics_component.status, session_component.status]
+
         if any(state == ComponentStatus.UNHEALTHY for state in core_states) or (
             broker_states
             and all(state == ComponentStatus.UNHEALTHY for state in broker_states)


### PR DESCRIPTION
Closes #151

## Changes
- Refactored health aggregation logic in `HealthService` to use explicit named component statuses for core components (metrics and session).
- Replaced order-dependent list slicing (`component_states[:2]`) with a more robust explicit list.
- Added explanatory comments for the aggregation logic.

## Test plan
- Verified with existing unit tests: `uv run pytest tests/unit/test_health_service.py`
- Verified that the logic correctly identifies unhealthy states when core components fail.