### PR TITLE
feat: add Kubernetes deployment artifacts and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,6 +345,8 @@ config.local.*
 *password*
 .secrets/
 secrets/
+# Allow committed Kubernetes Secret template (placeholders only, no real values)
+!examples/kubernetes/secret.yaml.example
 
 # Development Database Files
 *.sqlite

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ docker-compose up -d
 - Health monitoring
 - Security headers and CORS
 
+**Kubernetes / Orchestrated Deployment:**
+See [examples/kubernetes/README.md](examples/kubernetes/README.md) for Kustomize manifests covering HTTP transport, non-root security context, PVC-backed token/log persistence, and health probes.
+
 ## MCP Client Integration
 
 ### Claude Desktop

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,137 @@
+# Kubernetes Deployment — Open Stocks MCP
+
+Run the Open Stocks MCP server in a Kubernetes cluster using the Kustomize manifests in this directory.
+
+## Prerequisites
+
+- `kubectl` configured for a running cluster
+- A container image `open-stocks-mcp:latest` accessible to the cluster (see [Build the image](#build-the-image))
+- Robinhood credentials (and optionally Schwab credentials)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `deployment.yaml` | Deployment — HTTP transport, `/health` probes, non-root UID 1001 |
+| `service.yaml` | ClusterIP Service exposing port 3001 |
+| `configmap.yaml` | Non-secret runtime config (`LOG_LEVEL`, `ENABLED_BROKERS`, etc.) |
+| `persistentvolumeclaim.yaml` | 1 Gi PVC for token and log persistence |
+| `kustomization.yaml` | Kustomize entry point (excludes the Secret — create it manually) |
+| `secret.yaml.example` | Template for the required Kubernetes Secret |
+
+## Build the image
+
+The manifests reference `open-stocks-mcp:latest`. Build and load or push the image to wherever your cluster pulls from:
+
+```bash
+# Build locally (same Dockerfile as the Docker Compose example)
+docker build -t open-stocks-mcp:latest examples/open-stocks-mcp-docker/
+
+# For kind or k3d: load directly
+kind load docker-image open-stocks-mcp:latest
+# or
+k3d image import open-stocks-mcp:latest
+
+# For a remote registry: tag and push
+docker tag open-stocks-mcp:latest registry.example.com/open-stocks-mcp:latest
+docker push registry.example.com/open-stocks-mcp:latest
+# Then update deployment.yaml image field accordingly
+```
+
+## Create the Secret
+
+The Secret is intentionally excluded from `kustomization.yaml` to prevent placeholder values from being applied accidentally. Create it once before deploying:
+
+```bash
+kubectl create secret generic open-stocks-mcp-secrets \
+  --from-literal=ROBINHOOD_USERNAME='your-email@example.com' \
+  --from-literal=ROBINHOOD_PASSWORD='your-password'
+```
+
+For Schwab credentials, add them to the same secret:
+
+```bash
+kubectl create secret generic open-stocks-mcp-secrets \
+  --from-literal=ROBINHOOD_USERNAME='your-email@example.com' \
+  --from-literal=ROBINHOOD_PASSWORD='your-password' \
+  --from-literal=SCHWAB_API_KEY='your-api-key' \
+  --from-literal=SCHWAB_APP_SECRET='your-app-secret' \
+  --from-literal=SCHWAB_CALLBACK_URL='https://127.0.0.1:8182/' \
+  --from-literal=SCHWAB_TOKEN_PATH='/home/mcp/.tokens/schwab_token.json'
+```
+
+Alternatively, copy `secret.yaml.example` to `secret.yaml`, fill in real values, apply it, and then delete the file — never commit `secret.yaml` to version control.
+
+## Secrets model
+
+| Secret key | Required | Description |
+|-----------|----------|-------------|
+| `ROBINHOOD_USERNAME` | Yes | Robinhood account email |
+| `ROBINHOOD_PASSWORD` | Yes | Robinhood account password |
+| `SCHWAB_API_KEY` | No | Schwab developer API key |
+| `SCHWAB_APP_SECRET` | No | Schwab app secret |
+| `SCHWAB_CALLBACK_URL` | No | OAuth callback URL (default: `https://127.0.0.1:8182/`) |
+| `SCHWAB_TOKEN_PATH` | No | Path for Schwab token storage |
+
+Non-secret configuration lives in `configmap.yaml`: `LOG_LEVEL`, `ENABLED_BROKERS`, `DEFAULT_BROKER`, `MCP_SERVER_NAME`.
+
+## Validate (dry run)
+
+```bash
+kubectl apply --dry-run=client -k examples/kubernetes
+```
+
+This validates manifest syntax and object structure without creating any resources.
+
+## Deploy
+
+```bash
+kubectl apply -k examples/kubernetes
+```
+
+Check that the pod starts:
+
+```bash
+kubectl get pods -l app=open-stocks-mcp
+kubectl get service open-stocks-mcp
+```
+
+Watch logs during first startup (Robinhood device verification may appear):
+
+```bash
+kubectl logs -f -l app=open-stocks-mcp
+```
+
+## Health check
+
+Forward the service port and hit the health endpoint:
+
+```bash
+kubectl port-forward service/open-stocks-mcp 3001:3001
+curl http://localhost:3001/health
+```
+
+A healthy server returns HTTP 200 with `{"status": "ok", ...}`.
+
+## Persistence
+
+Session tokens and logs are stored on a PVC mounted at:
+
+- `/home/mcp/.tokens` — Robinhood pickle session (subPath: `tokens`)
+- `/home/mcp/.local/state/mcp-servers/logs` — application logs (subPath: `logs`)
+
+The PVC keeps state across pod restarts. **Pin `replicas: 1`** (the default) — Robinhood treats each new IP/session as a new device, which triggers MFA from a server with no terminal.
+
+## Cleanup
+
+```bash
+kubectl delete -k examples/kubernetes
+kubectl delete secret open-stocks-mcp-secrets
+# Optionally delete the PVC (this erases token/log data):
+kubectl delete pvc open-stocks-mcp-data
+```
+
+## Notes
+
+- CI workflow configuration (`.github/workflows/**`, etc.) is intentionally out of scope for these Kubernetes artifacts. Cluster image builds and deployment pipelines are operator-managed.
+- The Deployment uses HTTP transport (`--transport http`), not stdio — liveness and readiness probes use `httpGet /health` on port 3001.

--- a/examples/kubernetes/configmap.yaml
+++ b/examples/kubernetes/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: open-stocks-mcp-config
+  labels:
+    app: open-stocks-mcp
+data:
+  MCP_SERVER_NAME: "open-stocks-mcp"
+  LOG_LEVEL: "INFO"
+  ENABLED_BROKERS: "robinhood"
+  DEFAULT_BROKER: "robinhood"

--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-stocks-mcp
+  labels:
+    app: open-stocks-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: open-stocks-mcp
+  template:
+    metadata:
+      labels:
+        app: open-stocks-mcp
+    spec:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        runAsNonRoot: true
+      containers:
+        - name: open-stocks-mcp
+          image: open-stocks-mcp:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - open-stocks-mcp-server
+            - --transport
+            - http
+            - --host
+            - 0.0.0.0
+            - --port
+            - "3001"
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: open-stocks-mcp-config
+            - secretRef:
+                name: open-stocks-mcp-secrets
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - name: mcp-data
+              mountPath: /home/mcp/.tokens
+              subPath: tokens
+            - name: mcp-data
+              mountPath: /home/mcp/.local/state/mcp-servers/logs
+              subPath: logs
+      volumes:
+        - name: mcp-data
+          persistentVolumeClaim:
+            claimName: open-stocks-mcp-data

--- a/examples/kubernetes/kustomization.yaml
+++ b/examples/kubernetes/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap.yaml
+  - persistentvolumeclaim.yaml
+  - deployment.yaml
+  - service.yaml
+
+# secret.yaml.example is intentionally excluded.
+# Create the Secret separately before applying:
+#   kubectl create secret generic open-stocks-mcp-secrets \
+#     --from-literal=ROBINHOOD_USERNAME='...' \
+#     --from-literal=ROBINHOOD_PASSWORD='...'
+# See README.md for full instructions.

--- a/examples/kubernetes/persistentvolumeclaim.yaml
+++ b/examples/kubernetes/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: open-stocks-mcp-data
+  labels:
+    app: open-stocks-mcp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/kubernetes/secret.yaml.example
+++ b/examples/kubernetes/secret.yaml.example
@@ -1,0 +1,33 @@
+# Template Secret manifest for Open Stocks MCP.
+#
+# DO NOT COMMIT a filled-in copy of this file. The values below are
+# non-production placeholders intended only as documentation of the
+# expected secret keys. Replace each REPLACE_WITH_... value before
+# applying, and never check the filled-in file into version control.
+#
+# Preferred approach: create the Secret imperatively (see README.md
+# "Create the Secret"), which keeps real credentials off disk entirely.
+#
+# If you choose to use this file:
+#   1. Copy it:    cp secret.yaml.example secret.yaml
+#   2. Edit:       fill in real values for each REPLACE_WITH_... entry
+#   3. Apply:      kubectl apply -f secret.yaml
+#   4. Delete:     rm secret.yaml   # do not commit
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: open-stocks-mcp-secrets
+  labels:
+    app: open-stocks-mcp
+type: Opaque
+stringData:
+  # Required Robinhood credentials.
+  ROBINHOOD_USERNAME: "REPLACE_WITH_ROBINHOOD_EMAIL"
+  ROBINHOOD_PASSWORD: "REPLACE_WITH_ROBINHOOD_PASSWORD"
+
+  # Optional Schwab credentials. Remove these lines if Schwab is not enabled.
+  # SCHWAB_API_KEY: "REPLACE_WITH_SCHWAB_API_KEY"
+  # SCHWAB_APP_SECRET: "REPLACE_WITH_SCHWAB_APP_SECRET"
+  # SCHWAB_CALLBACK_URL: "https://127.0.0.1:8182/"
+  # SCHWAB_TOKEN_PATH: "/home/mcp/.tokens/schwab_token.json"

--- a/examples/kubernetes/service.yaml
+++ b/examples/kubernetes/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-stocks-mcp
+  labels:
+    app: open-stocks-mcp
+spec:
+  type: ClusterIP
+  selector:
+    app: open-stocks-mcp
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3001
+      protocol: TCP

--- a/tests/unit/test_kubernetes_examples.py
+++ b/tests/unit/test_kubernetes_examples.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import pytest
+
+K8S_DIR = Path("examples/kubernetes")
+DEPLOYMENT = K8S_DIR / "deployment.yaml"
+SERVICE = K8S_DIR / "service.yaml"
+CONFIGMAP = K8S_DIR / "configmap.yaml"
+PVC = K8S_DIR / "persistentvolumeclaim.yaml"
+KUSTOMIZATION = K8S_DIR / "kustomization.yaml"
+SECRET_EXAMPLE = K8S_DIR / "secret.yaml.example"
+K8S_README = K8S_DIR / "README.md"
+ROOT_README = Path("README.md")
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_kubernetes_manifest_files_exist():
+    for path in [DEPLOYMENT, SERVICE, CONFIGMAP, PVC, KUSTOMIZATION, SECRET_EXAMPLE]:
+        assert path.exists(), f"Expected {path} to exist"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_deployment_manifest_content():
+    text = DEPLOYMENT.read_text(encoding="utf-8")
+    required = [
+        "kind: Deployment",
+        "open-stocks-mcp-server",
+        "--transport",
+        "http",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "3001",
+        "/health",
+        "runAsUser: 1001",
+        "configMapRef",
+        "secretRef",
+        "/home/mcp/.tokens",
+        "/home/mcp/.local/state/mcp-servers/logs",
+    ]
+    for token in required:
+        assert token in text, f"Expected '{token}' in deployment.yaml"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_service_manifest_content():
+    text = SERVICE.read_text(encoding="utf-8")
+    assert "kind: Service" in text
+    assert "3001" in text
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_secret_example_content():
+    text = SECRET_EXAMPLE.read_text(encoding="utf-8")
+    assert "ROBINHOOD_USERNAME" in text
+    assert "ROBINHOOD_PASSWORD" in text
+    # Must not contain real-looking credential values
+    assert "your_email@example.com" not in text or "placeholder" in text.lower() or "example" in text.lower()
+    # Should not have real passwords
+    for suspicious in ["my_password", "secretpassword123", "hunter2"]:
+        assert suspicious not in text
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_kubernetes_readme_exists():
+    assert K8S_README.exists(), "Expected examples/kubernetes/README.md to exist"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_kubernetes_readme_content():
+    text = K8S_README.read_text(encoding="utf-8")
+    required_commands = [
+        "kubectl apply --dry-run=client -k examples/kubernetes",
+        "kubectl apply -k examples/kubernetes",
+        "kubectl port-forward service/open-stocks-mcp 3001:3001",
+        "curl http://localhost:3001/health",
+    ]
+    for cmd in required_commands:
+        assert cmd in text, f"Expected '{cmd}' in kubernetes README"
+    assert "ROBINHOOD_USERNAME" in text
+    assert "ROBINHOOD_PASSWORD" in text
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_root_readme_links_to_kubernetes():
+    text = ROOT_README.read_text(encoding="utf-8")
+    assert "examples/kubernetes" in text, "Expected root README.md to link to examples/kubernetes"


### PR DESCRIPTION
Closes #156

## Changes
- Add `examples/kubernetes/` with Kustomize-compatible manifests: `deployment.yaml`, `service.yaml`, `configmap.yaml`, `persistentvolumeclaim.yaml`, `kustomization.yaml`, and `secret.yaml.example`
- Deployment runs HTTP transport (`--transport http --host 0.0.0.0 --port 3001`), uses `/health` for liveness/readiness probes, non-root UID/GID 1001, and PVC-backed token/log mounts
- `secret.yaml.example` excluded from `kustomization.yaml` to prevent placeholder credentials from being applied accidentally
- Add `examples/kubernetes/README.md` documenting prerequisites, image build, secret creation, dry-run, deploy, health-check, persistence model, and cleanup
- Link Kubernetes example from root `README.md` Docker Deployment section
- Add `tests/unit/test_kubernetes_examples.py` with 7 structural tests (`@pytest.mark.unit @pytest.mark.journey_system`) validating manifest existence, required content, README commands, and root README link
- No CI configuration files touched

## Test plan
- `uv run pytest tests/unit/test_kubernetes_examples.py -q` → 7 passed
- `uv run ruff check tests/unit/test_kubernetes_examples.py` → clean
- `git diff --name-only -- .github/workflows .github/actions` → empty (no CI files touched)
- `kubectl apply --dry-run=client -k examples/kubernetes` — kubectl not available in build environment; structural pytest coverage validates manifest content