### PR TITLE
docs: add developer tooling support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run MCP server (HTTP)",
+      "type": "python",
+      "request": "launch",
+      "module": "open_stocks_mcp.server.app",
+      "args": ["--transport", "http", "--port", "3001"],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Pytest: current file",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["${file}", "-v"],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "python.defaultInterpreterPath": ".venv/bin/python",
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestArgs": ["tests"],
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true
+  },
+  "ruff.lint.run": "onSave",
+  "mypy-type-checker.args": ["--config-file=pyproject.toml"],
+  "files.exclude": {
+    ".mypy_cache": true,
+    ".ruff_cache": true,
+    ".pytest_cache": true,
+    "**/__pycache__": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "uv sync",
+      "type": "shell",
+      "command": "uv sync",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "ruff: fix",
+      "type": "shell",
+      "command": "uv run ruff check . --fix",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "ruff: format",
+      "type": "shell",
+      "command": "uv run ruff format .",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "mypy",
+      "type": "shell",
+      "command": "uv run mypy .",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "pytest: fast",
+      "type": "shell",
+      "command": "uv run pytest -m \"not slow and not exception_test\"",
+      "group": "test",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing
+
+This guide covers the local setup, quality checks, test journeys, and debugging recipes used for `open-stocks-mcp` development.
+
+## Setup
+
+Use Python >=3.11 and `uv` for dependency management. The repository is configured as a `uv` managed project, and `uv sync` creates the default `.venv` that the VS Code workspace settings use.
+
+```bash
+uv sync
+```
+
+Create a local `.env` file when you need live broker or evaluation flows. The required Robinhood, Schwab, and Google ADK variables are documented in [README.md](README.md). Never commit credentials or token files.
+
+## Code Quality
+
+Run the same tools locally that the project guidance expects:
+
+```bash
+uv run ruff check . --fix
+uv run ruff format .
+uv run mypy .
+```
+
+The VS Code task list in `.vscode/tasks.json` exposes those commands as one-shot tasks, along with `uv sync` and the fast pytest loop.
+
+## Testing
+
+The default pytest configuration skips live market and performance tests. Rate-limited live endpoint tests are also skipped unless selected explicitly with `-m rate_limited` or `RUN_RATE_LIMITED=1`.
+
+| Workflow | Command |
+| --- | --- |
+| Fast local loop | `uv run pytest -m "not slow and not exception_test"` |
+| Unit tests | `uv run pytest tests/unit/` |
+| Account journey | `uv run pytest -m "journey_account"` |
+| Portfolio journey | `uv run pytest -m "journey_portfolio"` |
+| Market data journey | `uv run pytest -m "journey_market_data"` |
+| Research journey | `uv run pytest -m "journey_research"` |
+| Watchlists journey | `uv run pytest -m "journey_watchlists"` |
+| Options journey | `uv run pytest -m "journey_options"` |
+| Notifications journey | `uv run pytest -m "journey_notifications"` |
+| System journey | `uv run pytest -m "journey_system"` |
+| Trading journey | `uv run pytest -m "journey_trading"` |
+| Integration tests | `uv run pytest tests/integration/ -m integration` |
+| Rate-limited live tests | `RUN_RATE_LIMITED=1 uv run pytest -m rate_limited` |
+
+VS Code Test Explorer uses `python.testing.pytestArgs` from `.vscode/settings.json`, so it discovers `tests/` and then applies the project-level marker defaults from `pyproject.toml`.
+
+## Debugging
+
+The workspace launch file `.vscode/launch.json` provides two common entry points:
+
+- `Run MCP server (HTTP)` starts `open_stocks_mcp.server.app` with `--transport http --port 3001` in the integrated terminal.
+- `Pytest: current file` runs the currently open test file through `pytest -v`.
+
+For command-line debugging, start the HTTP server with Python development checks enabled:
+
+```bash
+uv run python -X dev -m open_stocks_mcp.server.app --transport http --port 3001
+```
+
+Inspect the local server from another terminal:
+
+```bash
+curl http://localhost:3001/health
+curl http://localhost:3001/metrics
+```
+
+Use the standard debugger by setting `PYTHONBREAKPOINT` before running a focused test or server command:
+
+```bash
+PYTHONBREAKPOINT=pdb.set_trace uv run pytest tests/unit/test_health_service.py -q
+```
+
+If you prefer `ipdb`, install it in your local environment and use:
+
+```bash
+PYTHONBREAKPOINT=ipdb.set_trace uv run pytest tests/unit/test_health_service.py -q
+```
+
+Then place `breakpoint()` in the code path you are investigating. Remove breakpoints before committing.
+
+## Editor Setup
+
+The recommended VS Code extensions live in `.vscode/extensions.json`; install them from the Extensions prompt or run the `Extensions: Show Recommended Extensions` command. The workspace also includes:
+
+- `.vscode/settings.json` for the `.venv/bin/python` interpreter, Ruff formatting on save, pytest discovery, and mypy configuration.
+- `.vscode/tasks.json` for repeatable setup, lint, format, typecheck, and fast test commands.
+- `.vscode/launch.json` for server and current-file pytest debugging.
+
+If your virtual environment is not named `.venv`, either run `uv sync` at the repository root or update the interpreter path locally in VS Code without committing that personal override.

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent test
 ## Contributing
 
 See [CONTRIBUTING.md](contributing/README.md) for development guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and debugging recipes.
 
 ## License
 

--- a/tests/unit/test_dev_tooling.py
+++ b/tests/unit/test_dev_tooling.py
@@ -1,0 +1,56 @@
+"""Tests for developer tooling and contributor documentation."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+VSCODE = ROOT / ".vscode"
+
+
+def _load_jsonc(path: Path) -> dict[str, Any]:
+    content = re.sub(r"//[^\n]*", "", path.read_text(encoding="utf-8"))
+    return json.loads(content)
+
+
+@pytest.mark.unit
+def test_vscode_workspace_files_exist_and_parse() -> None:
+    settings = _load_jsonc(VSCODE / "settings.json")
+    launch = _load_jsonc(VSCODE / "launch.json")
+    tasks = _load_jsonc(VSCODE / "tasks.json")
+
+    assert settings["python.testing.pytestEnabled"] is True
+    assert settings["[python]"]["editor.defaultFormatter"] == "charliermarsh.ruff"
+
+    launch_names = {config["name"] for config in launch["configurations"]}
+    assert {"Run MCP server (HTTP)", "Pytest: current file"} <= launch_names
+
+    task_labels = {task["label"] for task in tasks["tasks"]}
+    assert {
+        "uv sync",
+        "ruff: fix",
+        "ruff: format",
+        "mypy",
+        "pytest: fast",
+    } <= task_labels
+
+
+@pytest.mark.unit
+def test_contributing_guide_exists_and_mentions_debugging_recipes() -> None:
+    guide = ROOT / "CONTRIBUTING.md"
+
+    content = guide.read_text(encoding="utf-8")
+
+    assert guide.stat().st_size >= 1024
+    for expected in (
+        "## Setup",
+        "## Testing",
+        "## Debugging",
+        ".vscode/launch.json",
+    ):
+        assert expected in content


### PR DESCRIPTION
Closes #155

## Changes
- Add VS Code workspace settings, launch configs, and repeatable dev tasks for setup, linting, formatting, type checking, and fast tests.
- Add a root CONTRIBUTING.md with setup, testing, editor, and debugging recipes.
- Add a focused unit test that validates the developer tooling files and contributor guide.
- Add a single README pointer to the new contributor guide.

## Test plan
- PASS: uv run pytest tests/unit/test_dev_tooling.py -q
- PASS: uv run ruff check tests/unit/test_dev_tooling.py
- PASS: uv run python -c "import json,re; s=open('.vscode/launch.json').read(); json.loads(re.sub(r'//[^\\n]*','',s))"
- CONCERN: uv run ruff check src tests currently fails on pre-existing files outside this issue scope: src/open_stocks_mcp/brokers/request_policy.py, src/open_stocks_mcp/tools/broker_utils.py, tests/unit/test_broker_request_policy.py, and tests/unit/test_capabilities_and_streaming.py.
- CONCERN: uv run pytest tests/unit -q was interrupted after no progress for over two minutes while running the existing broader unit suite; the focused new test passes.