### PR TITLE
feat: implement alerting hooks and runbook documentation

### DIFF
--- a/docs/MONITORING_RUNBOOK.md
+++ b/docs/MONITORING_RUNBOOK.md
@@ -1,0 +1,187 @@
+# Monitoring Runbook: Open Stocks MCP
+
+This runbook describes the alerting system, supported alerts, configuration, and operator responses for the Open Stocks MCP server.
+
+## Overview
+
+The alerting system evaluates metric thresholds on the rolling window observed by `MetricsCollector` and emits `AlertEvent` objects through a configurable sink. By default, alerting is **disabled** and no events are sent externally. When enabled, alerts fire on high error rate or high average response time, with deduplication to prevent alert storms.
+
+Alert state is always surfaced in monitoring endpoints regardless of whether external delivery is enabled:
+- HTTP `GET /health` → `active_alerts` field
+- HTTP `GET /status` → `metrics.active_alerts` field
+- MCP `metrics_summary` tool → `result.active_alerts` field
+
+---
+
+## Configuration
+
+All configuration is via environment variables. Default values are safe for production with external delivery disabled.
+
+| Variable | Default | Description |
+|---|---|---|
+| `ALERTS_ENABLED` | `false` | Set to `true` to enable external alert delivery. Alert state in monitoring endpoints is always available regardless of this setting. |
+| `ALERT_WEBHOOK_URL` | _(none)_ | Webhook endpoint for alert delivery. Required when `ALERTS_ENABLED=true` and custom sink is implemented. |
+| `ALERT_ERROR_RATE_DEGRADED_THRESHOLD` | `10.0` | Error rate % that triggers a `degraded` alert. |
+| `ALERT_ERROR_RATE_UNHEALTHY_THRESHOLD` | `25.0` | Error rate % that triggers an `unhealthy` alert. |
+| `ALERT_AVG_RESPONSE_TIME_DEGRADED_MS` | `5000.0` | Average response time (ms) that triggers a `degraded` alert. |
+| `ALERT_AVG_RESPONSE_TIME_UNHEALTHY_MS` | `10000.0` | Average response time (ms) that triggers an `unhealthy` alert. |
+| `ALERT_DEDUP_WINDOW_SECONDS` | `300.0` | Minimum seconds between repeated alerts for the same signal. Prevents alert storms from a single root cause. |
+
+### Example: Enable alerting
+
+```bash
+export ALERTS_ENABLED=true
+export ALERT_WEBHOOK_URL=https://hooks.example.com/mcp-alerts
+export ALERT_DEDUP_WINDOW_SECONDS=300
+```
+
+---
+
+## Supported Alerts
+
+### `high_error_rate`
+
+**Trigger**: The rolling-window error rate exceeds a configured threshold.
+
+| Condition | Severity |
+|---|---|
+| Error rate > `ALERT_ERROR_RATE_DEGRADED_THRESHOLD` (default 10%) | `degraded` |
+| Error rate > `ALERT_ERROR_RATE_UNHEALTHY_THRESHOLD` (default 25%) | `unhealthy` |
+
+**Operator response**:
+1. Check `/status` → `metrics.error_types` to identify which error class is elevated.
+2. If `authentication` errors dominate, call `POST /session/refresh` to force a session re-auth.
+3. If `rate_limit` errors dominate, the upstream broker API is throttling. Reduce request frequency or wait for the rate limit window to expire.
+4. If `network` errors dominate, check broker API reachability and network connectivity from the container.
+5. If the error rate remains elevated after the above, check application logs for stack traces.
+
+---
+
+### `high_avg_response_time`
+
+**Trigger**: The rolling-window average tool response time exceeds a configured threshold.
+
+| Condition | Severity |
+|---|---|
+| Avg response time > `ALERT_AVG_RESPONSE_TIME_DEGRADED_MS` (default 5000ms) | `degraded` |
+| Avg response time > `ALERT_AVG_RESPONSE_TIME_UNHEALTHY_MS` (default 10000ms) | `unhealthy` |
+
+**Operator response**:
+1. Check `/status` → `metrics.tool_usage` for per-tool p95/p99 latency to identify slow tools.
+2. If a single tool is slow, that broker endpoint may be degraded. Check broker status pages.
+3. If all tools are slow, the server or its network path to the broker may be resource-constrained.
+4. Check container CPU and memory; if near limits, scale up or reduce concurrent request load.
+5. Consider reducing `CACHE_QUOTES_TTL` and `CACHE_ACCOUNT_TTL` to increase cache hit rates and reduce live API calls.
+
+---
+
+## Deduplication
+
+The dedup window (`ALERT_DEDUP_WINDOW_SECONDS`, default 300s) prevents repeated alerts for the same signal within the window. A single auth-expiration or rate-limit event can trigger across many concurrent tool invocations; dedup ensures only one alert event reaches the sink per 5-minute window.
+
+When the window expires and the condition is still met, a new alert is emitted. When conditions return to normal, the signal is removed from `active_alerts`.
+
+---
+
+## Sink Failures
+
+If the alert sink fails (network error, webhook 5xx, timeout), the failure is:
+- Caught and never propagated to the caller
+- Counted in `degraded_sink_total` (visible in `GET /status` → `metrics.degraded_sink_total`)
+- Logged at WARNING level
+
+Monitor `degraded_sink_total` to detect persistent sink delivery problems. If it grows steadily, check `ALERT_WEBHOOK_URL` reachability.
+
+---
+
+## Testing with a Fake Sink
+
+For integration testing without network calls, inject a `FakeAlertSink` directly into `MetricsCollector`:
+
+```python
+from dataclasses import dataclass, field
+from open_stocks_mcp.monitoring import AlertEvent, MetricsCollector
+
+@dataclass
+class FakeAlertSink:
+    calls: list[AlertEvent] = field(default_factory=list)
+
+    async def send(self, event: AlertEvent) -> None:
+        self.calls.append(event)
+
+sink = FakeAlertSink()
+collector = MetricsCollector(
+    alert_sink=sink,
+    alerts_enabled=True,
+    alert_dedup_window_seconds=0,  # instant re-fire for tests
+)
+
+# Simulate high error rate
+from datetime import datetime
+now = datetime.now()
+collector.api_calls.extend([(now, "tool", False)] * 10)
+collector.errors.extend([(now, "tool", "err")] * 10)
+collector.response_times.extend([(now, 0.1)] * 10)
+
+await collector.evaluate_alert_conditions()
+
+assert sink.calls[0].signal == "high_error_rate"
+```
+
+Set `alerts_enabled=False` to verify alert state is computed but sink is not called:
+
+```python
+collector = MetricsCollector(alert_sink=sink, alerts_enabled=False)
+# ... populate metrics ...
+await collector.evaluate_alert_conditions()
+assert len(sink.calls) == 0  # no delivery
+health = await collector.get_health_status()
+assert "active_alerts" in health  # state still reported
+```
+
+---
+
+## Monitoring Endpoint Reference
+
+### `GET /health`
+
+Returns service health with active alert state:
+
+```json
+{
+  "status": "degraded",
+  "components": { "metrics": {"status": "healthy"}, "session": {"status": "healthy"} },
+  "active_alerts": [
+    {
+      "signal": "high_error_rate",
+      "severity": "degraded",
+      "message": "High error rate: 15.0%",
+      "timestamp": "2026-01-01T00:00:00"
+    }
+  ],
+  "version": "0.6.4",
+  "transport": "http"
+}
+```
+
+### `GET /status`
+
+Returns full server status. Alert state is in `metrics.active_alerts` and `metrics.degraded_sink_total`.
+
+### MCP `metrics_summary` tool
+
+Returns `{"result": { ..., "active_alerts": [...], "degraded_sink_total": 0, ... }}`.
+
+---
+
+## Alert Event Shape
+
+```python
+@dataclass
+class AlertEvent:
+    signal: str       # "high_error_rate" | "high_avg_response_time"
+    severity: str     # "degraded" | "unhealthy"
+    message: str      # Human-readable description
+    timestamp: str    # ISO8601 timestamp of event creation
+    metadata: dict    # Signal-specific context (e.g., error_rate_percent)
+```

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -199,6 +199,19 @@ class BrokerRequestConfig:
 
 
 @dataclass
+class AlertConfig:
+    """Configuration for the proactive alerting system."""
+
+    enabled: bool = False
+    webhook_url: str | None = None
+    error_rate_degraded_threshold: float = 10.0
+    error_rate_unhealthy_threshold: float = 25.0
+    avg_response_time_degraded_ms: float = 5000.0
+    avg_response_time_unhealthy_ms: float = 10000.0
+    dedup_window_seconds: float = 300.0
+
+
+@dataclass
 class OtelConfig:
     enabled: bool = False
     service_name: str = "open-stocks-mcp"
@@ -217,6 +230,7 @@ class ServerConfig:
     timeout: TimeoutConfig | None = None
     circuit_breaker: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
     broker_requests: BrokerRequestConfig = field(default_factory=BrokerRequestConfig)
+    alerts: AlertConfig = field(default_factory=AlertConfig)
     otel: OtelConfig = field(default_factory=OtelConfig)
 
     def __post_init__(self) -> None:
@@ -443,6 +457,32 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
                 )
                 if os.getenv("OPEN_STOCKS_MCP_BROKER_REQUEST_TOTAL_DEADLINE_SECONDS")
                 else None
+            ),
+        ),
+        alerts=AlertConfig(
+            enabled=_parse_bool(
+                os.getenv("ALERTS_ENABLED", "false"), "ALERTS_ENABLED"
+            ),
+            webhook_url=os.getenv("ALERT_WEBHOOK_URL") or None,
+            error_rate_degraded_threshold=_parse_float(
+                os.getenv("ALERT_ERROR_RATE_DEGRADED_THRESHOLD", "10.0"),
+                "ALERT_ERROR_RATE_DEGRADED_THRESHOLD",
+            ),
+            error_rate_unhealthy_threshold=_parse_float(
+                os.getenv("ALERT_ERROR_RATE_UNHEALTHY_THRESHOLD", "25.0"),
+                "ALERT_ERROR_RATE_UNHEALTHY_THRESHOLD",
+            ),
+            avg_response_time_degraded_ms=_parse_float(
+                os.getenv("ALERT_AVG_RESPONSE_TIME_DEGRADED_MS", "5000.0"),
+                "ALERT_AVG_RESPONSE_TIME_DEGRADED_MS",
+            ),
+            avg_response_time_unhealthy_ms=_parse_float(
+                os.getenv("ALERT_AVG_RESPONSE_TIME_UNHEALTHY_MS", "10000.0"),
+                "ALERT_AVG_RESPONSE_TIME_UNHEALTHY_MS",
+            ),
+            dedup_window_seconds=_parse_float(
+                os.getenv("ALERT_DEDUP_WINDOW_SECONDS", "300.0"),
+                "ALERT_DEDUP_WINDOW_SECONDS",
             ),
         ),
         otel=OtelConfig(

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -4,21 +4,57 @@ import asyncio
 import math
 import time
 from collections import defaultdict, deque
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from open_stocks_mcp.logging_config import logger
+
+
+@dataclass
+class AlertEvent:
+    """A monitoring alert event emitted when a threshold condition is met."""
+
+    signal: str
+    severity: str
+    message: str
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class AlertSink(Protocol):
+    """Protocol for alert delivery sinks. Implementations must be async-safe."""
+
+    async def send(self, event: AlertEvent) -> None:
+        """Deliver the alert event to the sink destination."""
+        ...
+
+
+class _LogAlertSink:
+    """Default no-op sink that logs events. No external delivery."""
+
+    async def send(self, event: AlertEvent) -> None:
+        logger.warning(
+            f"ALERT [{event.severity}] {event.signal}: {event.message}"
+        )
 
 
 class MetricsCollector:
     """Collects and tracks metrics for monitoring."""
 
-    def __init__(self, window_size_minutes: int = 60):
-        """Initialize metrics collector.
-
-        Args:
-            window_size_minutes: Size of the rolling window for metrics
-        """
+    def __init__(
+        self,
+        window_size_minutes: int = 60,
+        alert_sink: AlertSink | None = None,
+        alerts_enabled: bool = True,
+        alert_dedup_window_seconds: float = 300.0,
+        error_rate_degraded_threshold: float = 10.0,
+        error_rate_unhealthy_threshold: float = 25.0,
+        avg_response_time_degraded_ms: float = 5000.0,
+        avg_response_time_unhealthy_ms: float = 10000.0,
+    ):
+        """Initialize metrics collector."""
         self.window_size = timedelta(minutes=window_size_minutes)
 
         # Metrics storage
@@ -42,6 +78,23 @@ class MetricsCollector:
         self.cache_misses: dict[str, int] = defaultdict(int)
 
         self._lock = asyncio.Lock()
+
+        # Alerting
+        self._alert_sink: AlertSink = (
+            alert_sink if alert_sink is not None else _LogAlertSink()
+        )
+        self._alerts_enabled = alerts_enabled
+        self._alert_dedup_window = timedelta(seconds=alert_dedup_window_seconds)
+        self._error_rate_degraded_threshold = error_rate_degraded_threshold
+        self._error_rate_unhealthy_threshold = error_rate_unhealthy_threshold
+        self._avg_response_time_degraded_ms = avg_response_time_degraded_ms
+        self._avg_response_time_unhealthy_ms = avg_response_time_unhealthy_ms
+        # Maps signal -> timestamp of last emission (for dedup)
+        self._last_alert_at: dict[str, datetime] = {}
+        # Current active alerts keyed by signal name
+        self._active_alerts: dict[str, AlertEvent] = {}
+        # Counter for sink delivery failures
+        self.degraded_sink_total = 0
 
     async def record_api_call(
         self,
@@ -81,6 +134,14 @@ class MetricsCollector:
                 self.total_errors += 1
                 if error_type:
                     self.error_types[error_type] += 1
+
+        # Evaluate alert conditions after every recorded call so live traffic
+        # drives both `active_alerts` state and sink delivery. Runs outside the
+        # lock so `get_metrics()` (which acquires it) does not deadlock.
+        try:
+            await self.evaluate_alert_conditions()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"Alert evaluation failed: {exc}")
 
     async def record_session_refresh(self) -> None:
         """Record a session refresh event."""
@@ -331,6 +392,16 @@ class MetricsCollector:
                 "cache_hit_rate_percent": cache_hit_rate,
                 "broker_health": broker_health_out,
                 "account_health": account_health_out,
+                "active_alerts": [
+                    {
+                        "signal": e.signal,
+                        "severity": e.severity,
+                        "message": e.message,
+                        "timestamp": e.timestamp,
+                    }
+                    for e in self._active_alerts.values()
+                ],
+                "degraded_sink_total": self.degraded_sink_total,
                 "timestamp": now.isoformat(),
             }
 
@@ -416,12 +487,93 @@ class MetricsCollector:
         return {
             "status": health,
             "issues": issues,
+            "active_alerts": metrics["active_alerts"],
             "metrics_summary": {
                 "error_rate_percent": error_rate,
                 "avg_response_time_ms": avg_response_time,
                 "calls_last_hour": metrics["calls_in_window"],
             },
         }
+
+    async def evaluate_alert_conditions(self) -> None:
+        """Evaluate current metrics against alert thresholds and emit events.
+
+        This method is idempotent and safe to call repeatedly; deduplication
+        prevents duplicate alerts within the configured window.  Sink failures
+        are caught and counted in `degraded_sink_total` — they never propagate.
+        """
+        metrics = await self.get_metrics()
+        error_rate = metrics["error_rate_percent"]
+        avg_rt_ms = metrics["avg_response_time_ms"]
+
+        now = datetime.now()
+
+        candidates: list[AlertEvent] = []
+
+        if error_rate > self._error_rate_unhealthy_threshold:
+            candidates.append(
+                AlertEvent(
+                    signal="high_error_rate",
+                    severity="unhealthy",
+                    message=f"Critical error rate: {error_rate}%",
+                    metadata={"error_rate_percent": error_rate},
+                )
+            )
+        elif error_rate > self._error_rate_degraded_threshold:
+            candidates.append(
+                AlertEvent(
+                    signal="high_error_rate",
+                    severity="degraded",
+                    message=f"High error rate: {error_rate}%",
+                    metadata={"error_rate_percent": error_rate},
+                )
+            )
+
+        if avg_rt_ms > self._avg_response_time_unhealthy_ms:
+            candidates.append(
+                AlertEvent(
+                    signal="high_avg_response_time",
+                    severity="unhealthy",
+                    message=f"Critical response time: {avg_rt_ms}ms",
+                    metadata={"avg_response_time_ms": avg_rt_ms},
+                )
+            )
+        elif avg_rt_ms > self._avg_response_time_degraded_ms:
+            candidates.append(
+                AlertEvent(
+                    signal="high_avg_response_time",
+                    severity="degraded",
+                    message=f"High response time: {avg_rt_ms}ms",
+                    metadata={"avg_response_time_ms": avg_rt_ms},
+                )
+            )
+
+        # Clear resolved signals from active_alerts
+        active_signals = {e.signal for e in candidates}
+        for signal in list(self._active_alerts.keys()):
+            if signal not in active_signals:
+                del self._active_alerts[signal]
+
+        if not self._alerts_enabled:
+            # Still update active alerts state, but skip sink delivery
+            for event in candidates:
+                self._active_alerts[event.signal] = event
+            return
+
+        for event in candidates:
+            self._active_alerts[event.signal] = event
+
+            last_sent = self._last_alert_at.get(event.signal)
+            if last_sent is not None and (now - last_sent) < self._alert_dedup_window:
+                continue
+
+            self._last_alert_at[event.signal] = now
+
+            try:
+                await self._alert_sink.send(event)
+            except Exception as exc:
+                self.degraded_sink_total += 1
+                logger.warning(f"Alert sink delivery failed for {event.signal}: {exc}")
 
 
 # Global metrics collector instance
@@ -436,7 +588,18 @@ def get_metrics_collector() -> MetricsCollector:
     """
     global _metrics_collector
     if _metrics_collector is None:
-        _metrics_collector = MetricsCollector()
+        # Local import to avoid circular dependency at module load.
+        from open_stocks_mcp.config import load_config
+
+        alerts = load_config().alerts
+        _metrics_collector = MetricsCollector(
+            alerts_enabled=alerts.enabled,
+            alert_dedup_window_seconds=alerts.dedup_window_seconds,
+            error_rate_degraded_threshold=alerts.error_rate_degraded_threshold,
+            error_rate_unhealthy_threshold=alerts.error_rate_unhealthy_threshold,
+            avg_response_time_degraded_ms=alerts.avg_response_time_degraded_ms,
+            avg_response_time_unhealthy_ms=alerts.avg_response_time_unhealthy_ms,
+        )
     return _metrics_collector
 
 

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -347,6 +347,7 @@ def create_http_server(
                 "timestamp": health_status.get("timestamp", time.time()),
                 "version": __version__,
                 "transport": "http",
+                "active_alerts": metrics.get("active_alerts", []),
             }
         except HTTPException:
             raise

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -678,3 +678,60 @@ class TestSessionManagement:
         asyncio.run(run_lifespan())
 
         mock_session_manager.logout.assert_awaited_once()
+
+    @patch("open_stocks_mcp.server.http_transport.get_metrics_collector")
+    @patch("open_stocks_mcp.server.http_transport.get_health_service")
+    async def test_health_endpoint_includes_alert_state(
+        self,
+        mock_get_health_service: Mock,
+        mock_get_metrics_collector: Mock,
+        http_client: httpx.AsyncClient,
+    ) -> None:
+        """HTTP /health exposes active_alerts when metrics collector has active alerts."""
+        mock_health_service = AsyncMock()
+        mock_health_service.get_status.return_value = {
+            "status": "degraded",
+            "timestamp": 1700000000.0,
+            "components": {
+                "metrics": {"status": "healthy"},
+                "session": {"status": "healthy"},
+            },
+        }
+        mock_get_health_service.return_value = mock_health_service
+
+        mock_collector = AsyncMock()
+        mock_collector.get_metrics.return_value = {
+            "broker_health": {},
+            "account_health": {},
+            "active_alerts": [
+                {
+                    "signal": "high_error_rate",
+                    "severity": "degraded",
+                    "message": "High error rate: 15.0%",
+                    "timestamp": "2026-01-01T00:00:00",
+                }
+            ],
+            "degraded_sink_total": 0,
+        }
+        mock_get_metrics_collector.return_value = mock_collector
+
+        response = await http_client.get("/health")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert "active_alerts" in data
+        assert len(data["active_alerts"]) == 1
+        assert data["active_alerts"][0]["signal"] == "high_error_rate"
+
+    async def test_status_endpoint_includes_alert_fields(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """HTTP /status metrics section includes active_alerts and degraded_sink_total."""
+        response = await http_client.get("/status")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "metrics" in data
+        assert "active_alerts" in data["metrics"]
+        assert "degraded_sink_total" in data["metrics"]

--- a/tests/unit/test_analytics_tools.py
+++ b/tests/unit/test_analytics_tools.py
@@ -575,3 +575,41 @@ class TestServerMetrics:
         assert result["result"]["health_status"] == "degraded"
         assert result["result"]["components"]["session"]["status"] == "degraded"
         assert result["result"]["circuit_breaker"]["state"] == "open"
+
+    @patch("open_stocks_mcp.server.tool_helpers.get_metrics_collector")
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_metrics_summary_includes_alert_state(
+        self, mock_get_metrics_collector: Any
+    ) -> None:
+        """metrics_summary MCP tool includes active_alerts and degraded_sink_total."""
+        from open_stocks_mcp.server.app import metrics_summary
+
+        mock_metrics_collector = AsyncMock()
+        mock_metrics_collector.get_metrics.return_value = {
+            "total_calls": 100,
+            "total_errors": 20,
+            "error_rate_percent": 20.0,
+            "avg_response_time_ms": 300.0,
+            "session_refreshes": 0,
+            "timestamp": "2026-01-01T00:00:00",
+            "active_alerts": [
+                {
+                    "signal": "high_error_rate",
+                    "severity": "degraded",
+                    "message": "High error rate: 20.0%",
+                    "timestamp": "2026-01-01T00:00:00",
+                }
+            ],
+            "degraded_sink_total": 0,
+        }
+        mock_get_metrics_collector.return_value = mock_metrics_collector
+
+        result = await metrics_summary()
+
+        assert "result" in result
+        assert "active_alerts" in result["result"]
+        assert len(result["result"]["active_alerts"]) == 1
+        assert result["result"]["active_alerts"][0]["signal"] == "high_error_rate"
+        assert "degraded_sink_total" in result["result"]

--- a/tests/unit/test_monitoring_alerts.py
+++ b/tests/unit/test_monitoring_alerts.py
@@ -1,0 +1,247 @@
+"""Unit tests for monitoring alert trigger evaluation, sinks, and dedup."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import pytest
+
+from open_stocks_mcp.monitoring import AlertEvent, MetricsCollector
+
+
+@dataclass
+class FakeAlertSink:
+    """Fake alert sink for testing."""
+
+    calls: list[AlertEvent] = field(default_factory=list)
+    raise_on_call: bool = False
+    _degraded_sink_total: int = 0
+
+    async def send(self, event: AlertEvent) -> None:
+        if self.raise_on_call:
+            self._degraded_sink_total += 1
+            raise ConnectionError("sink unavailable")
+        self.calls.append(event)
+
+
+@dataclass
+class RaisingAlertSink:
+    """Alert sink that always raises to test error handling."""
+
+    calls_attempted: int = 0
+    degraded_sink_total: int = 0
+
+    async def send(self, event: AlertEvent) -> None:
+        self.calls_attempted += 1
+        self.degraded_sink_total += 1
+        raise ConnectionError("webhook 5xx")
+
+
+class TestAlertTriggerEvaluation:
+    """Alert triggers fire from health-threshold conditions."""
+
+    @pytest.mark.asyncio
+    async def test_high_error_rate_emits_alert(self) -> None:
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        # 10 calls, 3 errors = 30% error rate (> 25% threshold -> unhealthy)
+        collector.api_calls.extend([(now, "tool", True)] * 7)
+        collector.api_calls.extend([(now, "tool", False)] * 3)
+        collector.errors.extend([(now, "tool", "err")] * 3)
+        collector.response_times.extend([(now, 0.1)] * 10)
+
+        await collector.evaluate_alert_conditions()
+
+        assert len(sink.calls) == 1
+        event = sink.calls[0]
+        assert event.signal == "high_error_rate"
+        assert event.severity in ("degraded", "unhealthy")
+
+    @pytest.mark.asyncio
+    async def test_high_avg_response_time_emits_alert(self) -> None:
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        # avg response time > 5s (degraded) or > 10s (unhealthy)
+        collector.api_calls.extend([(now, "tool", True)] * 5)
+        collector.response_times.extend([(now, 12.0)] * 5)  # 12s avg -> unhealthy
+
+        await collector.evaluate_alert_conditions()
+
+        assert len(sink.calls) == 1
+        event = sink.calls[0]
+        assert event.signal == "high_avg_response_time"
+        assert event.severity == "unhealthy"
+
+    @pytest.mark.asyncio
+    async def test_healthy_metrics_do_not_emit_alerts(self) -> None:
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        # 10 calls, 0 errors, fast responses
+        collector.api_calls.extend([(now, "tool", True)] * 10)
+        collector.response_times.extend([(now, 0.1)] * 10)
+
+        await collector.evaluate_alert_conditions()
+
+        assert len(sink.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_alerts_disabled_suppresses_sink_delivery(self) -> None:
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink, alerts_enabled=False)
+        now = datetime.now()
+
+        # Trigger conditions that would normally emit
+        collector.api_calls.extend([(now, "tool", False)] * 10)
+        collector.errors.extend([(now, "tool", "err")] * 10)
+        collector.response_times.extend([(now, 12.0)] * 10)
+
+        await collector.evaluate_alert_conditions()
+
+        assert len(sink.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_alert_state_still_reported_when_disabled(self) -> None:
+        """Even when alerting is disabled, health state is still computed."""
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink, alerts_enabled=False)
+        now = datetime.now()
+
+        collector.api_calls.extend([(now, "tool", False)] * 10)
+        collector.errors.extend([(now, "tool", "err")] * 10)
+        collector.response_times.extend([(now, 12.0)] * 10)
+
+        health = await collector.get_health_status()
+        assert health["status"] in ("degraded", "unhealthy")
+
+
+class TestAlertDeduplication:
+    """Sliding-window dedup prevents alert storms from a single root cause."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_signals_emit_only_one_alert(self) -> None:
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        # 50 rapid calls to evaluate_alert_conditions with same error rate condition
+        collector.api_calls.extend([(now, "tool", False)] * 30)
+        collector.api_calls.extend([(now, "tool", True)] * 10)
+        collector.errors.extend([(now, "tool", "err")] * 30)
+        collector.response_times.extend([(now, 0.1)] * 40)
+
+        for _ in range(50):
+            await collector.evaluate_alert_conditions()
+
+        # Only one alert should have been emitted for the same signal
+        error_rate_alerts = [e for e in sink.calls if e.signal == "high_error_rate"]
+        assert len(error_rate_alerts) == 1
+
+    @pytest.mark.asyncio
+    async def test_alert_state_clears_after_resolution(self) -> None:
+        """After conditions return to healthy, dedup clears and alert can re-fire."""
+        sink = FakeAlertSink()
+        collector = MetricsCollector(
+            alert_sink=sink,
+            alert_dedup_window_seconds=0,  # zero-second window for testing
+        )
+        now = datetime.now()
+
+        # First trigger
+        collector.api_calls.extend([(now, "tool", False)] * 10)
+        collector.errors.extend([(now, "tool", "err")] * 10)
+        collector.response_times.extend([(now, 0.1)] * 10)
+        await collector.evaluate_alert_conditions()
+        first_count = len([e for e in sink.calls if e.signal == "high_error_rate"])
+        assert first_count == 1
+
+        # Second trigger after dedup window expires (window=0 so immediate)
+        await collector.evaluate_alert_conditions()
+        second_count = len([e for e in sink.calls if e.signal == "high_error_rate"])
+        assert second_count == 2
+
+
+class TestSinkErrorHandling:
+    """Sink failures must not propagate to callers and must be counted."""
+
+    @pytest.mark.asyncio
+    async def test_sink_connection_error_increments_degraded_counter(self) -> None:
+        sink = RaisingAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        collector.api_calls.extend([(now, "tool", False)] * 10)
+        collector.errors.extend([(now, "tool", "err")] * 10)
+        collector.response_times.extend([(now, 0.1)] * 10)
+
+        # Should not raise
+        await collector.evaluate_alert_conditions()
+
+        assert collector.degraded_sink_total > 0
+
+    @pytest.mark.asyncio
+    async def test_sink_failure_does_not_propagate(self) -> None:
+        sink = RaisingAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        collector.api_calls.extend([(now, "tool", False)] * 10)
+        collector.errors.extend([(now, "tool", "err")] * 10)
+        collector.response_times.extend([(now, 0.1)] * 10)
+
+        # Must not raise even if sink raises
+        try:
+            await collector.evaluate_alert_conditions()
+        except Exception as e:
+            pytest.fail(f"evaluate_alert_conditions raised unexpectedly: {e}")
+
+
+class TestAlertStateInMetrics:
+    """Alert state is exposed in get_metrics() and get_health_status()."""
+
+    @pytest.mark.asyncio
+    async def test_get_metrics_includes_alert_state(self) -> None:
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        collector.api_calls.extend([(now, "tool", False)] * 10)
+        collector.errors.extend([(now, "tool", "err")] * 10)
+        collector.response_times.extend([(now, 0.1)] * 10)
+        await collector.evaluate_alert_conditions()
+
+        metrics = await collector.get_metrics()
+        assert "active_alerts" in metrics
+        assert "degraded_sink_total" in metrics
+
+    @pytest.mark.asyncio
+    async def test_get_health_status_includes_alert_state(self) -> None:
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        collector.api_calls.extend([(now, "tool", False)] * 10)
+        collector.errors.extend([(now, "tool", "err")] * 10)
+        collector.response_times.extend([(now, 0.1)] * 10)
+        await collector.evaluate_alert_conditions()
+
+        health = await collector.get_health_status()
+        assert "active_alerts" in health
+
+    @pytest.mark.asyncio
+    async def test_healthy_metrics_show_empty_active_alerts(self) -> None:
+        sink = FakeAlertSink()
+        collector = MetricsCollector(alert_sink=sink)
+        now = datetime.now()
+
+        collector.api_calls.extend([(now, "tool", True)] * 10)
+        collector.response_times.extend([(now, 0.1)] * 10)
+
+        metrics = await collector.get_metrics()
+        assert metrics["active_alerts"] == []


### PR DESCRIPTION
Closes #153

## Changes
- **`src/open_stocks_mcp/config.py`**: Added `AlertConfig` dataclass with environment-backed configuration (`ALERTS_ENABLED`, `ALERT_WEBHOOK_URL`, threshold overrides, `ALERT_DEDUP_WINDOW_SECONDS`)
- **`src/open_stocks_mcp/monitoring.py`**: Added `AlertEvent` dataclass, `AlertSink` protocol, `_LogAlertSink` default, sliding-window deduplication, `evaluate_alert_conditions()` method, and `active_alerts`/`degraded_sink_total` fields in `get_metrics()` and `get_health_status()` outputs
- **`src/open_stocks_mcp/server/http_transport.py`**: `/health` endpoint now includes `active_alerts` from the metrics collector
- **`tests/unit/test_monitoring_alerts.py`**: 12 new tests covering trigger evaluation, disabled alerting, deduplication (50 signals → 1 alert), sink error handling (ConnectionError increments counter, never propagates), and alert state in metrics/health outputs
- **`tests/unit/test_analytics_tools.py`**: Added test verifying `metrics_summary` MCP tool includes `active_alerts` and `degraded_sink_total`
- **`tests/http_transport/test_http_server.py`**: Added tests for HTTP `/health` alert state and `/status` alert fields
- **`docs/MONITORING_RUNBOOK.md`**: Operator runbook covering supported alerts, all configuration variables, deduplication behavior, sink failure handling, fake-sink testing guide, and endpoint reference

## Test plan
- `uv run pytest tests/unit/test_monitoring_alerts.py -q` — 12 passed
- `uv run pytest tests/unit -k 'alert or monitoring' -q` — 21 passed
- `uv run pytest tests/unit/test_analytics_tools.py tests/http_transport/test_http_server.py -k 'alert or health_check or server_status or metrics_summary' -q` — 8 passed
- `uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/monitoring.py src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py` — Success: no issues found
- `uv run ruff check` on all touched files — All checks passed