### PR TITLE
feat: align circuit breaker recovery timeout config

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -128,7 +128,12 @@ class CircuitBreakerConfig:
 
     enabled: bool = True
     failure_threshold: int = 5
-    cooldown_seconds: float = 60.0
+    recovery_timeout_seconds: float = 60.0
+
+    @property
+    def cooldown_seconds(self) -> float:
+        """Backward-compatible alias for recovery timeout."""
+        return self.recovery_timeout_seconds
 
 
 @dataclass
@@ -222,8 +227,12 @@ def load_config() -> ServerConfig:
             failure_threshold=_env_int(
                 "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5
             ),
-            cooldown_seconds=_env_float(
-                "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_COOLDOWN_SECONDS", 60.0
+            recovery_timeout_seconds=_env_float_from(
+                (
+                    "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS",
+                    "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_COOLDOWN_SECONDS",
+                ),
+                60.0,
             ),
         ),
         broker_requests=BrokerRequestConfig(
@@ -235,7 +244,9 @@ def load_config() -> ServerConfig:
             ),
             retry_max_retries=_env_int("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", 3),
             retry_initial_delay=_env_float("OPEN_STOCKS_MCP_RETRY_INITIAL_DELAY", 1.0),
-            retry_backoff_factor=_env_float("OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR", 2.0),
+            retry_backoff_factor=_env_float(
+                "OPEN_STOCKS_MCP_RETRY_BACKOFF_FACTOR", 2.0
+            ),
             total_deadline_seconds=_env_float(
                 "OPEN_STOCKS_MCP_BROKER_REQUEST_TOTAL_DEADLINE_SECONDS", 45.0
             )

--- a/src/open_stocks_mcp/tools/circuit_breaker.py
+++ b/src/open_stocks_mcp/tools/circuit_breaker.py
@@ -17,7 +17,12 @@ class CircuitBreakerConfig:
 
     enabled: bool = True
     failure_threshold: int = 5
-    cooldown_seconds: float = 60.0
+    recovery_timeout_seconds: float = 60.0
+
+    @property
+    def cooldown_seconds(self) -> float:
+        """Backward-compatible alias for recovery timeout."""
+        return self.recovery_timeout_seconds
 
 
 class BrokerCircuitBreaker:
@@ -99,6 +104,7 @@ class BrokerCircuitBreaker:
             "state": self._state,
             "failure_count": self._failure_count,
             "failure_threshold": self._config.failure_threshold,
+            "recovery_timeout_seconds": self._config.recovery_timeout_seconds,
             "cooldown_seconds": self._config.cooldown_seconds,
             "opened_at": self._opened_at,
             "next_retry_at": self._next_retry_at,
@@ -127,7 +133,7 @@ def get_broker_circuit_breaker() -> BrokerCircuitBreaker:
             CircuitBreakerConfig(
                 enabled=cfg.enabled,
                 failure_threshold=cfg.failure_threshold,
-                cooldown_seconds=cfg.cooldown_seconds,
+                recovery_timeout_seconds=cfg.recovery_timeout_seconds,
             )
         )
     return _breaker

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from open_stocks_mcp.config import load_config, reset_cache_config
 from open_stocks_mcp.tools.circuit_breaker import (
     BrokerCircuitBreaker,
     CircuitBreakerConfig,
@@ -18,7 +19,9 @@ from open_stocks_mcp.tools.exceptions import NetworkError
 async def test_breaker_trips_after_threshold_and_blocks() -> None:
     state = {"mono": 100.0, "wall": 1_000.0}
     breaker = BrokerCircuitBreaker(
-        CircuitBreakerConfig(enabled=True, failure_threshold=2, cooldown_seconds=5.0),
+        CircuitBreakerConfig(
+            enabled=True, failure_threshold=2, recovery_timeout_seconds=5.0
+        ),
         monotonic_fn=lambda: state["mono"],
         time_fn=lambda: state["wall"],
     )
@@ -41,7 +44,9 @@ async def test_breaker_trips_after_threshold_and_blocks() -> None:
 async def test_half_open_probe_success_resets() -> None:
     state = {"mono": 100.0, "wall": 1_000.0}
     breaker = BrokerCircuitBreaker(
-        CircuitBreakerConfig(enabled=True, failure_threshold=1, cooldown_seconds=5.0),
+        CircuitBreakerConfig(
+            enabled=True, failure_threshold=1, recovery_timeout_seconds=5.0
+        ),
         monotonic_fn=lambda: state["mono"],
         time_fn=lambda: state["wall"],
     )
@@ -59,7 +64,9 @@ async def test_half_open_probe_success_resets() -> None:
 async def test_half_open_probe_failure_reopens() -> None:
     state = {"mono": 100.0, "wall": 1_000.0}
     breaker = BrokerCircuitBreaker(
-        CircuitBreakerConfig(enabled=True, failure_threshold=1, cooldown_seconds=5.0),
+        CircuitBreakerConfig(
+            enabled=True, failure_threshold=1, recovery_timeout_seconds=5.0
+        ),
         monotonic_fn=lambda: state["mono"],
         time_fn=lambda: state["wall"],
     )
@@ -75,7 +82,9 @@ async def test_half_open_probe_failure_reopens() -> None:
 @pytest.mark.asyncio
 async def test_disabled_breaker_never_blocks() -> None:
     breaker = BrokerCircuitBreaker(
-        CircuitBreakerConfig(enabled=False, failure_threshold=1, cooldown_seconds=1.0)
+        CircuitBreakerConfig(
+            enabled=False, failure_threshold=1, recovery_timeout_seconds=1.0
+        )
     )
     await breaker.before_request()
     await breaker.record_failure("network")
@@ -94,7 +103,9 @@ async def test_execute_with_retry_records_failures_and_blocks_fast() -> None:
         raise RuntimeError("connection timeout")
 
     shared_breaker = BrokerCircuitBreaker(
-        CircuitBreakerConfig(enabled=True, failure_threshold=1, cooldown_seconds=60.0),
+        CircuitBreakerConfig(
+            enabled=True, failure_threshold=1, recovery_timeout_seconds=60.0
+        ),
         monotonic_fn=lambda: 10.0,
         time_fn=lambda: 100.0,
     )
@@ -126,3 +137,29 @@ async def test_execute_with_retry_records_failures_and_blocks_fast() -> None:
         pytest.raises(CircuitBreakerError),
     ):
         await execute_with_retry(always_fail, max_retries=0)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_includes_recovery_timeout_seconds() -> None:
+    breaker = BrokerCircuitBreaker(
+        CircuitBreakerConfig(
+            enabled=True, failure_threshold=1, recovery_timeout_seconds=12.5
+        )
+    )
+    snap = breaker.snapshot()
+    assert snap["recovery_timeout_seconds"] == 12.5
+    assert snap["cooldown_seconds"] == 12.5
+
+
+def test_load_config_reads_recovery_timeout_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPEN_STOCKS_MCP_CIRCUIT_BREAKER_FAILURE_THRESHOLD", "2")
+    monkeypatch.setenv(
+        "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS", "0.25"
+    )
+    reset_cache_config()
+    cfg = load_config()
+    assert cfg.circuit_breaker.failure_threshold == 2
+    assert cfg.circuit_breaker.recovery_timeout_seconds == 0.25
+    assert cfg.circuit_breaker.cooldown_seconds == 0.25


### PR DESCRIPTION
Closes #167

## Changes
- add canonical  to circuit-breaker config with  compatibility alias
- support  env var, with fallback to existing cooldown env var
- expose both timeout keys in circuit-breaker snapshot payload for backward compatibility
- extend unit tests for config/env parsing and snapshot compatibility

## Test plan
- uv run pytest tests/unit/test_circuit_breaker.py -q
- uv run pytest tests/unit/test_stock_market_tools.py -q -k health_check
- uv run pytest tests/http_transport/test_http_server.py -q -k health_check
- uv run pytest tests/unit/test_circuit_breaker.py tests/unit/test_stock_market_tools.py tests/http_transport/test_http_server.py -q -k 'circuit_breaker or health_check'
- uv run ruff check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/circuit_breaker.py tests/unit/test_circuit_breaker.py
- uv run ruff format --check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/circuit_breaker.py tests/unit/test_circuit_breaker.py
- uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/circuit_breaker.py