### PR TITLE
docs: mark Phase 8 monitoring metrics as complete in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,12 +133,14 @@ ROBINHOOD_PASSWORD="password"
 - ✅ **Type Safety**: Zero MyPy errors maintained across codebase
 - ✅ **Trading Validation**: All functions live-tested or API-corrected
 - ✅ **Account Details Fix**: Fixed load_phoenix_account response parsing for real financial data
+- ✅ **Phase 8 Monitoring**: Per-tool latency (p50/p95/p99), throughput metrics, and `/metrics` Prometheus endpoint
 
-### Next Phase Priority
-**Phase 8: Quality & Reliability (v0.6.4)** - Final phase:
-- Advanced error handling and recovery mechanisms
-- Performance optimization and caching strategies
-- Enhanced monitoring and observability features
+### Phase 8 Status
+**Phase 8: Quality & Reliability (v0.6.4)** — monitoring and alerting features complete:
+- ✅ Per-tool latency percentiles and throughput metrics (`MetricsCollector`)
+- ✅ Unauthenticated `GET /metrics` Prometheus-compatible endpoint
+- ✅ MCP `tools/call` instrumentation in HTTP transport
+- Remaining: Performance optimization and caching strategies
 
 ## Critical Development Patterns
 


### PR DESCRIPTION
Closes #152

## Changes
- Update `CLAUDE.md` development status to mark per-tool latency percentiles, throughput metrics, and Prometheus `/metrics` endpoint as complete
- Reflects work implemented in #162, which was merged as PR #296 on 2026-05-20

## Background
Issue #152 was a duplicate tracker for #162. Per the `FOREMAN_IMPLEMENTATION_PLAN` on #152, this issue should be closed once #162 lands on `main`. PR #296 (merged 2026-05-20T22:29:03Z) implemented:
- Per-tool p50/p95/p99 latency in `MetricsCollector`
- Per-tool calls-per-minute throughput
- Unauthenticated `GET /metrics` Prometheus-compatible endpoint
- MCP `tools/call` instrumentation in HTTP transport

## Test plan
- `uv run pytest tests/unit/test_monitoring.py -q` — 5 passed
- `uv run pytest tests/http_transport/test_http_server.py -q -k 'metrics or tool_call'` — 2 passed
- `uv run pytest tests/unit/test_analytics_tools.py tests/unit/test_stock_market_tools.py -q -k metrics_summary` — 2 passed
- `uv run ruff check src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/http_transport.py tests/unit/test_monitoring.py tests/http_transport/test_http_server.py` — All checks passed