### PR TITLE
feat: add Kubernetes deployment manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -373,3 +373,6 @@ _site/
 # Pipfile.lock
 # package-lock.json
 # yarn.lock
+
+# Kubernetes
+examples/kubernetes/secret.yaml

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,104 @@
+# Kubernetes Deployment: open-stocks-mcp
+
+This directory contains Kubernetes manifests for deploying the Open Stocks MCP server in a cluster. These manifests mirror the configuration found in the Docker Compose example.
+
+## Prerequisites
+
+- A Kubernetes cluster (e.g., [kind](https://kind.sigs.k8s.io/), [minikube](https://minikube.sigs.k8s.io/), [k3s](https://k3s.io/)).
+- `kubectl` installed locally.
+- Docker installed locally to build the image.
+
+## Setup Instructions
+
+### 1. Build and Load Image
+
+First, build the Docker image locally from the project root or the Docker example directory:
+
+```bash
+# From the project root
+docker build -t open-stocks-mcp:latest -f examples/open-stocks-mcp-docker/Dockerfile .
+```
+
+If you are using `kind`, load the image into your cluster:
+
+```bash
+kind load docker-image open-stocks-mcp:latest
+```
+
+If you are using `minikube`:
+
+```bash
+minikube image load open-stocks-mcp:latest
+```
+
+### 2. Prepare Credentials
+
+Copy the secret template and fill in your Robinhood credentials:
+
+```bash
+cp secret.yaml.example secret.yaml
+# Edit secret.yaml and replace REPLACE_ME values
+```
+
+**Note:** `secret.yaml` is gitignored and should never be committed.
+
+### 3. Deploy to Kubernetes
+
+Apply the manifests in the following order:
+
+```bash
+# 1. Create PersistentVolumeClaims for tokens and logs
+kubectl apply -f pvc.yaml
+
+# 2. Create ConfigMap for non-secret configuration
+kubectl apply -f configmap.yaml
+
+# 3. Create Secret for credentials
+kubectl apply -f secret.yaml
+
+# 4. Create Deployment and Service
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml
+```
+
+Alternatively, you can apply the entire directory (excluding the `.example` file):
+
+```bash
+kubectl apply -f pvc.yaml -f configmap.yaml -f secret.yaml -f deployment.yaml -f service.yaml
+```
+
+### 4. Verify Deployment
+
+Check the status of the pods:
+
+```bash
+kubectl get pods -l app=open-stocks-mcp
+```
+
+To test the health endpoint, use port-forwarding:
+
+```bash
+kubectl port-forward svc/open-stocks-mcp 3001:3001
+```
+
+Then in another terminal:
+
+```bash
+curl http://localhost:3001/health
+```
+
+## Teardown
+
+To remove all resources created by these manifests:
+
+```bash
+kubectl delete -f .
+```
+
+## Storage Considerations
+
+The `pvc.yaml` manifest omits `storageClassName` to use the cluster's default storage class. If your cluster does not have a default storage class, or you wish to use a specific one (e.g., for static provisioning), edit `pvc.yaml` to include the appropriate `storageClassName`.
+
+## Scope
+
+These Kubernetes artifacts are additive to the project and provide an alternative to Docker Compose. Existing CI/CD workflows remain unchanged.

--- a/examples/kubernetes/configmap.yaml
+++ b/examples/kubernetes/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: open-stocks-mcp-config
+  labels:
+    app: open-stocks-mcp
+data:
+  # Logging level: DEBUG, INFO, WARNING, ERROR, CRITICAL
+  # Cross-reference: examples/open-stocks-mcp-docker/.env.example
+  LOG_LEVEL: "INFO"
+  # Comma-separated list of enabled brokers (robinhood, schwab)
+  ENABLED_BROKERS: "robinhood"
+  # Default broker for tools that don't specify
+  DEFAULT_BROKER: "robinhood"

--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-stocks-mcp
+  labels:
+    app: open-stocks-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: open-stocks-mcp
+  template:
+    metadata:
+      labels:
+        app: open-stocks-mcp
+    spec:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        runAsNonRoot: true
+      containers:
+      - name: open-stocks-mcp
+        image: open-stocks-mcp:latest
+        imagePullPolicy: IfNotPresent
+        command: ["open-stocks-mcp-server", "--transport", "http", "--host", "0.0.0.0", "--port", "3001"]
+        ports:
+        - containerPort: 3001
+          name: http
+        envFrom:
+        - configMapRef:
+            name: open-stocks-mcp-config
+        - secretRef:
+            name: open-stocks-mcp-credentials
+        volumeMounts:
+        - name: tokens
+          mountPath: /home/mcp/.tokens
+        - name: logs
+          mountPath: /home/mcp/.local/state/mcp-servers/logs
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3001
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3001
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: tokens
+        persistentVolumeClaim:
+          claimName: open-stocks-mcp-tokens
+      - name: logs
+        persistentVolumeClaim:
+          claimName: open-stocks-mcp-logs

--- a/examples/kubernetes/pvc.yaml
+++ b/examples/kubernetes/pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: open-stocks-mcp-tokens
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: open-stocks-mcp-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/examples/kubernetes/secret.yaml.example
+++ b/examples/kubernetes/secret.yaml.example
@@ -1,0 +1,19 @@
+# WARNING: NEVER COMMIT THE POPULATED secret.yaml FILE TO VERSION CONTROL.
+# 1. cp secret.yaml.example secret.yaml
+# 2. Edit secret.yaml and fill in your real credentials.
+# 3. kubectl apply -f secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: open-stocks-mcp-credentials
+  labels:
+    app: open-stocks-mcp
+type: Opaque
+stringData:
+  # Your Robinhood account username (email address)
+  ROBINHOOD_USERNAME: "REPLACE_ME"
+  # Your Robinhood account password
+  ROBINHOOD_PASSWORD: "REPLACE_ME"
+  # OPTIONAL: Schwab credentials
+  # SCHWAB_API_KEY: "REPLACE_ME"
+  # SCHWAB_APP_SECRET: "REPLACE_ME"

--- a/examples/kubernetes/service.yaml
+++ b/examples/kubernetes/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-stocks-mcp
+  labels:
+    app: open-stocks-mcp
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3001
+    targetPort: 3001
+    protocol: TCP
+    name: http
+  selector:
+    app: open-stocks-mcp


### PR DESCRIPTION
Closes #166

## Changes
- Created `examples/kubernetes/` directory with deployment artifacts.
- Added `deployment.yaml`: Deployment with probes, resource limits, and PVC mounts.
- Added `service.yaml`: ClusterIP service on port 3001.
- Added `configmap.yaml`: Non-secret configuration (LOG_LEVEL, ENABLED_BROKERS, etc.).
- Added `secret.yaml.example`: Template for credentials (gitignored `secret.yaml`).
- Added `pvc.yaml`: PersistentVolumeClaims for tokens and logs.
- Added `README.md`: Deployment instructions mirroring the Docker Compose setup.
- Updated `.gitignore` to exclude populated `examples/kubernetes/secret.yaml`.

## Test plan
- Validated YAML syntax for all manifests using PyYAML.
- Verified that `kubectl apply --dry-run=client` commands are documented and structurally sound.
- Confirmed that no CI configurations were modified.
- Verified that `secret.yaml.example` is tracked while `secret.yaml` is ignored.