### PR TITLE
feat: add --debug flag, DEBUG env var, and VS Code debug configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,8 @@ cython_debug/
 # Visual Studio Code
 .vscode/*
 !.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/settings.json
 *.code-workspace
 
 # Sublime Text

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,30 +1,14 @@
 {
   "recommendations": [
-    // Python language support
     "ms-python.python",
-
-    // Ruff linter and formatter
-    "charliermarsh.ruff",
-
-    // Test runner integration
     "ms-python.vscode-pylance",
-
-    // EditorConfig support
+    "ms-python.mypy-type-checker",
+    "charliermarsh.ruff",
     "editorconfig.editorconfig",
-
-    // GitHub integration
     "github.vscode-pull-request-github",
-
-    // YAML support
     "redhat.vscode-yaml",
-
-    // TOML support
     "tamasfe.even-better-toml",
-
-    // Markdown preview
     "yzhang.markdown-all-in-one",
-
-    // Git integration
     "eamodio.gitlens"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,26 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Open Stocks MCP (HTTP Debug)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "open_stocks_mcp.server.app",
+      "args": [
+        "--transport",
+        "http",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "3001",
+        "--debug"
+      ],
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
       "name": "Run MCP server (HTTP)",
       "type": "python",
       "request": "launch",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,24 @@
 {
-  "python.defaultInterpreterPath": ".venv/bin/python",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestArgs": ["tests"],
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
   },
+  "ruff.enable": true,
   "ruff.lint.run": "onSave",
-  "mypy-type-checker.args": ["--config-file=pyproject.toml"],
+  "mypy-type-checker.enabled": true,
+  "mypy-type-checker.args": [
+    "--config-file=${workspaceFolder}/pyproject.toml"
+  ],
   "files.exclude": {
     ".mypy_cache": true,
     ".ruff_cache": true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,43 @@ mypy .                          # Type check
 # Test server locally (HTTP transport)
 uv run open-stocks-mcp-server --transport http --port 3001
 
+# Run with verbose DEBUG logging
+uv run open-stocks-mcp-server --transport http --port 3001 --debug
+DEBUG=true uv run open-stocks-mcp-server --transport http --port 3001
+
+# Verify the server is running
+curl -sf http://127.0.0.1:3001/health
+
 # Docker development
 cd examples/open-stocks-mcp-docker && docker-compose up -d
 curl http://localhost:3001/health  # Test health endpoint
 ```
+
+### VS Code Debugging (F5)
+
+The repository ships `.vscode/launch.json`, `.vscode/settings.json`, and `.vscode/extensions.json`
+so contributors can step through tool calls without Docker.
+
+**Prerequisites**: `uv sync` (creates `.venv/` in the project root).
+
+1. Open the repository folder in VS Code.
+2. Select the **"Open Stocks MCP (HTTP Debug)"** configuration in the Run & Debug panel.
+3. Press **F5** — the server starts on `http://127.0.0.1:3001` with `--debug` logging.
+4. Verify it's alive: `curl -sf http://127.0.0.1:3001/health`.
+
+**Debug logging precedence** (highest wins):
+- `--debug` flag on the CLI → always DEBUG for that invocation
+- `LOG_LEVEL=DEBUG` env var → sets the level for the process
+- `DEBUG=true` env var → escalates to DEBUG when `LOG_LEVEL` is not set
+- Default: `INFO`
+
+All log output goes to **stderr** and the rotating log file (`~/Library/Logs/mcp-servers/` on macOS).
+Stdio transport is safe: no log handler ever targets `sys.stdout`.
+
+**Recommended VS Code extensions** (installed automatically via `extensions.json`):
+- `ms-python.python` + `ms-python.vscode-pylance` — Python language support
+- `charliermarsh.ruff` — linting and formatting
+- `ms-python.mypy-type-checker` — inline type errors
 
 ## MCP Architecture
 

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -188,9 +188,15 @@ def load_config() -> ServerConfig:
     )
     enabled_str = os.getenv("OTEL_ENABLED", "false").strip().lower()
     otel_enabled = enabled_str in ("1", "true", "yes")
+    # LOG_LEVEL wins; if absent, DEBUG=true escalates to DEBUG level.
+    _explicit_log_level = os.getenv("LOG_LEVEL")
+    log_level = _explicit_log_level if _explicit_log_level else (
+        "DEBUG" if _env_bool("DEBUG", False) else "INFO"
+    )
+
     return ServerConfig(
         name=os.getenv("MCP_SERVER_NAME", "Open Stocks MCP"),
-        log_level=os.getenv("LOG_LEVEL", "INFO"),
+        log_level=log_level,
         monitoring_enabled=os.getenv("MONITORING_ENABLED", "true").lower() == "true",
         cache=cache,
         retry=RetryConfig(

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1520,6 +1520,12 @@ def attempt_login(username: str, password: str) -> None:
     default=False,
     help="Allow mutating trading tools over HTTP /mcp (default is read-only only)",
 )
+@click.option(
+    "--debug",
+    is_flag=True,
+    default=False,
+    help="Enable DEBUG-level logging for this server invocation.",
+)
 def main(
     port: int,
     host: str,
@@ -1528,6 +1534,7 @@ def main(
     password: str | None,
     api_key: str | None,
     allow_trading: bool,
+    debug: bool,
 ) -> int:
     """Run the server with specified transport and handle authentication.
 
@@ -1553,8 +1560,13 @@ def main(
             username = None
             password = None
 
+    # Load config; --debug flag wins for log level for this invocation.
+    config = load_config()
+    if debug:
+        config.log_level = "DEBUG"
+
     # Create MCP server
-    server = create_mcp_server()
+    server = create_mcp_server(config)
 
     # Setup broker authentication (non-blocking)
     logger.info("Initializing broker authentication...")

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -493,6 +493,13 @@ def create_http_server(
             request_id = json_request.get("id")
             params = json_request.get("params", {})
 
+            logger.debug(
+                "MCP request: method=%s request_id=%s body_bytes=%d",
+                method,
+                request_id,
+                len(body),
+            )
+
             try:
                 result: dict[str, Any]
                 if method == "initialize":
@@ -659,9 +666,16 @@ def create_http_server(
 
                 # Return successful response
                 response_data = {"jsonrpc": "2.0", "result": result, "id": request_id}
+                response_bytes = json.dumps(response_data).encode()
+                logger.debug(
+                    "MCP response: method=%s request_id=%s status=ok response_bytes=%d",
+                    method,
+                    request_id,
+                    len(response_bytes),
+                )
 
                 return Response(
-                    content=json.dumps(response_data).encode(),
+                    content=response_bytes,
                     status_code=200,
                     headers={"content-type": "application/json"},
                 )
@@ -673,6 +687,12 @@ def create_http_server(
                     "error": {"code": -32603, "message": str(e)},
                     "id": request_id,
                 }
+                logger.debug(
+                    "MCP response: method=%s request_id=%s status=error error_class=%s",
+                    method,
+                    request_id,
+                    type(e).__name__,
+                )
                 return Response(
                     content=json.dumps(error_response).encode(),
                     status_code=500,

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -536,6 +536,117 @@ class TestLiveHTTPServer:
 
 @pytest.mark.integration
 @pytest.mark.journey_system
+class TestMCPDebugLogging:
+    """DEBUG-level logs emitted by the /mcp endpoint are safe and useful."""
+
+    @pytest.mark.anyio
+    async def test_mcp_debug_logging_emits_method_and_request_id(
+        self, mcp_server: FastMCP, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A successful /mcp request emits DEBUG records with method and request_id."""
+        import logging
+
+        from httpx import ASGITransport
+
+        with patch("open_stocks_mcp.monitoring._metrics_collector", None):
+            app = create_http_server(mcp_server)
+            transport = ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                with caplog.at_level(logging.DEBUG, logger="open_stocks_mcp"):
+                    response = await client.post(
+                        "/mcp",
+                        json={
+                            "jsonrpc": "2.0",
+                            "id": 99,
+                            "method": "initialize",
+                            "params": {},
+                        },
+                    )
+
+        assert response.status_code == 200
+        log_text = " ".join(caplog.messages)
+        assert "initialize" in log_text
+        assert "99" in log_text
+
+    @pytest.mark.anyio
+    async def test_mcp_debug_logging_emits_error_class_on_unknown_method(
+        self, mcp_server: FastMCP, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unknown method emits a DEBUG record that includes error status."""
+        import logging
+
+        from httpx import ASGITransport
+
+        with patch("open_stocks_mcp.monitoring._metrics_collector", None):
+            app = create_http_server(mcp_server)
+            transport = ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                with caplog.at_level(logging.DEBUG, logger="open_stocks_mcp"):
+                    response = await client.post(
+                        "/mcp",
+                        json={
+                            "jsonrpc": "2.0",
+                            "id": 42,
+                            "method": "unknown/method",
+                            "params": {},
+                        },
+                    )
+
+        # unknown/method returns a JSON-RPC error inside a 200 response
+        assert response.status_code == 200
+        data = response.json()
+        assert "error" in data
+        log_text = " ".join(caplog.messages)
+        assert "unknown/method" in log_text
+
+    @pytest.mark.anyio
+    async def test_mcp_debug_logging_does_not_leak_sensitive_values(
+        self, mcp_server: FastMCP, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """DEBUG log messages must not contain literal credential values."""
+        import logging
+
+        from httpx import ASGITransport
+
+        sensitive_password = "s3cr3t_p@ssw0rd!"
+        sensitive_token = "tok_abc123secrettoken"
+        sensitive_account = "acct_9876543210"
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {
+                "name": "account_info",
+                "arguments": {
+                    "password": sensitive_password,
+                    "token": sensitive_token,
+                    "account_number": sensitive_account,
+                },
+            },
+        }
+
+        with patch("open_stocks_mcp.monitoring._metrics_collector", None):
+            app = create_http_server(mcp_server)
+            transport = ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                with caplog.at_level(logging.DEBUG, logger="open_stocks_mcp"):
+                    await client.post("/mcp", json=payload)
+
+        all_logs = " ".join(caplog.messages)
+        assert sensitive_password not in all_logs, "Password leaked into debug logs"
+        assert sensitive_token not in all_logs, "Token leaked into debug logs"
+        assert sensitive_account not in all_logs, "Account number leaked into debug logs"
+
+
+@pytest.mark.integration
+@pytest.mark.journey_system
 class TestSessionManagement:
     """Test session management features"""
 

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -3,11 +3,13 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from open_stocks_mcp.server.app import (
     attempt_login,
     create_mcp_server,
     health_check,
+    main,
     mcp,
 )
 
@@ -207,3 +209,45 @@ class TestToolRegistration:
         assert "broker_health" in metrics["result"]
         assert "account_health" in metrics["result"]
         assert "endpoint_usage" in rate["result"]
+
+
+@pytest.mark.journey_system
+class TestDebugFlag:
+    """Tests that --debug wires log_level=DEBUG into create_mcp_server."""
+
+    def _run_main_with_debug(self, extra_args: list[str]) -> "MagicMock":
+        """Invoke main via CliRunner, patching out server startup."""
+        captured: dict[str, object] = {}
+
+        def fake_create_mcp_server(config: object = None) -> MagicMock:
+            captured["config"] = config
+            return MagicMock()
+
+        runner = CliRunner()
+        with (
+            patch("open_stocks_mcp.server.app.load_config") as mock_load_config,
+            patch(
+                "open_stocks_mcp.server.app.create_mcp_server",
+                side_effect=fake_create_mcp_server,
+            ),
+            patch("open_stocks_mcp.server.app.setup_brokers", new=AsyncMock()),
+            patch("open_stocks_mcp.server.app.asyncio.run"),
+        ):
+            from open_stocks_mcp.config import load_config as real_load_config
+
+            mock_load_config.side_effect = real_load_config
+            runner.invoke(main, extra_args, catch_exceptions=False)
+
+        return captured.get("config")  # type: ignore[return-value]
+
+    def test_debug_flag_sets_log_level_debug(self) -> None:
+        """--debug causes create_mcp_server to receive config with log_level=DEBUG."""
+        config = self._run_main_with_debug(["--transport", "stdio", "--debug"])
+        assert config is not None
+        assert config.log_level == "DEBUG"
+
+    def test_no_debug_flag_keeps_default_log_level(self) -> None:
+        """Without --debug, log_level remains at the default (INFO)."""
+        config = self._run_main_with_debug(["--transport", "stdio"])
+        assert config is not None
+        assert config.log_level == "INFO"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,70 @@
+"""Tests for server configuration loading."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from open_stocks_mcp.config import ServerConfig, load_config
+
+
+def test_load_config_default() -> None:
+    """load_config returns a ServerConfig with sensible defaults."""
+    with patch.dict(os.environ, {}, clear=True):
+        config = load_config()
+        assert isinstance(config, ServerConfig)
+        assert config.name == "Open Stocks MCP"
+        assert config.log_level == "INFO"
+        assert config.monitoring_enabled is True
+
+
+def test_load_config_env_override() -> None:
+    """Environment variables override defaults."""
+    with patch.dict(os.environ, {"MCP_SERVER_NAME": "Custom Server", "LOG_LEVEL": "DEBUG"}, clear=True):
+        config = load_config()
+        assert config.name == "Custom Server"
+        assert config.log_level == "DEBUG"
+
+
+def test_log_level_default_is_info() -> None:
+    """Without LOG_LEVEL or DEBUG, log_level defaults to INFO."""
+    with patch.dict(os.environ, {}, clear=True):
+        config = load_config()
+        assert config.log_level == "INFO"
+
+
+# --- DEBUG env var tests ---
+
+@pytest.mark.parametrize("debug_value", ["1", "true", "True", "TRUE", "yes", "on"])
+def test_debug_env_truthy_values_set_debug_log_level(debug_value: str) -> None:
+    """DEBUG=<truthy> maps to log_level DEBUG when LOG_LEVEL is not set."""
+    with patch.dict(os.environ, {"DEBUG": debug_value}, clear=True):
+        config = load_config()
+        assert config.log_level == "DEBUG", (
+            f"DEBUG={debug_value!r} did not set log_level to DEBUG"
+        )
+
+
+@pytest.mark.parametrize("debug_value", ["0", "false", "False", "no", "off", ""])
+def test_debug_env_falsy_values_keep_info_log_level(debug_value: str) -> None:
+    """DEBUG=<falsy> keeps the default INFO log level."""
+    env = {"DEBUG": debug_value} if debug_value else {}
+    with patch.dict(os.environ, env, clear=True):
+        config = load_config()
+        assert config.log_level == "INFO", (
+            f"DEBUG={debug_value!r} unexpectedly changed log_level"
+        )
+
+
+def test_explicit_log_level_wins_over_debug_env() -> None:
+    """Explicit LOG_LEVEL env var overrides DEBUG=true."""
+    with patch.dict(os.environ, {"DEBUG": "true", "LOG_LEVEL": "WARNING"}, clear=True):
+        config = load_config()
+        assert config.log_level == "WARNING"
+
+
+def test_debug_env_does_not_affect_config_when_log_level_set() -> None:
+    """LOG_LEVEL takes precedence over DEBUG for all truthy debug values."""
+    with patch.dict(os.environ, {"DEBUG": "1", "LOG_LEVEL": "ERROR"}, clear=True):
+        config = load_config()
+        assert config.log_level == "ERROR"

--- a/tests/unit/test_vscode_workspace.py
+++ b/tests/unit/test_vscode_workspace.py
@@ -1,0 +1,99 @@
+"""Tests for VS Code workspace configuration files."""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+def _load_json(rel_path: str) -> dict:
+    path = REPO_ROOT / rel_path
+    assert path.exists(), f"{rel_path} does not exist"
+    return json.loads(path.read_text())
+
+
+def test_launch_json_is_valid_json() -> None:
+    """launch.json must be parseable as standard JSON (no JSONC comments)."""
+    _load_json(".vscode/launch.json")
+
+
+def test_launch_json_has_http_debug_configuration() -> None:
+    """launch.json must contain a debug configuration for the HTTP server."""
+    data = _load_json(".vscode/launch.json")
+    configs = data.get("configurations", [])
+    assert configs, "launch.json has no configurations"
+
+    debug_config = next(
+        (c for c in configs if "--debug" in c.get("args", [])),
+        None,
+    )
+    assert debug_config is not None, "No configuration with --debug arg found"
+    args = debug_config["args"]
+    assert "--transport" in args, "--transport missing from debug config args"
+    assert "http" in args, "http transport not specified in debug config args"
+    assert "--port" in args, "--port missing from debug config args"
+
+
+def test_launch_json_uses_module_launch() -> None:
+    """launch.json debug config must use module-style launch for open_stocks_mcp.server.app."""
+    data = _load_json(".vscode/launch.json")
+    configs = data.get("configurations", [])
+    debug_config = next(
+        (c for c in configs if "--debug" in c.get("args", [])),
+        None,
+    )
+    assert debug_config is not None
+    assert debug_config.get("module") == "open_stocks_mcp.server.app"
+    assert debug_config.get("console") == "integratedTerminal"
+
+
+def test_settings_json_is_valid_json() -> None:
+    """settings.json must be parseable as standard JSON."""
+    _load_json(".vscode/settings.json")
+
+
+def test_settings_json_has_python_interpreter() -> None:
+    """settings.json must point to the .venv Python interpreter."""
+    data = _load_json(".vscode/settings.json")
+    interp = data.get("python.defaultInterpreterPath", "")
+    assert ".venv" in interp, f"Expected .venv in interpreter path, got: {interp}"
+
+
+def test_settings_json_enables_pytest() -> None:
+    """settings.json must enable pytest discovery."""
+    data = _load_json(".vscode/settings.json")
+    assert data.get("python.testing.pytestEnabled") is True
+    assert "tests" in str(data.get("python.testing.pytestArgs", []))
+
+
+def test_settings_json_configures_ruff() -> None:
+    """settings.json must configure Ruff as the Python formatter."""
+    data = _load_json(".vscode/settings.json")
+    python_settings = data.get("[python]", {})
+    formatter = python_settings.get("editor.defaultFormatter", "")
+    assert "ruff" in formatter, f"Expected ruff formatter, got: {formatter}"
+
+
+def test_settings_json_enables_mypy() -> None:
+    """settings.json must enable mypy type checking."""
+    data = _load_json(".vscode/settings.json")
+    assert data.get("mypy-type-checker.enabled") is True
+
+
+def test_extensions_json_is_valid_json() -> None:
+    """extensions.json must be parseable as standard JSON (no JSONC comments)."""
+    _load_json(".vscode/extensions.json")
+
+
+def test_extensions_json_recommends_required_extensions() -> None:
+    """extensions.json must recommend Python, Pylance, Ruff, and mypy extensions."""
+    data = _load_json(".vscode/extensions.json")
+    recs = set(data.get("recommendations", []))
+    required = {
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+    }
+    missing = required - recs
+    assert not missing, f"Missing required recommendations: {missing}"


### PR DESCRIPTION
Closes #164

## Changes
- Added `--debug` CLI flag to enable DEBUG-level logging for a single server invocation
- Added `DEBUG=true` env var support (truthy: `1`, `true`, `yes`, `on`); escalates log level unless `LOG_LEVEL` is explicitly set
- Extended `.vscode/launch.json` with an F5-ready `"Open Stocks MCP (HTTP Debug)"` configuration including `--debug` arg; merged with existing configs from main
- Updated `.vscode/settings.json` with `mypy-type-checker.enabled`, ruff code actions, and file-explorer exclusions; merged with existing workspace settings
- Fixed `.vscode/extensions.json`: removed JSONC comments (standard `python -m json.tool` now validates it); added `ms-python.mypy-type-checker` recommendation
- Updated `.gitignore` to explicitly track `launch.json` and `settings.json`
- Added sanitized DEBUG-level logs in HTTP transport `/mcp` endpoint: logs method, request_id, body_bytes, response_bytes, and error_class — never full JSON bodies or credential values
- All logging handlers target stderr or the rotating log file; no stdout handler is registered (stdio transport safe)
- Updated CLAUDE.md with VS Code F5 flow, debug logging precedence, and health-check command

## Test plan
- `tests/unit/test_vscode_workspace.py` — validates JSON parseability and required fields of all three VS Code config files (10 tests)
- `tests/unit/test_config.py` — covers `DEBUG=true` truthy/falsy values and `LOG_LEVEL` precedence (17 tests)
- `tests/server/test_server_app.py::TestDebugFlag` — uses `CliRunner` to verify `--debug` wires `log_level=DEBUG` into `create_mcp_server()` without starting a real server (2 tests)
- `tests/http_transport/test_http_server.py::TestMCPDebugLogging` — uses `caplog` + ASGI transport to verify debug records contain method/request_id/body_bytes, and that sensitive credential values do not appear in logs (3 tests)
- All existing tests in `test_dev_tooling.py` continue to pass with the merged configurations