### PR TITLE
feat: add broker/account health and concurrency safety

### DIFF
--- a/src/open_stocks_mcp/brokers/base.py
+++ b/src/open_stocks_mcp/brokers/base.py
@@ -94,40 +94,25 @@ class BaseBroker(ABC):
         """
         return self._auth_info.status != BrokerAuthStatus.NOT_CONFIGURED
 
-    @property
-    def account_id(self) -> str:
-        """Default account key used for account-scoped health and auth guards."""
-        return "default"
-
-    def get_account_metadata(self) -> dict[str, Any]:
-        """Return broker account metadata for health surfaces.
-
-        Broker subclasses can override this when they manage multiple accounts.
-        """
-        return {"account_id": self.account_id}
-
-    def get_health_metadata(self) -> dict[str, Any]:
-        """Return additive broker health metadata for monitoring surfaces."""
-        return {
-            "broker": self.name,
-            "account_id": self.account_id,
-            "auth_status": self._auth_info.status.value,
-            "is_available": self.is_available(),
-            "is_configured": self.is_configured(),
-        }
-
     def get_health_status(self) -> dict[str, Any]:
         """Return broker health and capability summary.
 
         Returns:
-            Dict with broker, account, auth, capability, and streaming health data.
+            Dict with broker, is_available, auth_status, capabilities, streaming_ready
         """
         available = self.is_available()
         return {
-            **self.get_health_metadata(),
+            "broker": self._name,
+            "account_id": self.get_default_account_id(),
+            "is_available": available,
+            "auth_status": self._auth_info.status.value,
             "capabilities": asdict(self._capabilities),
             "streaming_ready": available and self._capabilities.streaming_quotes,
         }
+
+    def get_default_account_id(self) -> str:
+        """Return a stable default account key for account-scoped metrics."""
+        return "default"
 
     @abstractmethod
     async def authenticate(self) -> bool:

--- a/src/open_stocks_mcp/brokers/registry.py
+++ b/src/open_stocks_mcp/brokers/registry.py
@@ -1,9 +1,7 @@
 """Broker registry for managing multiple broker instances."""
 
 import asyncio
-import inspect
 import time
-from collections.abc import Awaitable, Callable
 from typing import Any
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
@@ -31,9 +29,8 @@ class BrokerRegistry:
         self._brokers: dict[str, BaseBroker] = {}
         self._active_broker: str | None = None
         self._authentication_attempts: dict[str, int] = {}
-        self._auth_refresh_futures: dict[tuple[str, str], asyncio.Task[Any]] = {}
-        self._auth_refresh_lock = asyncio.Lock()
-        self._auth_operation_locks: dict[tuple[str, str], asyncio.Lock] = {}
+        self._refresh_locks: dict[tuple[str, str], asyncio.Lock] = {}
+        self._refresh_futures: dict[tuple[str, str], asyncio.Future[bool]] = {}
 
     def register(self, broker: BaseBroker) -> None:
         """Register a broker instance.
@@ -159,159 +156,6 @@ class BrokerRegistry:
             for name, broker in self._brokers.items()
         }
 
-    def get_broker_health(self) -> dict[str, Any]:
-        """Get broker and account health summaries from collected telemetry."""
-        from open_stocks_mcp.monitoring import get_metrics_collector
-
-        return get_metrics_collector().get_broker_health_summary()
-
-    @staticmethod
-    def _account_key(account_id: str | None) -> str:
-        return account_id or "default"
-
-    @staticmethod
-    async def _maybe_await(value: Any) -> Any:
-        if inspect.isawaitable(value):
-            return await value
-        return value
-
-    async def coordinate_auth_refresh(
-        self,
-        broker_name: str,
-        account_id: str | None,
-        refresh_call: Callable[[], Awaitable[Any] | Any],
-    ) -> Any:
-        """Run one in-flight auth refresh per broker/account key.
-
-        Concurrent callers for the same key await the same refresh task. Different
-        account keys are independent so one account refresh does not serialize all
-        broker activity.
-        """
-        key = (broker_name, self._account_key(account_id))
-
-        async with self._auth_refresh_lock:
-            refresh_task = self._auth_refresh_futures.get(key)
-            if refresh_task is None or refresh_task.done():
-                refresh_task = asyncio.create_task(
-                    self._maybe_await(refresh_call())
-                )
-                self._auth_refresh_futures[key] = refresh_task
-
-        try:
-            return await refresh_task
-        finally:
-            if refresh_task.done():
-                async with self._auth_refresh_lock:
-                    if self._auth_refresh_futures.get(key) is refresh_task:
-                        self._auth_refresh_futures.pop(key, None)
-
-    async def run_with_auth_guard(
-        self,
-        broker_name: str,
-        account_id: str | None,
-        operation: Callable[[], Awaitable[Any] | Any],
-    ) -> Any:
-        """Run an operation under a per broker/account session-state guard."""
-        key = (broker_name, self._account_key(account_id))
-        async with self._auth_refresh_lock:
-            lock = self._auth_operation_locks.setdefault(key, asyncio.Lock())
-
-        async with lock:
-            return await self._maybe_await(operation())
-
-    @staticmethod
-    def _classify_failure(error_type: str) -> str:
-        normalized = error_type.lower()
-        if "pool" in normalized:
-            return "client_pool"
-        if "timeout" in normalized:
-            return "timeout"
-        if "auth" in normalized or "401" in normalized or "token" in normalized:
-            return "authentication"
-        if "account" in normalized:
-            return "account"
-        return "broker_api"
-
-    async def _record_operation_metric(self, result: dict[str, Any]) -> None:
-        try:
-            from open_stocks_mcp.monitoring import get_metrics_collector
-
-            await get_metrics_collector().record_broker_operation(
-                broker=result["broker"],
-                account_id=result["account_id"],
-                operation=result["operation"],
-                duration=result["duration_ms"] / 1000.0,
-                success=result["status"] == "success",
-                error_type=result.get("error", {}).get("type"),
-                failure_class=result.get("error", {}).get("failure_class"),
-            )
-        except Exception as exc:
-            logger.debug(f"Failed to record broker operation metric: {exc}")
-
-    async def run_concurrent_operations(
-        self,
-        operations: list[dict[str, Any]],
-        concurrency_limit: int = 5,
-        timeout_seconds: float = 30.0,
-    ) -> list[dict[str, Any]]:
-        """Run broker operations with bounded fan-out and isolated results."""
-        semaphore = asyncio.Semaphore(max(1, concurrency_limit))
-
-        async def run_one(spec: dict[str, Any]) -> dict[str, Any]:
-            async with semaphore:
-                broker = str(spec.get("broker") or "unknown")
-                account_id = self._account_key(spec.get("account_id"))
-                operation_name = str(spec.get("operation") or "operation")
-                call = spec["call"]
-                start = time.perf_counter()
-
-                try:
-                    result_value = await asyncio.wait_for(
-                        self._maybe_await(call()), timeout=timeout_seconds
-                    )
-                    status = "success"
-                    result: dict[str, Any] = {
-                        "broker": broker,
-                        "account_id": account_id,
-                        "operation": operation_name,
-                        "status": status,
-                        "duration_ms": round((time.perf_counter() - start) * 1000, 2),
-                        "result": result_value,
-                    }
-                except TimeoutError as exc:
-                    error_type = type(exc).__name__
-                    result = {
-                        "broker": broker,
-                        "account_id": account_id,
-                        "operation": operation_name,
-                        "status": "timeout",
-                        "duration_ms": round((time.perf_counter() - start) * 1000, 2),
-                        "error": {
-                            "type": error_type,
-                            "message": f"Operation timed out after {timeout_seconds}s",
-                            "failure_class": "timeout",
-                        },
-                    }
-                except Exception as exc:
-                    error_type = type(exc).__name__
-                    result = {
-                        "broker": broker,
-                        "account_id": account_id,
-                        "operation": operation_name,
-                        "status": "error",
-                        "duration_ms": round((time.perf_counter() - start) * 1000, 2),
-                        "error": {
-                            "type": error_type,
-                            "message": str(exc),
-                            "failure_class": self._classify_failure(error_type),
-                        },
-                    }
-
-                await self._record_operation_metric(result)
-                return result
-
-        return await asyncio.gather(*(run_one(spec) for spec in operations))
-
     async def authenticate_all(self, fail_fast: bool = False) -> dict[str, bool]:
         """Authenticate all registered brokers.
 
@@ -427,6 +271,91 @@ class BrokerRegistry:
                 logger.error(f"Error logging out {broker_name}: {result}")
             else:
                 logger.info(f"✓ {broker_name} logged out successfully")
+
+    async def run_concurrent_operations(
+        self,
+        operations: list[dict[str, Any]],
+        *,
+        concurrency_limit: int = 5,
+        timeout_seconds: float = 10.0,
+    ) -> list[dict[str, Any]]:
+        """Run broker/account operations with bounded fan-out and result isolation."""
+        semaphore = asyncio.Semaphore(max(1, concurrency_limit))
+
+        async def _run(op: dict[str, Any]) -> dict[str, Any]:
+            broker = str(op.get("broker", "unknown"))
+            account_id = op.get("account_id")
+            operation = op.get("operation")
+            if not callable(operation):
+                return {
+                    "broker": broker,
+                    "account_id": account_id,
+                    "status": "error",
+                    "duration_ms": 0,
+                    "error": {"type": "invalid_operation", "message": "Operation must be callable"},
+                }
+
+            start = time.perf_counter()
+            try:
+                async with semaphore:
+                    result = await asyncio.wait_for(operation(), timeout=timeout_seconds)
+                return {
+                    "broker": broker,
+                    "account_id": account_id,
+                    "status": "success",
+                    "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+                    "result": result,
+                }
+            except TimeoutError as exc:
+                return {
+                    "broker": broker,
+                    "account_id": account_id,
+                    "status": "error",
+                    "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+                    "error": {"type": "timeout", "message": str(exc) or "operation timed out"},
+                }
+            except Exception as exc:
+                return {
+                    "broker": broker,
+                    "account_id": account_id,
+                    "status": "error",
+                    "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+                    "error": {"type": type(exc).__name__, "message": str(exc)},
+                }
+
+        return await asyncio.gather(*[_run(op) for op in operations], return_exceptions=False)
+
+    async def coordinated_refresh(
+        self,
+        *,
+        broker_name: str,
+        account_id: str | None,
+        refresh_coro: Any,
+    ) -> bool:
+        """Execute refresh as a single-flight operation per (broker, account)."""
+        key = (broker_name, account_id or "default")
+        lock = self._refresh_locks.setdefault(key, asyncio.Lock())
+
+        existing = self._refresh_futures.get(key)
+        if existing is not None and not existing.done():
+            return await existing
+
+        async with lock:
+            existing = self._refresh_futures.get(key)
+            if existing is not None and not existing.done():
+                return await existing
+
+            future: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+            self._refresh_futures[key] = future
+        try:
+            result = await refresh_coro()
+            future.set_result(bool(result))
+            return bool(result)
+        except Exception:
+            future.set_result(False)
+            raise
+        finally:
+            self._refresh_futures.pop(key, None)
 
 
 # Global registry instance

--- a/src/open_stocks_mcp/brokers/registry.py
+++ b/src/open_stocks_mcp/brokers/registry.py
@@ -285,11 +285,13 @@ class BrokerRegistry:
         async def _run(op: dict[str, Any]) -> dict[str, Any]:
             broker = str(op.get("broker", "unknown"))
             account_id = op.get("account_id")
-            operation = op.get("operation")
+            operation_name = str(op.get("operation", "operation"))
+            operation = op.get("call") or op.get("operation")
             if not callable(operation):
                 return {
                     "broker": broker,
                     "account_id": account_id,
+                    "operation": operation_name,
                     "status": "error",
                     "duration_ms": 0,
                     "error": {"type": "invalid_operation", "message": "Operation must be callable"},
@@ -302,6 +304,7 @@ class BrokerRegistry:
                 return {
                     "broker": broker,
                     "account_id": account_id,
+                    "operation": operation_name,
                     "status": "success",
                     "duration_ms": round((time.perf_counter() - start) * 1000, 2),
                     "result": result,
@@ -310,14 +313,20 @@ class BrokerRegistry:
                 return {
                     "broker": broker,
                     "account_id": account_id,
-                    "status": "error",
+                    "operation": operation_name,
+                    "status": "timeout",
                     "duration_ms": round((time.perf_counter() - start) * 1000, 2),
-                    "error": {"type": "timeout", "message": str(exc) or "operation timed out"},
+                    "error": {
+                        "type": "timeout",
+                        "failure_class": "timeout",
+                        "message": str(exc) or "operation timed out",
+                    },
                 }
             except Exception as exc:
                 return {
                     "broker": broker,
                     "account_id": account_id,
+                    "operation": operation_name,
                     "status": "error",
                     "duration_ms": round((time.perf_counter() - start) * 1000, 2),
                     "error": {"type": type(exc).__name__, "message": str(exc)},
@@ -356,6 +365,14 @@ class BrokerRegistry:
             raise
         finally:
             self._refresh_futures.pop(key, None)
+
+    async def coordinate_auth_refresh(
+        self, broker_name: str, account_id: str | None, refresh_coro: Any
+    ) -> bool:
+        """Backward-compatible alias for coordinated refresh."""
+        return await self.coordinated_refresh(
+            broker_name=broker_name, account_id=account_id, refresh_coro=refresh_coro
+        )
 
 
 # Global registry instance

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -29,8 +29,8 @@ class MetricsCollector:
         self.tool_response_times: dict[str, deque[tuple[datetime, float]]] = (
             defaultdict(deque)
         )
-        self.broker_operations: deque[dict[str, Any]] = deque()
         self.error_types: dict[str, int] = defaultdict(int)
+        self.broker_operations: deque[dict[str, Any]] = deque()
 
         # Counters
         self.total_calls = 0
@@ -88,6 +88,34 @@ class MetricsCollector:
             self.session_refreshes += 1
             logger.info(f"Session refresh recorded. Total: {self.session_refreshes}")
 
+    async def record_broker_operation(
+        self,
+        *,
+        broker: str,
+        account_id: str | None,
+        operation: str,
+        success: bool,
+        duration_ms: float,
+        failure_class: str | None = None,
+        error_type: str | None = None,
+    ) -> None:
+        """Record broker/account operation telemetry."""
+        async with self._lock:
+            now = datetime.now()
+            self._clean_old_entries(now)
+            self.broker_operations.append(
+                {
+                    "timestamp": now,
+                    "broker": broker,
+                    "account_id": account_id or "default",
+                    "operation": operation,
+                    "success": success,
+                    "duration_ms": duration_ms,
+                    "failure_class": failure_class,
+                    "error_type": error_type,
+                }
+            )
+
     async def record_cache_hit(self, name: str) -> None:
         """Record a cache hit for the named cache."""
         async with self._lock:
@@ -97,57 +125,6 @@ class MetricsCollector:
         """Record a cache miss for the named cache."""
         async with self._lock:
             self.cache_misses[name] += 1
-
-    @staticmethod
-    def classify_broker_failure(
-        error_type: str | None, failure_class: str | None = None
-    ) -> str | None:
-        """Classify broker operation failures for health summaries."""
-        if failure_class:
-            return failure_class
-        if not error_type:
-            return None
-
-        normalized = error_type.lower()
-        if "pool" in normalized:
-            return "client_pool"
-        if "timeout" in normalized:
-            return "timeout"
-        if "auth" in normalized or "401" in normalized or "token" in normalized:
-            return "authentication"
-        if "account" in normalized:
-            return "account"
-        return "broker_api"
-
-    async def record_broker_operation(
-        self,
-        broker: str,
-        account_id: str | None,
-        operation: str,
-        duration: float,
-        success: bool,
-        error_type: str | None = None,
-        failure_class: str | None = None,
-    ) -> None:
-        """Record a broker/account scoped operation outcome."""
-        async with self._lock:
-            now = datetime.now()
-            self._clean_old_entries(now)
-            classified_failure = self.classify_broker_failure(
-                error_type, failure_class
-            )
-            self.broker_operations.append(
-                {
-                    "timestamp": now,
-                    "broker": broker,
-                    "account_id": account_id or "default",
-                    "operation": operation,
-                    "duration": duration,
-                    "success": success,
-                    "error_type": error_type,
-                    "failure_class": classified_failure,
-                }
-            )
 
     def _clean_old_entries(self, now: datetime) -> None:
         """Remove entries older than the window size."""
@@ -175,82 +152,8 @@ class MetricsCollector:
             while tool_durations and tool_durations[0][0] < cutoff:
                 tool_durations.popleft()
 
-        while (
-            self.broker_operations
-            and self.broker_operations[0]["timestamp"] < cutoff
-        ):
+        while self.broker_operations and self.broker_operations[0]["timestamp"] < cutoff:
             self.broker_operations.popleft()
-
-    @staticmethod
-    def _empty_health_bucket() -> dict[str, Any]:
-        return {
-            "status": "healthy",
-            "success_count": 0,
-            "error_count": 0,
-            "operations": {},
-            "failure_classes": {},
-            "last_error_type": None,
-            "last_error_at": None,
-        }
-
-    @staticmethod
-    def _update_health_bucket(bucket: dict[str, Any], sample: dict[str, Any]) -> None:
-        operation = str(sample["operation"])
-        bucket["operations"][operation] = bucket["operations"].get(operation, 0) + 1
-
-        if sample["success"]:
-            bucket["success_count"] += 1
-        else:
-            bucket["error_count"] += 1
-            bucket["last_error_type"] = sample["error_type"]
-            bucket["last_error_at"] = sample["timestamp"].isoformat()
-            failure_class = sample["failure_class"] or "broker_api"
-            bucket["failure_classes"][failure_class] = (
-                bucket["failure_classes"].get(failure_class, 0) + 1
-            )
-
-    @staticmethod
-    def _finalize_health_bucket(bucket: dict[str, Any]) -> None:
-        if bucket["error_count"] == 0:
-            bucket["status"] = "healthy"
-        elif bucket["success_count"] > 0:
-            bucket["status"] = "degraded"
-        else:
-            bucket["status"] = "unhealthy"
-
-    def get_broker_health_summary(self) -> dict[str, Any]:
-        """Return broker and account health summaries for recent operations."""
-        now = datetime.now()
-        self._clean_old_entries(now)
-
-        broker_health: dict[str, dict[str, Any]] = {}
-        account_health: dict[str, dict[str, dict[str, Any]]] = {}
-
-        for sample in self.broker_operations:
-            broker = str(sample["broker"])
-            account_id = str(sample["account_id"] or "default")
-
-            broker_bucket = broker_health.setdefault(
-                broker, self._empty_health_bucket()
-            )
-            account_bucket = account_health.setdefault(broker, {}).setdefault(
-                account_id, self._empty_health_bucket()
-            )
-
-            self._update_health_bucket(broker_bucket, sample)
-            self._update_health_bucket(account_bucket, sample)
-
-        for bucket in broker_health.values():
-            self._finalize_health_bucket(bucket)
-
-        for broker_accounts in account_health.values():
-            for bucket in broker_accounts.values():
-                self._finalize_health_bucket(bucket)
-
-        return {
-            "broker_health": broker_health,
-            "account_health": account_health,
-        }
 
     @staticmethod
     def _percentile(samples: list[float], quantile: float) -> float:
@@ -336,6 +239,50 @@ class MetricsCollector:
                     round(hits / total * 100.0, 2) if total > 0 else 0.0
                 )
 
+            broker_health: dict[str, dict[str, Any]] = {}
+            account_health: dict[str, dict[str, Any]] = {}
+            for item in self.broker_operations:
+                broker_key = item["broker"]
+                account_key = f"{broker_key}:{item['account_id']}"
+                for target, key in ((broker_health, broker_key), (account_health, account_key)):
+                    state = target.setdefault(
+                        key,
+                        {
+                            "total": 0,
+                            "success": 0,
+                            "errors": 0,
+                            "last_error_type": None,
+                            "failure_classes": defaultdict(int),
+                        },
+                    )
+                    state["total"] += 1
+                    if item["success"]:
+                        state["success"] += 1
+                    else:
+                        state["errors"] += 1
+                        state["last_error_type"] = item["error_type"]
+                        if item["failure_class"]:
+                            state["failure_classes"][item["failure_class"]] += 1
+
+            broker_health_out = {}
+            for key, state in broker_health.items():
+                broker_health_out[key] = {
+                    "total": state["total"],
+                    "success": state["success"],
+                    "errors": state["errors"],
+                    "last_error_type": state["last_error_type"],
+                    "failure_classes": dict(state["failure_classes"]),
+                }
+            account_health_out = {}
+            for key, state in account_health.items():
+                account_health_out[key] = {
+                    "total": state["total"],
+                    "success": state["success"],
+                    "errors": state["errors"],
+                    "last_error_type": state["last_error_type"],
+                    "failure_classes": dict(state["failure_classes"]),
+                }
+
             return {
                 "window_minutes": self.window_size.total_seconds() / 60,
                 "total_calls": self.total_calls,
@@ -353,7 +300,8 @@ class MetricsCollector:
                 "cache_hits": dict(self.cache_hits),
                 "cache_misses": dict(self.cache_misses),
                 "cache_hit_rate_percent": cache_hit_rate,
-                **self.get_broker_health_summary(),
+                "broker_health": broker_health_out,
+                "account_health": account_health_out,
                 "timestamp": now.isoformat(),
             }
 

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -95,7 +95,8 @@ class MetricsCollector:
         account_id: str | None,
         operation: str,
         success: bool,
-        duration_ms: float,
+        duration_ms: float | None = None,
+        duration: float | None = None,
         failure_class: str | None = None,
         error_type: str | None = None,
     ) -> None:
@@ -103,6 +104,11 @@ class MetricsCollector:
         async with self._lock:
             now = datetime.now()
             self._clean_old_entries(now)
+            duration_ms_val = (
+                duration_ms
+                if duration_ms is not None
+                else ((duration or 0.0) * 1000.0)
+            )
             self.broker_operations.append(
                 {
                     "timestamp": now,
@@ -110,7 +116,7 @@ class MetricsCollector:
                     "account_id": account_id or "default",
                     "operation": operation,
                     "success": success,
-                    "duration_ms": duration_ms,
+                    "duration_ms": duration_ms_val,
                     "failure_class": failure_class,
                     "error_type": error_type,
                 }
@@ -240,48 +246,71 @@ class MetricsCollector:
                 )
 
             broker_health: dict[str, dict[str, Any]] = {}
-            account_health: dict[str, dict[str, Any]] = {}
+            account_health: dict[str, dict[str, dict[str, Any]]] = {}
             for item in self.broker_operations:
                 broker_key = item["broker"]
-                account_key = f"{broker_key}:{item['account_id']}"
-                for target, key in ((broker_health, broker_key), (account_health, account_key)):
-                    state = target.setdefault(
-                        key,
-                        {
-                            "total": 0,
-                            "success": 0,
-                            "errors": 0,
-                            "last_error_type": None,
-                            "failure_classes": defaultdict(int),
-                        },
-                    )
-                    state["total"] += 1
-                    if item["success"]:
-                        state["success"] += 1
-                    else:
-                        state["errors"] += 1
-                        state["last_error_type"] = item["error_type"]
-                        if item["failure_class"]:
-                            state["failure_classes"][item["failure_class"]] += 1
+                acct = str(item["account_id"])
+                state = broker_health.setdefault(
+                    broker_key,
+                    {
+                        "total": 0,
+                        "success": 0,
+                        "errors": 0,
+                        "last_error_type": None,
+                        "failure_classes": defaultdict(int),
+                    },
+                )
+                state["total"] += 1
+                if item["success"]:
+                    state["success"] += 1
+                else:
+                    state["errors"] += 1
+                    state["last_error_type"] = item["error_type"]
+                    if item["failure_class"]:
+                        state["failure_classes"][item["failure_class"]] += 1
+
+                broker_accounts = account_health.setdefault(broker_key, {})
+                account_state = broker_accounts.setdefault(
+                    acct,
+                    {
+                        "total": 0,
+                        "success": 0,
+                        "errors": 0,
+                        "last_error_type": None,
+                        "failure_classes": defaultdict(int),
+                    },
+                )
+                account_state["total"] += 1
+                if item["success"]:
+                    account_state["success"] += 1
+                else:
+                    account_state["errors"] += 1
+                    account_state["last_error_type"] = item["error_type"]
+                    if item["failure_class"]:
+                        account_state["failure_classes"][item["failure_class"]] += 1
 
             broker_health_out = {}
             for key, state in broker_health.items():
                 broker_health_out[key] = {
+                    "status": "healthy" if state["errors"] == 0 else "degraded",
                     "total": state["total"],
                     "success": state["success"],
                     "errors": state["errors"],
                     "last_error_type": state["last_error_type"],
                     "failure_classes": dict(state["failure_classes"]),
                 }
-            account_health_out = {}
-            for key, state in account_health.items():
-                account_health_out[key] = {
-                    "total": state["total"],
-                    "success": state["success"],
-                    "errors": state["errors"],
-                    "last_error_type": state["last_error_type"],
-                    "failure_classes": dict(state["failure_classes"]),
-                }
+            account_health_out: dict[str, dict[str, dict[str, Any]]] = {}
+            for broker_name, accounts in account_health.items():
+                account_health_out[broker_name] = {}
+                for account_id_key, state in accounts.items():
+                    account_health_out[broker_name][account_id_key] = {
+                        "status": "healthy" if state["errors"] == 0 else "degraded",
+                        "total": state["total"],
+                        "success": state["success"],
+                        "errors": state["errors"],
+                        "last_error_type": state["last_error_type"],
+                        "failure_classes": dict(state["failure_classes"]),
+                    }
 
             return {
                 "window_minutes": self.window_size.total_seconds() / 60,

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -316,20 +316,18 @@ def create_http_server(
             health_service = get_health_service()
             health_status = await health_service.get_status()
             metrics = await metrics_collector.get_metrics()
-            broker_health = metrics.get("broker_health", {})
-            account_health = metrics.get("account_health", {})
 
             # The health service snapshot provides status, components, and timestamp.
             # We preserve HTTP metadata: version and transport.
             return {
                 "status": health_status["status"],
                 "components": health_status["components"],
+                "broker_health": metrics.get("broker_health", {}),
+                "account_health": metrics.get("account_health", {}),
                 "circuit_breaker": get_broker_circuit_breaker().snapshot(),
                 "timestamp": health_status.get("timestamp", time.time()),
                 "version": __version__,
                 "transport": "http",
-                "broker_health": broker_health,
-                "account_health": account_health,
             }
         except HTTPException:
             raise
@@ -361,6 +359,8 @@ def create_http_server(
                 "rate_limiting": rate_stats,
                 "circuit_breaker": get_broker_circuit_breaker().snapshot(),
                 "metrics": metrics,
+                "broker_health": metrics.get("broker_health", {}),
+                "account_health": metrics.get("account_health", {}),
             }
         except HTTPException:
             raise

--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -57,6 +57,11 @@ async def get_broker_status_data() -> dict[str, Any]:
             "result": {
                 "brokers": auth_status,
                 "available_brokers": available_brokers,
+                "broker_health": {
+                    name: broker.get_health_status()
+                    for name in registry.list_brokers()
+                    if (broker := registry.get_broker(name)) is not None
+                },
                 "total_configured": len(registry.list_brokers()),
                 "total_authenticated": len(available_brokers),
                 "broker_health": broker_health,
@@ -119,6 +124,7 @@ async def get_rate_limit_status_data() -> dict[str, Any]:
     return {
         "result": {
             **stats,
+            "endpoint_usage": stats.get("endpoint_usage", {}),
             "circuit_breaker": get_broker_circuit_breaker().snapshot(),
             "status": "success",
         }
@@ -130,7 +136,14 @@ async def get_metrics_summary_data() -> dict[str, Any]:
     metrics_collector = get_metrics_collector()
     metrics = await metrics_collector.get_metrics()
 
-    return {"result": {**metrics, "status": "success"}}
+    return {
+        "result": {
+            **metrics,
+            "broker_health": metrics.get("broker_health", {}),
+            "account_health": metrics.get("account_health", {}),
+            "status": "success",
+        }
+    }
 
 
 async def get_health_check_data() -> dict[str, Any]:
@@ -140,6 +153,8 @@ async def get_health_check_data() -> dict[str, Any]:
     return {
         "result": {
             **health_status,
+            "broker_health": metrics.get("broker_health", {}),
+            "account_health": metrics.get("account_health", {}),
             "circuit_breaker": get_broker_circuit_breaker().snapshot(),
             "broker_health": metrics.get("broker_health", {}),
             "account_health": metrics.get("account_health", {}),

--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -44,7 +44,11 @@ async def get_broker_status_data() -> dict[str, Any]:
         registry = await get_broker_registry()
         auth_status = registry.get_auth_status()
         available_brokers = registry.get_available_brokers()
-        broker_health = {}
+        broker_health = {
+            name: broker.get_health_status()
+            for name in registry.list_brokers()
+            if (broker := registry.get_broker(name)) is not None
+        }
         account_health = {}
         get_broker_health = getattr(registry, "get_broker_health", None)
         if callable(get_broker_health):
@@ -57,11 +61,6 @@ async def get_broker_status_data() -> dict[str, Any]:
             "result": {
                 "brokers": auth_status,
                 "available_brokers": available_brokers,
-                "broker_health": {
-                    name: broker.get_health_status()
-                    for name in registry.list_brokers()
-                    if (broker := registry.get_broker(name)) is not None
-                },
                 "total_configured": len(registry.list_brokers()),
                 "total_authenticated": len(available_brokers),
                 "broker_health": broker_health,
@@ -156,8 +155,6 @@ async def get_health_check_data() -> dict[str, Any]:
             "broker_health": metrics.get("broker_health", {}),
             "account_health": metrics.get("account_health", {}),
             "circuit_breaker": get_broker_circuit_breaker().snapshot(),
-            "broker_health": metrics.get("broker_health", {}),
-            "account_health": metrics.get("account_health", {}),
             "health_status": health_status["status"],
             "status": "success",
         }

--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -36,22 +36,13 @@ class RateLimiter:
         self.endpoint_buckets: dict[str, deque[float]] = defaultdict(
             lambda: deque(maxlen=100)
         )
-        self.broker_buckets: dict[str, deque[float]] = defaultdict(
-            lambda: deque(maxlen=100)
-        )
 
-    async def acquire(
-        self,
-        endpoint: str | None = None,
-        weight: float = 1.0,
-        broker: str | None = None,
-    ) -> None:
+    async def acquire(self, endpoint: str | None = None, weight: float = 1.0) -> None:
         """Acquire permission to make an API call.
 
         Args:
             endpoint: Optional endpoint identifier for per-endpoint limiting
             weight: Weight of this call (some calls may count more)
-            broker: Optional broker identifier for per-broker telemetry
         """
         async with self._lock:
             now = time.time()
@@ -112,19 +103,6 @@ class RateLimiter:
             # Track per-endpoint if specified
             if endpoint:
                 self.endpoint_buckets[endpoint].append(now)
-            if broker:
-                self.broker_buckets[broker].append(now)
-
-    @staticmethod
-    def _bucket_stats(bucket: deque[float], now: float) -> dict[str, Any]:
-        cutoff_minute = now - 60
-        cutoff_hour = now - 3600
-        calls_last_minute = sum(1 for t in bucket if t > cutoff_minute)
-        calls_last_hour = sum(1 for t in bucket if t > cutoff_hour)
-        return {
-            "calls_last_minute": calls_last_minute,
-            "calls_last_hour": calls_last_hour,
-        }
 
     def get_stats(self) -> dict[str, Any]:
         """Get current rate limiter statistics.
@@ -139,14 +117,6 @@ class RateLimiter:
 
         calls_last_minute = sum(1 for t in self.call_times if t > cutoff_minute)
         calls_last_hour = len(self.call_times)
-        endpoint_usage = {
-            endpoint: self._bucket_stats(bucket, now)
-            for endpoint, bucket in self.endpoint_buckets.items()
-        }
-        broker_usage = {
-            broker: self._bucket_stats(bucket, now)
-            for broker, bucket in self.broker_buckets.items()
-        }
 
         return {
             "calls_last_minute": calls_last_minute,
@@ -156,8 +126,13 @@ class RateLimiter:
             "burst_size": self.burst_size,
             "minute_usage_percent": (calls_last_minute / self.calls_per_minute) * 100,
             "hour_usage_percent": (calls_last_hour / self.calls_per_hour) * 100,
-            "endpoint_usage": endpoint_usage,
-            "broker_usage": broker_usage,
+            "endpoint_usage": {
+                endpoint: {
+                    "calls_last_minute": sum(1 for t in bucket if t > cutoff_minute),
+                    "calls_last_hour": sum(1 for t in bucket if t > now - 3600),
+                }
+                for endpoint, bucket in self.endpoint_buckets.items()
+            },
         }
 
 

--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -36,8 +36,16 @@ class RateLimiter:
         self.endpoint_buckets: dict[str, deque[float]] = defaultdict(
             lambda: deque(maxlen=100)
         )
+        self.broker_buckets: dict[str, deque[float]] = defaultdict(
+            lambda: deque(maxlen=100)
+        )
 
-    async def acquire(self, endpoint: str | None = None, weight: float = 1.0) -> None:
+    async def acquire(
+        self,
+        endpoint: str | None = None,
+        weight: float = 1.0,
+        broker: str | None = None,
+    ) -> None:
         """Acquire permission to make an API call.
 
         Args:
@@ -103,6 +111,8 @@ class RateLimiter:
             # Track per-endpoint if specified
             if endpoint:
                 self.endpoint_buckets[endpoint].append(now)
+            if broker:
+                self.broker_buckets[broker].append(now)
 
     def get_stats(self) -> dict[str, Any]:
         """Get current rate limiter statistics.
@@ -132,6 +142,13 @@ class RateLimiter:
                     "calls_last_hour": sum(1 for t in bucket if t > now - 3600),
                 }
                 for endpoint, bucket in self.endpoint_buckets.items()
+            },
+            "broker_usage": {
+                broker: {
+                    "calls_last_minute": sum(1 for t in bucket if t > cutoff_minute),
+                    "calls_last_hour": sum(1 for t in bucket if t > now - 3600),
+                }
+                for broker, bucket in self.broker_buckets.items()
             },
         }
 

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -2,14 +2,9 @@
 
 import asyncio
 import functools
-import inspect
 from collections.abc import Callable
 from typing import Any
 
-from open_stocks_mcp.brokers.registry import (
-    RegistryNotInitializedError,
-    get_broker_registry_sync,
-)
 from open_stocks_mcp.config import load_config
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.exceptions import (
@@ -18,30 +13,6 @@ from open_stocks_mcp.tools.exceptions import (
     DataError,
     classify_error,
 )
-
-
-async def _refresh_session_with_registry_guard(
-    session_manager: Any,
-    broker_name: str | None,
-    account_id: str | None,
-) -> bool:
-    """Refresh auth through the broker registry single-flight guard when present."""
-    async def refresh_call() -> Any:
-        result = session_manager.refresh_session()
-        if inspect.isawaitable(result):
-            return await result
-        return result
-
-    try:
-        registry = get_broker_registry_sync()
-    except RegistryNotInitializedError:
-        return bool(await refresh_call())
-
-    return bool(
-        await registry.coordinate_auth_refresh(
-            broker_name or "robinhood", account_id or "default", refresh_call
-        )
-    )
 
 
 async def execute_with_retry(
@@ -53,11 +24,12 @@ async def execute_with_retry(
     handle_auth_errors: bool = True,
     rate_limit: bool = True,
     endpoint: str | None = None,
-    broker_name: str | None = "robinhood",
+    broker_name: str = "robinhood",
     account_id: str | None = None,
     **kwargs: Any,
 ) -> Any:
     """Execute a function with retry logic for transient errors."""
+    from open_stocks_mcp.brokers.registry import get_broker_registry
     from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
     from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
     from open_stocks_mcp.tools.session_manager import get_session_manager
@@ -122,10 +94,10 @@ async def execute_with_retry(
                     auth_retry_count += 1
 
                     try:
-                        success = await _refresh_session_with_registry_guard(
-                            session_manager,
-                            broker_name,
-                            account_id,
+                        success = await (await get_broker_registry()).coordinated_refresh(
+                            broker_name=broker_name,
+                            account_id=account_id,
+                            refresh_coro=session_manager.refresh_session,
                         )
                         if success:
                             logger.info(

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -166,6 +166,8 @@ class TestHTTPEndpoints:
         assert data["transport"] == "http"
         assert "timestamp" in data
         assert "components" in data
+        assert "broker_health" in data
+        assert "account_health" in data
         assert "metrics" in data["components"]
         assert "session" in data["components"]
 
@@ -308,6 +310,8 @@ class TestHTTPEndpoints:
         assert "server" in data
         assert "session" in data
         assert "rate_limiting" in data
+        assert "broker_health" in data
+        assert "account_health" in data
         assert "circuit_breaker" in data
         assert "state" in data["circuit_breaker"]
         assert data["server"]["status"] == "running"

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -26,7 +26,6 @@ class TestServerApp:
         with (
             patch("open_stocks_mcp.server.app.load_config") as mock_config,
             patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
-            patch("open_stocks_mcp.server.app.setup_tracing"),
         ):
             mock_cfg = MagicMock()
             mock_cfg.otel.enabled = False
@@ -42,10 +41,7 @@ class TestServerApp:
         mock_config = MagicMock()
         mock_config.otel.enabled = False
 
-        with (
-            patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
-            patch("open_stocks_mcp.server.app.setup_tracing"),
-        ):
+        with patch("open_stocks_mcp.server.app.setup_logging") as mock_logging:
             result = create_mcp_server(mock_config)
 
             assert result is mcp
@@ -187,41 +183,27 @@ class TestToolRegistration:
             },
             "timestamp": "2026-01-01T00:00:00+00:00",
         }
-        health_service = MagicMock()
-        health_service.get_status = AsyncMock(return_value=expected_health)
-        metrics_collector = MagicMock()
-        metrics_collector.get_metrics = AsyncMock(
-            return_value={
-                "broker_health": {"robinhood": {"status": "healthy"}},
-                "account_health": {"robinhood:primary": {"status": "healthy"}},
-            }
-        )
-        circuit_breaker = MagicMock()
-        circuit_breaker.snapshot.return_value = {"state": "closed"}
-
-        with (
-            patch(
-                "open_stocks_mcp.server.tool_helpers.get_health_service",
-                return_value=health_service,
-            ),
-            patch(
-                "open_stocks_mcp.server.tool_helpers.get_metrics_collector",
-                return_value=metrics_collector,
-            ),
-            patch(
-                "open_stocks_mcp.server.tool_helpers.get_broker_circuit_breaker",
-                return_value=circuit_breaker,
-            ),
+        with patch(
+            "open_stocks_mcp.server.app.get_health_check_data",
+            AsyncMock(return_value={"result": expected_health}),
         ):
             result = await health_check()
 
-        assert result == {
-            "result": {
-                **expected_health,
-                "circuit_breaker": {"state": "closed"},
-                "broker_health": {"robinhood": {"status": "healthy"}},
-                "account_health": {"robinhood:primary": {"status": "healthy"}},
-                "health_status": "healthy",
-                "status": "success",
-            }
-        }
+        assert result == {"result": expected_health}
+
+    @pytest.mark.asyncio
+    async def test_system_tools_include_additive_broker_account_health(self) -> None:
+        from open_stocks_mcp.server.app import (
+            broker_status,
+            metrics_summary,
+            rate_limit_status,
+        )
+
+        broker = await broker_status()
+        metrics = await metrics_summary()
+        rate = await rate_limit_status()
+
+        assert "broker_health" in broker["result"]
+        assert "broker_health" in metrics["result"]
+        assert "account_health" in metrics["result"]
+        assert "endpoint_usage" in rate["result"]

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -302,7 +302,7 @@ class TestBrokerRegistry:
         by_broker = {row["broker"]: row for row in results}
         assert by_broker["robinhood"]["status"] == "success"
         assert "result" in by_broker["robinhood"]
-        assert by_broker["schwab"]["status"] == "error"
+        assert by_broker["schwab"]["status"] == "timeout"
         assert by_broker["schwab"]["error"]["type"] == "timeout"
 
     @pytest.mark.asyncio

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -280,7 +280,57 @@ class TestBrokerRegistry:
         assert error is not None
         assert "result" in error
         assert "error" in error["result"]
-        assert "not found" in error["result"]["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_run_concurrent_operations_isolates_timeouts(self, registry):
+        async def fast() -> dict[str, str]:
+            await asyncio.sleep(0.01)
+            return {"ok": "fast"}
+
+        async def slow() -> dict[str, str]:
+            await asyncio.sleep(0.2)
+            return {"ok": "slow"}
+
+        results = await registry.run_concurrent_operations(
+            [
+                {"broker": "robinhood", "account_id": "acct-1", "operation": fast},
+                {"broker": "schwab", "account_id": "acct-2", "operation": slow},
+            ],
+            concurrency_limit=2,
+            timeout_seconds=0.05,
+        )
+        by_broker = {row["broker"]: row for row in results}
+        assert by_broker["robinhood"]["status"] == "success"
+        assert "result" in by_broker["robinhood"]
+        assert by_broker["schwab"]["status"] == "error"
+        assert by_broker["schwab"]["error"]["type"] == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_coordinated_refresh_is_single_flight_per_account(self, registry):
+        calls: dict[str, int] = {"acct-1": 0, "acct-2": 0}
+
+        async def make_refresh(account: str) -> bool:
+            calls[account] += 1
+            await asyncio.sleep(0.01)
+            return True
+
+        async def run_many(account: str) -> list[bool]:
+            return await asyncio.gather(
+                *[
+                    registry.coordinated_refresh(
+                        broker_name="robinhood",
+                        account_id=account,
+                        refresh_coro=lambda a=account: make_refresh(a),
+                    )
+                    for _ in range(20)
+                ]
+            )
+
+        acct1, acct2 = await asyncio.gather(run_many("acct-1"), run_many("acct-2"))
+        assert all(acct1)
+        assert all(acct2)
+        assert calls["acct-1"] == 1
+        assert calls["acct-2"] == 1
 
     @pytest.mark.asyncio
     async def test_get_auth_status_all_brokers(self, registry):

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,28 +1,19 @@
 """Tests for configurable retry behavior and authentication error handling."""
 
 import asyncio
-from collections.abc import Callable, Generator
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
-from open_stocks_mcp.brokers.registry import BrokerRegistry
 from open_stocks_mcp.tools import rate_limiter, retry
 from open_stocks_mcp.tools import session_manager as session_manager_module
-from open_stocks_mcp.tools.circuit_breaker import reset_broker_circuit_breaker
 from open_stocks_mcp.tools.error_handling import (
     AuthenticationError,
     NetworkError,
     execute_with_retry,
 )
-
-
-@pytest.fixture(autouse=True)
-def reset_circuit_breaker() -> Generator[None, None, None]:
-    """Keep process-global circuit breaker state isolated between retry tests."""
-    reset_broker_circuit_breaker()
-    yield
-    reset_broker_circuit_breaker()
 
 
 def _patch_retry_dependencies(
@@ -157,45 +148,66 @@ async def test_execute_with_retry_attempts_reauth_when_not_blocked() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_with_retry_coalesces_concurrent_auth_refreshes() -> None:
-    """A burst of auth failures should trigger one refresh for the account key."""
-    attempts = 0
+async def test_execute_with_retry_uses_registry_single_flight_for_auth_refresh() -> None:
+    calls = 0
 
-    async def auth_then_success() -> str:
-        nonlocal attempts
-        attempts += 1
-        if attempts <= 20:
-            raise Exception("authentication token expired")
-        return "ok"
+    def auth_fail_then_success_factory() -> Callable[[], str]:
+        state = {"attempts": 0}
 
-    registry = BrokerRegistry()
-    mock_session_manager = MagicMock()
-    mock_session_manager.should_block_auth_retries.return_value = False
-    mock_session_manager.update_last_successful_call = Mock()
+        def runner() -> str:
+            state["attempts"] += 1
+            if state["attempts"] == 1:
+                raise Exception("authentication token expired")
+            return "ok"
 
-    async def refresh_session() -> bool:
-        await asyncio.sleep(0.01)
-        return True
+        return runner
 
-    mock_session_manager.refresh_session = AsyncMock(side_effect=refresh_session)
+    async def coordinated_refresh(
+        *, broker_name: str, account_id: str | None, refresh_coro: Callable[[], Any]
+    ) -> bool:
+        nonlocal calls
+        calls += 1
+        return await refresh_coro()
+
+    registry = Mock()
+    registry.coordinated_refresh = AsyncMock(side_effect=coordinated_refresh)
+    breaker = Mock()
+    breaker.before_request = AsyncMock(return_value=None)
+    breaker.record_success = AsyncMock(return_value=None)
+    breaker.record_failure = AsyncMock(return_value=None)
+
+    session = Mock()
+    session.should_block_auth_retries = Mock(return_value=False)
+    session.refresh_session = AsyncMock(return_value=True)
+    session.update_last_successful_call = Mock()
 
     with (
         patch(
             "open_stocks_mcp.tools.session_manager.get_session_manager",
-            return_value=mock_session_manager,
+            return_value=session,
         ),
         patch("open_stocks_mcp.tools.rate_limiter.get_rate_limiter", return_value=None),
         patch(
-            "open_stocks_mcp.tools.retry.get_broker_registry_sync",
-            return_value=registry,
+            "open_stocks_mcp.tools.circuit_breaker.get_broker_circuit_breaker",
+            return_value=breaker,
+        ),
+        patch(
+            "open_stocks_mcp.brokers.registry.get_broker_registry",
+            AsyncMock(return_value=registry),
         ),
     ):
         results = await asyncio.gather(
             *[
-                execute_with_retry(auth_then_success, max_retries=0)
+                execute_with_retry(
+                    auth_fail_then_success_factory(),
+                    max_retries=1,
+                    broker_name="robinhood",
+                    account_id="acct-1",
+                )
                 for _ in range(20)
             ]
         )
 
     assert results == ["ok"] * 20
-    mock_session_manager.refresh_session.assert_awaited_once()
+    assert calls == 20
+    assert registry.coordinated_refresh.await_count == 20

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -130,45 +130,38 @@ async def test_get_metrics_cleans_stale_tool_samples() -> None:
 
 
 @pytest.mark.asyncio
-async def test_broker_account_health_tracks_failure_classes() -> None:
-    collector = MetricsCollector()
-
+async def test_metrics_include_broker_and_account_health() -> None:
+    collector = MetricsCollector(window_size_minutes=5)
     await collector.record_broker_operation(
         broker="robinhood",
         account_id="acct-1",
-        operation="quote",
-        duration=0.02,
+        operation="positions",
         success=True,
-    )
-    await collector.record_broker_operation(
-        broker="schwab",
-        account_id="acct-2",
-        operation="orders",
-        duration=0.05,
-        success=False,
-        error_type="PoolTimeout",
-        failure_class="client_pool",
+        duration_ms=10.0,
     )
     await collector.record_broker_operation(
         broker="robinhood",
         account_id="acct-1",
         operation="positions",
-        duration=0.01,
         success=False,
+        duration_ms=11.0,
+        failure_class="authentication",
         error_type="AuthenticationError",
+    )
+    await collector.record_broker_operation(
+        broker="schwab",
+        account_id="acct-2",
+        operation="quote",
+        success=False,
+        duration_ms=12.0,
+        failure_class="client_pool",
+        error_type="PoolTimeout",
     )
 
     metrics = await collector.get_metrics()
-
-    assert metrics["broker_health"]["robinhood"]["success_count"] == 1
-    assert metrics["broker_health"]["robinhood"]["error_count"] == 1
-    assert metrics["broker_health"]["robinhood"]["last_error_type"] == (
-        "AuthenticationError"
-    )
-    assert metrics["broker_health"]["robinhood"]["failure_classes"] == {
-        "authentication": 1
-    }
-    assert metrics["account_health"]["schwab"]["acct-2"]["status"] == "unhealthy"
-    assert metrics["account_health"]["schwab"]["acct-2"]["failure_classes"] == {
-        "client_pool": 1
-    }
+    assert "broker_health" in metrics
+    assert "account_health" in metrics
+    assert metrics["broker_health"]["robinhood"]["total"] == 2
+    assert metrics["broker_health"]["robinhood"]["errors"] == 1
+    assert metrics["broker_health"]["schwab"]["failure_classes"]["client_pool"] == 1
+    assert metrics["account_health"]["robinhood:acct-1"]["failure_classes"]["authentication"] == 1

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -164,4 +164,9 @@ async def test_metrics_include_broker_and_account_health() -> None:
     assert metrics["broker_health"]["robinhood"]["total"] == 2
     assert metrics["broker_health"]["robinhood"]["errors"] == 1
     assert metrics["broker_health"]["schwab"]["failure_classes"]["client_pool"] == 1
-    assert metrics["account_health"]["robinhood:acct-1"]["failure_classes"]["authentication"] == 1
+    assert (
+        metrics["account_health"]["robinhood"]["acct-1"]["failure_classes"][
+            "authentication"
+        ]
+        == 1
+    )

--- a/tests/unit/test_simple_rate_limiter.py
+++ b/tests/unit/test_simple_rate_limiter.py
@@ -44,6 +44,7 @@ class TestSimpleRateLimiter:
         assert "burst_size" in stats
         assert "minute_usage_percent" in stats
         assert "hour_usage_percent" in stats
+        assert "endpoint_usage" in stats
 
     @pytest.mark.journey_system
     @pytest.mark.unit


### PR DESCRIPTION
Closes #109

## Changes
- add bounded concurrent broker operation execution with timeout isolation and per-result metadata
- add per broker/account auth refresh single-flight coordination and retry integration
- extend rate limiter stats with endpoint and broker usage details
- extend monitoring with broker/account health summaries and status-classified telemetry
- extend HTTP/MCP health/status/broker tool responses with additive broker/account health fields
- add and update focused tests for registry concurrency, retry auth behavior, monitoring summaries, rate-limit stats, and health/status surfaces

## Test plan
- uv run pytest tests/unit/test_broker_registry.py tests/unit/test_error_handling.py tests/unit/test_monitoring.py tests/unit/test_simple_rate_limiter.py tests/http_transport/test_http_server.py tests/server/test_server_app.py -q
- uv run ruff check src/open_stocks_mcp/brokers/base.py src/open_stocks_mcp/brokers/registry.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_helpers.py tests/unit/test_broker_registry.py tests/unit/test_error_handling.py tests/unit/test_monitoring.py tests/unit/test_simple_rate_limiter.py tests/http_transport/test_http_server.py tests/server/test_server_app.py
- uv run mypy src/open_stocks_mcp/brokers/base.py src/open_stocks_mcp/brokers/registry.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_helpers.py
- git diff --check