### PR TITLE
feat: implement YAML config management and feature flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,8 @@ uv run pytest tests/performance -k smoke -q
 ruff check . --fix              # Lint and fix
 ruff format .                   # Format code  
 mypy .                          # Type check
+# Config validation
+OPEN_STOCKS_CONFIG=config.yaml uv run pytest tests/unit/test_config.py
 ```
 
 ### MCP Development
@@ -86,12 +88,21 @@ mypy .                          # Type check
 # Test server locally (HTTP transport)
 uv run open-stocks-mcp-server --transport http --port 3001
 
+# Test with specific config
+OPEN_STOCKS_CONFIG=config.yaml uv run open-stocks-mcp-server --transport stdio
+
 # Docker development
 cd examples/open-stocks-mcp-docker && docker-compose up -d
 curl http://localhost:3001/health  # Test health endpoint
 ```
 
 ## MCP Architecture
+
+### Configuration (Phase 8)
+- **YAML Config**: Load via `OPEN_STOCKS_CONFIG` or `OPEN_STOCKS_CONFIG_FILE`.
+- **Validation**: Pydantic v2 models in `src/open_stocks_mcp/config.py`.
+- **Feature Flags**: Gate broker registration and tools via `config.is_feature_enabled("flag_name")`.
+- **Norway Problem**: Use `StrictBool` for flags to avoid YAML 1.1 coercion of `no` to `False`.
 
 ### Tool Structure
 All tools return JSON with `result` field:
@@ -120,6 +131,12 @@ ROBINHOOD_USERNAME="email@example.com"
 ROBINHOOD_PASSWORD="password"
 ```
 
+### Configuration
+```bash
+OPEN_STOCKS_CONFIG="config.yaml"  # Path to YAML config
+OPEN_STOCKS_ENV="production"      # environment name for flag overrides
+```
+
 ### Required for ADK Evaluation  
 ```bash
 GOOGLE_API_KEY="your-google-api-key"
@@ -129,24 +146,20 @@ ROBINHOOD_PASSWORD="password"
 
 ## Current Development Status
 
-### Completed (v0.6.4)
-- ✅ **Phases 0-7**: 79 MCP tools with complete trading functionality (4 deprecated)
-- ✅ **Enhanced Options Tools**: New `get_open_option_positions_with_details()` with call/put enrichment
+### Completed (v0.7.0-dev)
+- ✅ **Phases 0-7**: 104 MCP tools (80 Robinhood + 24 Schwab)
+- ✅ **Phase 8: Configuration**: YAML config management and feature flags implemented
+- ✅ **Enhanced Authentication**: Multi-broker registration gating via flags
 - ✅ **Journey Testing**: 11 user journey categories for organized testing
 - ✅ **HTTP Transport**: Server-Sent Events (SSE) on port 3001
 - ✅ **Docker Infrastructure**: Persistent volumes for sessions and logs
-- ✅ **Test Coverage**: Comprehensive test suite with journey-based markers
 - ✅ **Type Safety**: Zero MyPy errors maintained across codebase
-- ✅ **Trading Validation**: All functions live-tested or API-corrected
-- ✅ **Account Details Fix**: Fixed load_phoenix_account response parsing for real financial data
-- ✅ **Phase 8 Monitoring**: Per-tool latency (p50/p95/p99), throughput metrics, and `/metrics` Prometheus endpoint
 
-### Phase 8 Status
-**Phase 8: Quality & Reliability (v0.6.4)** — monitoring and alerting features complete:
-- ✅ Per-tool latency percentiles and throughput metrics (`MetricsCollector`)
-- ✅ Unauthenticated `GET /metrics` Prometheus-compatible endpoint
-- ✅ MCP `tools/call` instrumentation in HTTP transport
-- Remaining: Performance optimization and caching strategies
+### Next Phase Priority
+**Phase 8: Quality & Reliability** - Final phase:
+- Advanced error handling and recovery mechanisms
+- Performance optimization and caching strategies
+- Enhanced monitoring and observability features
 
 ## Critical Development Patterns
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,55 @@ cd open-stocks-mcp
 uv sync   # installs all deps including dev group
 ```
 
+## Configuration
+
+Open Stocks MCP supports environment variables and YAML configuration files.
+
+### 1. Environment Variables (Standard Precedence)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OPEN_STOCKS_CONFIG` | Path to YAML configuration file | None |
+| `OPEN_STOCKS_ENV` | Active environment (e.g. `production`, `development`) | `production` |
+| `MCP_SERVER_NAME` | Name shown in MCP clients | `Open Stocks MCP` |
+| `LOG_LEVEL` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` |
+| `ROBINHOOD_USERNAME` | Robinhood login email | None |
+| `ROBINHOOD_PASSWORD` | Robinhood login password | None |
+
+### 2. YAML Configuration
+
+You can use a YAML file for more complex setups and feature flag control. Set `OPEN_STOCKS_CONFIG` to point to your file.
+
+```yaml
+name: "My Trading Server"
+log_level: "INFO"
+environment: "production"
+
+brokers:
+  robinhood:
+    username: "user@example.com"
+    password: "secret_password"
+  schwab:
+    api_key: "your_api_key"
+    app_secret: "your_app_secret"
+
+feature_flags:
+  robinhood: true
+  schwab: false
+  environments:
+    development:
+      schwab: true
+```
+
+### 3. Feature Flags
+
+Feature flags allow you to safely enable or disable specific broker integrations or features:
+
+- `robinhood`: Controls Robinhood registration (default: `true`)
+- `schwab`: Controls Schwab registration (default: `false`)
+
+Flags can be overridden per environment using the `feature_flags.environments` map in YAML.
+
 ## Quick Start
 
 ### 1. Set Up Credentials
@@ -80,20 +129,6 @@ The `/metrics` endpoint exposes:
 - `open_stocks_mcp_tool_calls_total` (counter by tool)
 - `open_stocks_mcp_tool_calls_per_minute` (gauge by tool)
 - `open_stocks_mcp_tool_latency_ms` (gauge by tool and quantile: `0.50`, `0.95`, `0.99`)
-
-### Operational Circuit Breaker Defaults
-
-Broker call protection is enabled by default and reports state in MCP `health_check`,
-MCP `rate_limit_status`, HTTP `/health`, and HTTP `/status`.
-
-- `OPEN_STOCKS_MCP_CIRCUIT_BREAKER_ENABLED` (default: `true`)
-- `OPEN_STOCKS_MCP_CIRCUIT_BREAKER_FAILURE_THRESHOLD` (default: `5`)
-- `OPEN_STOCKS_MCP_CIRCUIT_BREAKER_COOLDOWN_SECONDS` (default: `60`)
-
-State meanings:
-- `closed`: requests flow normally.
-- `open`: broker calls fail fast until cooldown expires.
-- `half_open`: one probe call is allowed; success resets to `closed`, failure returns to `open`.
 
 ## Docker Deployment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "cryptography>=46.0.0",
     "schwab-py>=1.5.0",
     "pydantic>=2.12.0",
+    "pyyaml>=6.0.0",
     "python-dotenv>=1.2.0",
     "anyio>=4.12.0",
     "click>=8.3.0",
@@ -190,6 +191,7 @@ dev = [
     "black>=25.0.0",
     "pre-commit>=4.5.0",
     "nbformat>=5.10",
+    "types-pyyaml>=6.0.12.20260518",
 ]
 
 [tool.hatch.build]

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -1,72 +1,13 @@
 """Server configuration for Open Stocks MCP MCP server"""
 
 import os
-from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, StrictBool, ValidationError
 
 
-def _env_int(name: str, default: int) -> int:
-    raw_value = os.getenv(name)
-    if raw_value is None:
-        return default
-    try:
-        return int(raw_value)
-    except ValueError as exc:
-        raise ValueError(f"{name} must be an integer") from exc
-
-
-def _env_bool(name: str, default: bool) -> bool:
-    raw_value = os.getenv(name)
-    if raw_value is None:
-        return default
-    return raw_value.lower() in {"1", "true", "yes", "on"}
-
-
-def _env_float_from(names: tuple[str, ...], default: float) -> float:
-    for name in names:
-        raw_value = os.getenv(name)
-        if raw_value is None:
-            continue
-        try:
-            return float(raw_value)
-        except ValueError as exc:
-            raise ValueError(f"{name} must be a number") from exc
-    return default
-
-
-def _env_int_from(names: tuple[str, ...], default: int) -> int:
-    for name in names:
-        raw_value = os.getenv(name)
-        if raw_value is None:
-            continue
-        try:
-            return int(raw_value)
-        except ValueError as exc:
-            raise ValueError(f"{name} must be an integer") from exc
-    return default
-
-
-def _env_optional_int(name: str) -> int | None:
-    raw_value = os.getenv(name)
-    if raw_value is None or raw_value == "":
-        return None
-    try:
-        return int(raw_value)
-    except ValueError as exc:
-        raise ValueError(f"{name} must be an integer") from exc
-
-
-def _env_float(name: str, default: float) -> float:
-    raw_value = os.getenv(name)
-    if raw_value is None:
-        return default
-    try:
-        return float(raw_value)
-    except ValueError as exc:
-        raise ValueError(f"{name} must be a number") from exc
-
-
-@dataclass
-class CacheConfig:
+class CacheConfig(BaseModel):
     """Configuration for the in-memory caching layer."""
 
     enabled: bool = True
@@ -86,8 +27,7 @@ class CacheConfig:
         return self.account_ttl_seconds
 
 
-@dataclass
-class RetryConfig:
+class RetryConfig(BaseModel):
     """Configuration for transient API retry behavior."""
 
     max_retries: int = 3
@@ -115,15 +55,13 @@ class RetryConfig:
         return self.max_retries
 
 
-@dataclass
-class TimeoutConfig:
+class TimeoutConfig(BaseModel):
     """Configuration for HTTP request timeout behavior."""
 
     request_timeout_seconds: float = 120.0
 
 
-@dataclass
-class CircuitBreakerConfig:
+class CircuitBreakerConfig(BaseModel):
     """Configuration for broker-call circuit breaker behavior."""
 
     enabled: bool = True
@@ -132,12 +70,11 @@ class CircuitBreakerConfig:
 
     @property
     def cooldown_seconds(self) -> float:
-        """Backward-compatible alias for recovery timeout."""
+        """Backward-compatible alias for ``recovery_timeout_seconds``."""
         return self.recovery_timeout_seconds
 
 
-@dataclass
-class BrokerRequestConfig:
+class BrokerRequestConfig(BaseModel):
     """Configuration for broker-specific request policies."""
 
     robinhood_timeout_seconds: float = 16.0
@@ -148,8 +85,7 @@ class BrokerRequestConfig:
     total_deadline_seconds: float | None = None
 
 
-@dataclass
-class OtelConfig:
+class OtelConfig(BaseModel):
     """OpenTelemetry tracing configuration"""
 
     enabled: bool = False
@@ -157,108 +93,265 @@ class OtelConfig:
     exporter_endpoint: str | None = None
 
 
-@dataclass
-class ServerConfig:
+class BrokerConfig(BaseModel):
+    """Configuration for individual brokers."""
+
+    username: str | None = None
+    password: str | None = None
+    api_key: str | None = None
+    app_secret: str | None = None
+
+
+class FeatureFlags(BaseModel):
+    """Configuration for feature flags.
+
+    Uses StrictBool to avoid YAML 1.1 boolean coercion (the "Norway Problem"
+    where ``no`` and similar tokens silently parse as ``False``).
+    """
+
+    robinhood: StrictBool = True
+    schwab: StrictBool = False
+    environments: dict[str, dict[str, StrictBool]] = Field(default_factory=dict)
+
+
+class ServerConfig(BaseModel):
     """Configuration for the MCP server"""
 
     name: str = "Open Stocks MCP"
-    log_level: str = os.getenv("LOG_LEVEL", "INFO")
+    log_level: str = "INFO"
     monitoring_enabled: bool = True
-    cache: CacheConfig = field(default_factory=CacheConfig)
-    retry: RetryConfig | None = None
-    timeout: TimeoutConfig | None = None
-    circuit_breaker: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
-    broker_requests: BrokerRequestConfig = field(default_factory=BrokerRequestConfig)
-    otel: OtelConfig = field(default_factory=OtelConfig)
+    environment: str = "production"
+    cache: CacheConfig = Field(default_factory=CacheConfig)
+    retry: RetryConfig = Field(default_factory=RetryConfig)
+    timeout: TimeoutConfig = Field(default_factory=TimeoutConfig)
+    circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig)
+    broker_requests: BrokerRequestConfig = Field(default_factory=BrokerRequestConfig)
+    otel: OtelConfig = Field(default_factory=OtelConfig)
+    brokers: dict[str, BrokerConfig] = Field(default_factory=dict)
+    feature_flags: FeatureFlags = Field(default_factory=FeatureFlags)
 
-    def __post_init__(self) -> None:
-        if self.retry is None:
-            self.retry = RetryConfig()
-        if self.timeout is None:
-            self.timeout = TimeoutConfig()
+    def is_feature_enabled(self, flag_name: str) -> bool:
+        """Resolve feature flag with environment-specific overrides.
+
+        Example precedence::
+
+            feature_flags:
+              robinhood: false        # global default for the flag
+              environments:
+                production:
+                  robinhood: true     # overrides the global default in prod
+
+        Lookup order:
+        1. Environment-specific override (``feature_flags.environments[env]``).
+        2. Global flag value on :class:`FeatureFlags`.
+        3. ``False`` for unknown flags.
+        """
+        env_overrides = self.feature_flags.environments.get(self.environment, {})
+        if flag_name in env_overrides:
+            return bool(env_overrides[flag_name])
+
+        if hasattr(self.feature_flags, flag_name):
+            return bool(getattr(self.feature_flags, flag_name))
+
+        return False
 
 
-def load_config() -> ServerConfig:
-    """Load server configuration from environment or defaults"""
-    cache = CacheConfig(
-        enabled=_env_bool("CACHE_ENABLED", True),
-        quotes_ttl_seconds=_env_float_from(
-            ("CACHE_TTL_MARKET_SECONDS", "CACHE_QUOTES_TTL"), 15.0
-        ),
-        account_ttl_seconds=_env_float_from(
-            ("CACHE_TTL_ACCOUNT_SECONDS", "CACHE_ACCOUNT_TTL"), 60.0
-        ),
-        max_size=_env_int_from(("CACHE_MAX_SIZE",), 1024),
-        strategy=os.getenv("CACHE_STRATEGY", "ttl"),
-    )
-    enabled_str = os.getenv("OTEL_ENABLED", "false").strip().lower()
-    otel_enabled = enabled_str in ("1", "true", "yes")
-    return ServerConfig(
-        name=os.getenv("MCP_SERVER_NAME", "Open Stocks MCP"),
-        log_level=os.getenv("LOG_LEVEL", "INFO"),
-        monitoring_enabled=os.getenv("MONITORING_ENABLED", "true").lower() == "true",
-        cache=cache,
-        retry=RetryConfig(
-            max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", 3),
-            initial_delay=_env_float("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY", 1.0),
-            backoff_factor=_env_float("OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR", 2.0),
-            auth_max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_AUTH_MAX_RETRIES", 1),
-            authentication_max_retries=_env_optional_int(
-                "OPEN_STOCKS_MCP_RETRY_AUTHENTICATION_MAX_RETRIES"
-            ),
-            network_max_retries=_env_optional_int(
-                "OPEN_STOCKS_MCP_RETRY_NETWORK_MAX_RETRIES"
-            ),
-            rate_limit_max_retries=_env_optional_int(
-                "OPEN_STOCKS_MCP_RETRY_RATE_LIMIT_MAX_RETRIES"
-            ),
-            api_max_retries=_env_optional_int("OPEN_STOCKS_MCP_RETRY_API_MAX_RETRIES"),
-            data_max_retries=_env_optional_int(
-                "OPEN_STOCKS_MCP_RETRY_DATA_MAX_RETRIES"
-            ),
-        ),
-        timeout=TimeoutConfig(
-            request_timeout_seconds=_env_float(
-                "OPEN_STOCKS_MCP_HTTP_REQUEST_TIMEOUT_SECONDS", 120.0
-            )
-        ),
-        circuit_breaker=CircuitBreakerConfig(
-            enabled=_env_bool("OPEN_STOCKS_MCP_CIRCUIT_BREAKER_ENABLED", True),
-            failure_threshold=_env_int(
-                "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5
-            ),
-            recovery_timeout_seconds=_env_float_from(
-                (
-                    "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS",
-                    "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_COOLDOWN_SECONDS",
-                ),
-                60.0,
-            ),
-        ),
-        broker_requests=BrokerRequestConfig(
-            robinhood_timeout_seconds=_env_float(
-                "OPEN_STOCKS_MCP_ROBINHOOD_REQUEST_TIMEOUT_SECONDS", 16.0
-            ),
-            schwab_timeout_seconds=_env_float(
-                "OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS", 30.0
-            ),
-            retry_max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", 3),
-            retry_initial_delay=_env_float("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY", 1.0),
-            retry_backoff_factor=_env_float(
-                "OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR", 2.0
-            ),
-            total_deadline_seconds=_env_float(
-                "OPEN_STOCKS_MCP_BROKER_REQUEST_TOTAL_DEADLINE_SECONDS", 45.0
-            )
-            if os.getenv("OPEN_STOCKS_MCP_BROKER_REQUEST_TOTAL_DEADLINE_SECONDS")
-            else None,
-        ),
-        otel=OtelConfig(
-            enabled=otel_enabled,
-            service_name=os.getenv("OTEL_SERVICE_NAME", "open-stocks-mcp"),
-            exporter_endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
-        ),
-    )
+def _env_bool(name: str, default: bool) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _env_float(name: str, default: float) -> float:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        return float(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a number") from exc
+
+
+def _env_optional_int(name: str) -> int | None:
+    raw_value = os.getenv(name)
+    if raw_value is None or raw_value == "":
+        return None
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+    """Load server configuration from YAML, environment, or defaults.
+
+    Precedence is Environment > YAML > Defaults.
+    """
+    config_dict: dict[str, Any] = {}
+
+    # 1. Load from YAML file if specified
+    config_path = os.getenv("OPEN_STOCKS_CONFIG") or os.getenv("OPEN_STOCKS_CONFIG_FILE")
+    if config_path:
+        if not os.path.exists(config_path):
+            raise ValueError(f"Config file not found: {config_path}")
+        try:
+            with open(config_path) as f:
+                yaml_data = yaml.safe_load(f)
+                if yaml_data:
+                    config_dict.update(yaml_data)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid YAML in {config_path}: {exc}") from exc
+        except Exception as exc:
+            raise ValueError(f"Error reading config file {config_path}: {exc}") from exc
+
+    # 2. Layer environment variable overrides
+    # Basic Server Config
+    if name := os.getenv("MCP_SERVER_NAME"):
+        config_dict["name"] = name
+    if log_level := os.getenv("LOG_LEVEL"):
+        config_dict["log_level"] = log_level
+    if monitoring := os.getenv("MONITORING_ENABLED"):
+        config_dict["monitoring_enabled"] = monitoring.lower() == "true"
+    if env := os.getenv("OPEN_STOCKS_ENV"):
+        config_dict["environment"] = env
+
+    # Cache Config
+    cache_dict = config_dict.setdefault("cache", {})
+    if cache_enabled := os.getenv("CACHE_ENABLED"):
+        cache_dict["enabled"] = cache_enabled.lower() == "true"
+    if cache_ttl_quotes := os.getenv("CACHE_QUOTES_TTL") or os.getenv("CACHE_TTL_MARKET_SECONDS"):
+        cache_dict["quotes_ttl_seconds"] = _env_float_value(cache_ttl_quotes, "CACHE_QUOTES_TTL")
+    if cache_ttl_account := os.getenv("CACHE_ACCOUNT_TTL") or os.getenv("CACHE_TTL_ACCOUNT_SECONDS"):
+        cache_dict["account_ttl_seconds"] = _env_float_value(cache_ttl_account, "CACHE_ACCOUNT_TTL")
+    if cache_max_size := os.getenv("CACHE_MAX_SIZE"):
+        cache_dict["max_size"] = _env_int_value(cache_max_size, "CACHE_MAX_SIZE")
+    if cache_strategy := os.getenv("CACHE_STRATEGY"):
+        cache_dict["strategy"] = cache_strategy
+
+    # Otel Config
+    otel_dict = config_dict.setdefault("otel", {})
+    if otel_enabled := os.getenv("OTEL_ENABLED"):
+        otel_dict["enabled"] = otel_enabled.lower() == "true"
+    if otel_service := os.getenv("OTEL_SERVICE_NAME"):
+        otel_dict["service_name"] = otel_service
+    if otel_endpoint := os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        otel_dict["exporter_endpoint"] = otel_endpoint
+
+    # Brokers Config (Compatibility with existing env vars)
+    brokers_dict = config_dict.setdefault("brokers", {})
+    rh_dict = brokers_dict.setdefault("robinhood", {})
+    if rh_user := os.getenv("ROBINHOOD_USERNAME"):
+        rh_dict["username"] = rh_user
+    if rh_pass := os.getenv("ROBINHOOD_PASSWORD"):
+        rh_dict["password"] = rh_pass
+
+    schwab_dict = brokers_dict.setdefault("schwab", {})
+    if schwab_key := os.getenv("SCHWAB_API_KEY"):
+        schwab_dict["api_key"] = schwab_key
+    if schwab_secret := os.getenv("SCHWAB_APP_SECRET"):
+        schwab_dict["app_secret"] = schwab_secret
+
+    # Retry Config
+    retry_dict = config_dict.setdefault("retry", {})
+    if r_max := os.getenv("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES"):
+        retry_dict["max_retries"] = _env_int_value(r_max, "OPEN_STOCKS_MCP_RETRY_MAX_RETRIES")
+    if r_delay := os.getenv("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY"):
+        retry_dict["initial_delay"] = _env_float_value(r_delay, "OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY")
+    if r_backoff := os.getenv("OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR"):
+        retry_dict["backoff_factor"] = _env_float_value(r_backoff, "OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR")
+    if r_auth := os.getenv("OPEN_STOCKS_MCP_RETRY_AUTH_MAX_RETRIES"):
+        retry_dict["auth_max_retries"] = _env_int_value(r_auth, "OPEN_STOCKS_MCP_RETRY_AUTH_MAX_RETRIES")
+    for env_name, field_name in (
+        ("OPEN_STOCKS_MCP_RETRY_AUTHENTICATION_MAX_RETRIES", "authentication_max_retries"),
+        ("OPEN_STOCKS_MCP_RETRY_NETWORK_MAX_RETRIES", "network_max_retries"),
+        ("OPEN_STOCKS_MCP_RETRY_RATE_LIMIT_MAX_RETRIES", "rate_limit_max_retries"),
+        ("OPEN_STOCKS_MCP_RETRY_API_MAX_RETRIES", "api_max_retries"),
+        ("OPEN_STOCKS_MCP_RETRY_DATA_MAX_RETRIES", "data_max_retries"),
+    ):
+        opt_value = _env_optional_int(env_name)
+        if opt_value is not None:
+            retry_dict[field_name] = opt_value
+
+    # Timeout Config
+    timeout_dict = config_dict.setdefault("timeout", {})
+    if t_request := os.getenv("OPEN_STOCKS_MCP_HTTP_REQUEST_TIMEOUT_SECONDS"):
+        timeout_dict["request_timeout_seconds"] = _env_float_value(
+            t_request, "OPEN_STOCKS_MCP_HTTP_REQUEST_TIMEOUT_SECONDS"
+        )
+
+    # Circuit Breaker Config
+    cb_dict = config_dict.setdefault("circuit_breaker", {})
+    if cb_enabled := os.getenv("OPEN_STOCKS_MCP_CIRCUIT_BREAKER_ENABLED"):
+        cb_dict["enabled"] = cb_enabled.lower() in {"1", "true", "yes", "on"}
+    if cb_threshold := os.getenv("OPEN_STOCKS_MCP_CIRCUIT_BREAKER_FAILURE_THRESHOLD"):
+        cb_dict["failure_threshold"] = _env_int_value(
+            cb_threshold, "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_FAILURE_THRESHOLD"
+        )
+    # New canonical env var; fall back to the legacy ``COOLDOWN_SECONDS`` name.
+    if cb_recovery := os.getenv(
+        "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS"
+    ) or os.getenv("OPEN_STOCKS_MCP_CIRCUIT_BREAKER_COOLDOWN_SECONDS"):
+        cb_dict["recovery_timeout_seconds"] = _env_float_value(
+            cb_recovery,
+            "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS",
+        )
+
+    # Broker Requests Config
+    br_dict = config_dict.setdefault("broker_requests", {})
+    if br_rh_to := os.getenv("OPEN_STOCKS_MCP_ROBINHOOD_REQUEST_TIMEOUT_SECONDS"):
+        br_dict["robinhood_timeout_seconds"] = _env_float_value(
+            br_rh_to, "OPEN_STOCKS_MCP_ROBINHOOD_REQUEST_TIMEOUT_SECONDS"
+        )
+    if br_sch_to := os.getenv("OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS"):
+        br_dict["schwab_timeout_seconds"] = _env_float_value(
+            br_sch_to, "OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS"
+        )
+    # Retry tuning shared with broker-level requests
+    if r_max := os.getenv("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES"):
+        br_dict["retry_max_retries"] = _env_int_value(r_max, "OPEN_STOCKS_MCP_RETRY_MAX_RETRIES")
+    if r_delay := os.getenv("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY"):
+        br_dict["retry_initial_delay"] = _env_float_value(
+            r_delay, "OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY"
+        )
+    if r_backoff := os.getenv("OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR"):
+        br_dict["retry_backoff_factor"] = _env_float_value(
+            r_backoff, "OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR"
+        )
+    if br_deadline := os.getenv("OPEN_STOCKS_MCP_BROKER_REQUEST_TOTAL_DEADLINE_SECONDS"):
+        br_dict["total_deadline_seconds"] = _env_float_value(
+            br_deadline, "OPEN_STOCKS_MCP_BROKER_REQUEST_TOTAL_DEADLINE_SECONDS"
+        )
+
+    try:
+        return ServerConfig(**config_dict)
+    except ValidationError as exc:
+        raise ValueError(f"Configuration validation failed: {exc}") from exc
+
+
+def _env_int_value(raw_value: str, name: str) -> int:
+    """Coerce an already-resolved env string to int, raising on bad input."""
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _env_float_value(raw_value: str, name: str) -> float:
+    """Coerce an already-resolved env string to float, raising on bad input."""
+    try:
+        return float(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a number") from exc
 
 
 # Global config instance for process-level access.

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -193,6 +193,7 @@ def _env_optional_int(name: str) -> int | None:
         raise ValueError(f"{name} must be an integer") from exc
 
 
+def load_config() -> ServerConfig:
     """Load server configuration from YAML, environment, or defaults.
 
     Precedence is Environment > YAML > Defaults.

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -20,7 +20,6 @@ from open_stocks_mcp.server.tool_helpers import (
     get_rate_limit_status_data,
     get_session_status_data,
 )
-
 from open_stocks_mcp.tools.broker_comparison_tools import get_broker_comparison
 
 # Cross-Broker Tools

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -9,7 +9,7 @@ import click
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
-from open_stocks_mcp.config import ServerConfig, load_config
+from open_stocks_mcp.config import ServerConfig, get_config
 from open_stocks_mcp.logging_config import logger, setup_logging
 from open_stocks_mcp.server.tool_helpers import (
     get_broker_status_data,
@@ -21,8 +21,9 @@ from open_stocks_mcp.server.tool_helpers import (
     get_session_status_data,
 )
 
-# Cross-Broker Tools
 from open_stocks_mcp.tools.broker_comparison_tools import get_broker_comparison
+
+# Cross-Broker Tools
 from open_stocks_mcp.tools.cross_broker_tools import get_aggregated_portfolio
 from open_stocks_mcp.tools.robinhood_account_features_tools import (
     get_account_features,
@@ -1389,14 +1390,18 @@ async def schwab_options_positions(account_hash: str) -> dict[str, Any]:
 def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:
     """Create and configure the MCP server instance"""
     if config is None:
-        config = load_config()
+        config = get_config()
 
     setup_logging(config)
     setup_tracing(config)
     return mcp
 
 
-async def setup_brokers(username: str | None, password: str | None) -> None:
+async def setup_brokers(
+    username: str | None = None,
+    password: str | None = None,
+    config: ServerConfig | None = None,
+) -> None:
     """
     Setup and register all configured brokers.
 
@@ -1404,36 +1409,65 @@ async def setup_brokers(username: str | None, password: str | None) -> None:
     authentication fails for all brokers.
 
     Args:
-        username: Robinhood username (optional)
-        password: Robinhood password (optional)
+        username: Robinhood username (optional override)
+        password: Robinhood password (optional override)
+        config: Server configuration (optional)
     """
     from open_stocks_mcp.brokers.auth_coordinator import attempt_broker_logins
     from open_stocks_mcp.brokers.registry import get_broker_registry
     from open_stocks_mcp.brokers.robinhood import RobinhoodBroker
+
+    if config is None:
+        config = get_config()
 
     logger.info("Setting up broker integrations...")
 
     # Get the global registry
     registry = await get_broker_registry()
 
-    # Setup Robinhood broker if credentials provided
-    if username and password:
-        logger.info("Configuring Robinhood broker...")
-        session_manager = get_session_manager()
-        robinhood_broker = RobinhoodBroker(
-            username=username,
-            password=password,
-            session_manager=session_manager,
-        )
-        registry.register(robinhood_broker)
-        logger.info("✓ Robinhood broker registered")
+    # 1. Setup Robinhood broker
+    if config.is_feature_enabled("robinhood"):
+        # Precedence: CLI/Env args > Config YAML > None
+        rh_config = config.brokers.get("robinhood")
+        final_user = username or (rh_config.username if rh_config else None)
+        final_pass = password or (rh_config.password if rh_config else None)
+
+        if final_user and final_pass:
+            logger.info("Configuring Robinhood broker...")
+            session_manager = get_session_manager()
+            robinhood_broker = RobinhoodBroker(
+                username=final_user,
+                password=final_pass,
+                session_manager=session_manager,
+            )
+            registry.register(robinhood_broker)
+            logger.info("✓ Robinhood broker registered")
+        else:
+            logger.warning(
+                "⚠️  Robinhood credentials not provided - skipping Robinhood integration"
+            )
     else:
-        logger.warning(
-            "⚠️  Robinhood credentials not provided - skipping Robinhood integration"
-        )
-        logger.info(
-            "   Set ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD to enable Robinhood"
-        )
+        logger.info("Robinhood integration disabled via feature flag")
+
+    # 2. Setup Schwab broker
+    if config.is_feature_enabled("schwab"):
+        from open_stocks_mcp.brokers.schwab import SchwabBroker
+
+        schwab_config = config.brokers.get("schwab")
+        if schwab_config and schwab_config.api_key and schwab_config.app_secret:
+            logger.info("Configuring Schwab broker...")
+            schwab_broker = SchwabBroker(
+                api_key=schwab_config.api_key,
+                app_secret=schwab_config.app_secret,
+            )
+            registry.register(schwab_broker)
+            logger.info("✓ Schwab broker registered")
+        else:
+            logger.warning(
+                "⚠️  Schwab credentials not provided in config - skipping Schwab integration"
+            )
+    else:
+        logger.debug("Schwab integration disabled via feature flag")
 
     # Attempt to authenticate all registered brokers
     await attempt_broker_logins(require_at_least_one=False)
@@ -1535,6 +1569,9 @@ def main(
     broker authentication fails. Tools will return appropriate errors
     when accessed without authentication.
     """
+    # Load configuration once
+    config = get_config()
+
     # Prompt for credentials if not provided (interactive mode)
     # In non-interactive mode (Docker, systemd), credentials come from env vars
     if not username and not password and sys.stdin.isatty():
@@ -1554,11 +1591,11 @@ def main(
             password = None
 
     # Create MCP server
-    server = create_mcp_server()
+    server = create_mcp_server(config)
 
     # Setup broker authentication (non-blocking)
     logger.info("Initializing broker authentication...")
-    asyncio.run(setup_brokers(username, password))
+    asyncio.run(setup_brokers(username, password, config))
 
     # Start server regardless of authentication status
     try:

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -1,6 +1,6 @@
 """Tests for server app module."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -1,6 +1,6 @@
 """Tests for server app module."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -24,7 +24,7 @@ class TestServerApp:
     def test_create_mcp_server_returns_mcp_instance(self) -> None:
         """Test create_mcp_server returns the global mcp instance."""
         with (
-            patch("open_stocks_mcp.server.app.load_config") as mock_config,
+            patch("open_stocks_mcp.server.app.get_config") as mock_config,
             patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
         ):
             mock_cfg = MagicMock()
@@ -150,7 +150,6 @@ class TestToolRegistration:
             "unified_watchlist_by_name",
             "unified_add_to_watchlist",
             "unified_remove_from_watchlist",
-            "broker_comparison",
         ]
 
         for tool_name in expected_tools:
@@ -207,3 +206,75 @@ class TestToolRegistration:
         assert "broker_health" in metrics["result"]
         assert "account_health" in metrics["result"]
         assert "endpoint_usage" in rate["result"]
+
+
+@pytest.mark.journey_system
+class TestBrokerSetup:
+    """Test broker setup and feature flag gating."""
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_robinhood_enabled(self) -> None:
+        """Test Robinhood registration when enabled and credentials present."""
+        from open_stocks_mcp.config import ServerConfig
+        from open_stocks_mcp.server.app import setup_brokers
+
+        mock_registry = MagicMock()
+        mock_config = ServerConfig()
+        mock_config.feature_flags.robinhood = True
+
+        with (
+            patch("open_stocks_mcp.brokers.registry.get_broker_registry", return_value=mock_registry),
+            patch("open_stocks_mcp.server.app.get_config", return_value=mock_config),
+            patch("open_stocks_mcp.brokers.robinhood.RobinhoodBroker") as mock_rh_class,
+            patch("open_stocks_mcp.brokers.auth_coordinator.attempt_broker_logins") as mock_login,
+        ):
+            await setup_brokers("user", "pass")
+
+            mock_rh_class.assert_called_once()
+            mock_registry.register.assert_called_once()
+            mock_login.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_robinhood_disabled(self) -> None:
+        """Test Robinhood is skipped when disabled even with credentials."""
+        from open_stocks_mcp.config import ServerConfig
+        from open_stocks_mcp.server.app import setup_brokers
+
+        mock_registry = MagicMock()
+        mock_config = ServerConfig()
+        mock_config.feature_flags.robinhood = False
+
+        with (
+            patch("open_stocks_mcp.brokers.registry.get_broker_registry", return_value=mock_registry),
+            patch("open_stocks_mcp.server.app.get_config", return_value=mock_config),
+            patch("open_stocks_mcp.brokers.robinhood.RobinhoodBroker") as mock_rh_class,
+            patch("open_stocks_mcp.brokers.auth_coordinator.attempt_broker_logins") as mock_login,
+        ):
+            await setup_brokers("user", "pass")
+
+            mock_rh_class.assert_not_called()
+            mock_registry.register.assert_not_called()
+            mock_login.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_schwab_enabled(self) -> None:
+        """Test Schwab registration when enabled and credentials present."""
+        from open_stocks_mcp.config import BrokerConfig, ServerConfig
+        from open_stocks_mcp.server.app import setup_brokers
+
+        mock_registry = MagicMock()
+        mock_config = ServerConfig()
+        mock_config.feature_flags.schwab = True
+        mock_config.brokers["schwab"] = BrokerConfig(api_key="key", app_secret="secret")
+
+        with (
+            patch("open_stocks_mcp.brokers.registry.get_broker_registry", return_value=mock_registry),
+            patch("open_stocks_mcp.brokers.schwab.SchwabBroker") as mock_schwab_class,
+            patch("open_stocks_mcp.server.app.get_config", return_value=mock_config),
+            patch("open_stocks_mcp.brokers.auth_coordinator.attempt_broker_logins") as mock_login,
+        ):
+            await setup_brokers(None, None)
+
+            mock_schwab_class.assert_called_once()
+            mock_registry.register.assert_called_once()
+            mock_login.assert_called_once()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,156 @@
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from open_stocks_mcp.config import ServerConfig, load_config
+
+
+def test_load_config_default():
+    """Test that load_config returns a ServerConfig with defaults when no env/YAML is present."""
+    with patch.dict(os.environ, {}, clear=True):
+        config = load_config()
+        assert isinstance(config, ServerConfig)
+        assert config.name == "Open Stocks MCP"
+        assert config.log_level == "INFO"
+        assert config.monitoring_enabled is True
+
+def test_load_config_env_override():
+    """Test that environment variables still override defaults."""
+    with patch.dict(os.environ, {"MCP_SERVER_NAME": "Custom Server", "LOG_LEVEL": "DEBUG"}, clear=True):
+        config = load_config()
+        assert config.name == "Custom Server"
+        assert config.log_level == "DEBUG"
+
+def test_load_config_yaml_file(tmp_path):
+    """Test loading configuration from a YAML file via OPEN_STOCKS_CONFIG."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    config_file = config_dir / "config.yaml"
+    
+    config_data = {
+        "name": "YAML Server",
+        "log_level": "WARNING",
+        "monitoring_enabled": False,
+        "cache": {
+            "enabled": False,
+            "max_size": 500
+        }
+    }
+    
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+        
+    with patch.dict(os.environ, {"OPEN_STOCKS_CONFIG": str(config_file)}, clear=True):
+        config = load_config()
+        assert config.name == "YAML Server"
+        assert config.log_level == "WARNING"
+        assert config.monitoring_enabled is False
+        assert config.cache.enabled is False
+        assert config.cache.max_size == 500
+
+def test_load_config_yaml_file_alternate_env(tmp_path):
+    """Test loading configuration from a YAML file via OPEN_STOCKS_CONFIG_FILE."""
+    config_file = tmp_path / "alternate.yaml"
+    
+    config_data = {"name": "Alternate YAML"}
+    
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+        
+    with patch.dict(os.environ, {"OPEN_STOCKS_CONFIG_FILE": str(config_file)}, clear=True):
+        config = load_config()
+        assert config.name == "Alternate YAML"
+
+def test_load_config_yaml_with_env_fallback(tmp_path):
+    """Test that environment variables override YAML values (Standard precedence)."""
+    config_file = tmp_path / "config.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump({"name": "YAML Name", "log_level": "INFO"}, f)
+        
+    with patch.dict(os.environ, {
+        "OPEN_STOCKS_CONFIG": str(config_file),
+        "MCP_SERVER_NAME": "Env Name"
+    }, clear=True):
+        config = load_config()
+        assert config.name == "Env Name"  # Env overrides YAML
+        assert config.log_level == "INFO" # YAML value preserved
+
+def test_load_config_invalid_yaml(tmp_path):
+    """Test that invalid YAML raises ValueError."""
+    config_file = tmp_path / "invalid.yaml"
+    with open(config_file, "w") as f:
+        f.write("invalid: yaml: : :")
+        
+    with patch.dict(os.environ, {"OPEN_STOCKS_CONFIG": str(config_file)}, clear=True):
+        with pytest.raises(ValueError) as excinfo:
+            load_config()
+        assert "invalid" in str(excinfo.value).lower()
+        assert str(config_file) in str(excinfo.value)
+
+def test_load_config_schema_validation(tmp_path):
+    """Test that invalid field types in YAML raise ValueError."""
+    config_file = tmp_path / "bad_schema.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump({"cache": {"max_size": "not-an-int"}}, f)
+        
+    with patch.dict(os.environ, {"OPEN_STOCKS_CONFIG": str(config_file)}, clear=True):
+        with pytest.raises(ValueError) as excinfo:
+            load_config()
+        assert "cache" in str(excinfo.value).lower()
+
+def test_norway_problem(tmp_path):
+    """Exercise StrictBool against YAML 1.1's ``no``/``off`` boolean coercion.
+
+    PyYAML parses bareword ``no`` and ``off`` as ``False``; this asserts the
+    parsed False reaches the flag (rather than being silently dropped).
+    Uses ``robinhood`` because its default is True, so a False resolution is
+    a real signal that the YAML value won.
+    """
+    config_file = tmp_path / "norway.yaml"
+    with open(config_file, "w") as f:
+        f.write("feature_flags:\n  robinhood: no\n")
+
+    with patch.dict(os.environ, {"OPEN_STOCKS_CONFIG": str(config_file)}, clear=True):
+        config = load_config()
+        assert config.is_feature_enabled("robinhood") is False
+
+def test_feature_flags_defaults(tmp_path):
+    """Test that unknown flags resolve to False."""
+    with patch.dict(os.environ, {}, clear=True):
+        config = load_config()
+        assert config.is_feature_enabled("non_existent_flag") is False
+
+def test_feature_flags_environment_override(tmp_path):
+    """Test environment-specific feature flag overrides."""
+    config_file = tmp_path / "flags.yaml"
+    config_data = {
+        "environment": "production",
+        "feature_flags": {
+            "robinhood": True,
+            "schwab": False,
+            "environments": {
+                "development": {
+                    "schwab": True
+                }
+            }
+        }
+    }
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+        
+    # Test production (default)
+    with patch.dict(os.environ, {"OPEN_STOCKS_CONFIG": str(config_file)}, clear=True):
+        config = load_config()
+        assert config.is_feature_enabled("robinhood") is True
+        assert config.is_feature_enabled("schwab") is False
+        
+    # Test development override
+    with patch.dict(os.environ, {
+        "OPEN_STOCKS_CONFIG": str(config_file),
+        "OPEN_STOCKS_ENV": "development"
+    }, clear=True):
+        config = load_config()
+        assert config.is_feature_enabled("robinhood") is True
+        assert config.is_feature_enabled("schwab") is True

--- a/uv.lock
+++ b/uv.lock
@@ -1743,6 +1743,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "robin-stocks" },
     { name = "schwab-py" },
@@ -1783,6 +1784,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1809,6 +1811,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.15.0" },
     { name = "python-dotenv", specifier = ">=1.2.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "robin-stocks", specifier = ">=3.4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.0" },
@@ -1830,6 +1833,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.15.0" },
     { name = "ruff", specifier = ">=0.14.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 
 [[package]]
@@ -3003,6 +3007,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #157

## Changes
- Replaced dataclass-based configuration with Pydantic v2 models in `src/open_stocks_mcp/config.py`.
- Added support for loading configuration from YAML files via `OPEN_STOCKS_CONFIG` or `OPEN_STOCKS_CONFIG_FILE`.
- Implemented environment-specific feature flags with safe defaults.
- Updated `src/open_stocks_mcp/server/app.py` to gate broker registration (Robinhood, Schwab) via feature flags.
- Updated `README.md` and `CLAUDE.md` with configuration guidance.
- Added comprehensive unit tests for YAML loading, validation, and feature flag resolution.
- Added server integration tests for feature-gated startup.

## Test plan
- Run unit tests: `uv run pytest tests/unit/test_config.py`
- Run server startup tests: `uv run pytest tests/server/test_server_app.py -k TestBrokerSetup`
- Verify with `ruff` and `mypy`.