### PR TITLE
feat: add OpenTelemetry MCP tool-call tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ The `/metrics` endpoint exposes:
 - `open_stocks_mcp_tool_calls_per_minute` (gauge by tool)
 - `open_stocks_mcp_tool_latency_ms` (gauge by tool and quantile: `0.50`, `0.95`, `0.99`)
 
+Distributed tracing setup (OpenTelemetry, Jaeger, Tempo):
+- [docs/OPENTELEMETRY_TRACING.md](docs/OPENTELEMETRY_TRACING.md)
+
 ### Operational Circuit Breaker Defaults
 
 Broker call protection is enabled by default and reports state in MCP `health_check`,

--- a/docs/OPENTELEMETRY_TRACING.md
+++ b/docs/OPENTELEMETRY_TRACING.md
@@ -1,0 +1,47 @@
+# OpenTelemetry Tracing
+
+OpenTelemetry tracing is disabled by default. Enable it only when you want to export MCP tool-call spans to an OTLP-compatible backend.
+
+## Environment Variables
+
+- `OTEL_ENABLED` (default: `false`)
+- `OTEL_SERVICE_NAME` (default: `open-stocks-mcp`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (optional, for remote export)
+
+## Enable Tracing
+
+```bash
+export OTEL_ENABLED=true
+export OTEL_SERVICE_NAME=open-stocks-mcp
+```
+
+When enabled, each MCP `tools/call` invocation creates a span with:
+
+- `tool.name`
+- `tool.outcome` (`success` or `error`)
+- `tool.error_type` (error path only)
+
+## Jaeger (OTLP gRPC) Example
+
+Start Jaeger with OTLP enabled and point the server at it:
+
+```bash
+export OTEL_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+open-stocks-mcp-server --transport http --port 3001
+```
+
+## Grafana Tempo (OTLP gRPC) Example
+
+Use the Tempo OTLP gRPC endpoint:
+
+```bash
+export OTEL_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+open-stocks-mcp-server --transport http --port 3001
+```
+
+## Notes
+
+- If `OTEL_ENABLED` is not `true`, tracing is a no-op.
+- If no OTLP endpoint is set, spans are still created in-process but are not exported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
     "uvicorn>=0.40.0",
     "sse-starlette>=3.1.0",
     "jsonrpclib-pelix>=1.0.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp>=1.20.0",
 ]
 
 [project.optional-dependencies]
@@ -62,8 +64,6 @@ docs = [
 ]
 tracing = [
     "opentelemetry-api>=1.20.0",
-    "opentelemetry-sdk>=1.20.0",
-    "opentelemetry-exporter-otlp>=1.20.0",
 ]
 
 [project.urls]

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -170,7 +170,11 @@ from open_stocks_mcp.tools.unified_watchlist_tools import (
     get_unified_watchlists,
     remove_symbols_from_unified_watchlist,
 )
-from open_stocks_mcp.tracing import setup_tracing, trace_tool_call
+from open_stocks_mcp.tracing import (
+    instrument_mcp_tool_calls,
+    setup_tracing,
+    trace_tool_call,
+)
 
 # Load environment variables from .env file
 load_dotenv()
@@ -1315,7 +1319,9 @@ async def schwab_transactions_by_date(
 
 
 @mcp.tool()
-async def schwab_get_transaction(account_hash: str, transaction_id: str) -> dict[str, Any]:
+async def schwab_get_transaction(
+    account_hash: str, transaction_id: str
+) -> dict[str, Any]:
     """Get details for a specific Schwab transaction.
 
     Args:
@@ -1393,6 +1399,7 @@ def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:
 
     setup_logging(config)
     setup_tracing(config)
+    instrument_mcp_tool_calls(mcp)
     return mcp
 
 

--- a/src/open_stocks_mcp/tracing.py
+++ b/src/open_stocks_mcp/tracing.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from functools import wraps
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
 from open_stocks_mcp.config import ServerConfig
 
 _tracer_provider: TracerProvider | None = None
+_instrumented_servers: set[int] = set()
 
 
 def setup_tracing(config: ServerConfig) -> TracerProvider | None:
@@ -87,3 +89,22 @@ async def trace_tool_call(tool_name: str) -> AsyncIterator[None]:
             span.record_exception(exc)
             span.set_status(Status(StatusCode.ERROR))
             raise
+
+
+def instrument_mcp_tool_calls(mcp_server: object) -> None:
+    """Wrap FastMCP.call_tool once so each tool call emits a tracing span."""
+    server_id = id(mcp_server)
+    if server_id in _instrumented_servers:
+        return
+
+    call_tool = getattr(mcp_server, "call_tool", None)
+    if call_tool is None:
+        return
+
+    @wraps(call_tool)
+    async def _wrapped_call_tool(name: str, arguments: dict[str, object]) -> object:
+        async with trace_tool_call(name):
+            return await call_tool(name, arguments)
+
+    mcp_server.call_tool = _wrapped_call_tool  # type: ignore[attr-defined]
+    _instrumented_servers.add(server_id)

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -9,12 +9,15 @@ import httpx
 import pytest
 from mcp.server.fastmcp import FastMCP
 
+import open_stocks_mcp.tracing as tracing_module
 from open_stocks_mcp import __version__
+from open_stocks_mcp.config import load_config
 from open_stocks_mcp.server.http_transport import (
     READ_ONLY_HTTP_TOOL_NAMES,
     TimeoutMiddleware,
     create_http_server,
 )
+from open_stocks_mcp.tracing import instrument_mcp_tool_calls, setup_tracing
 
 
 @pytest.fixture
@@ -493,6 +496,96 @@ class TestMCPIntegration:
             assert data["jsonrpc"] == "2.0"
             assert data["id"] == 3
             assert "result" in data
+
+    @pytest.mark.anyio
+    async def test_tools_call_emits_tracing_span_on_success(
+        self, monkeypatch: pytest.MonkeyPatch, mcp_server: FastMCP
+    ) -> None:
+        """tools/call emits a span with success outcome when tracing is enabled."""
+        from httpx import ASGITransport
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        monkeypatch.setenv("OTEL_ENABLED", "true")
+        monkeypatch.setattr(tracing_module, "_tracer_provider", None)
+        monkeypatch.setattr(tracing_module, "_instrumented_servers", set())
+
+        provider = setup_tracing(load_config())
+        assert provider is not None
+        exporter = InMemorySpanExporter()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        instrument_mcp_tool_calls(mcp_server)
+        app = create_http_server(mcp_server)
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            payload = {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {"name": "account_info", "arguments": {}},
+            }
+            response = await client.post("/mcp", json=payload)
+            assert response.status_code == 200
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "account_info"
+        assert span.attributes["tool.name"] == "account_info"
+        assert span.attributes["tool.outcome"] == "success"
+
+    @pytest.mark.anyio
+    async def test_tools_call_emits_tracing_span_on_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """tools/call emits error outcome and error type for failing tool calls."""
+        from httpx import ASGITransport
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        failing_server = FastMCP("Failing Open Stocks MCP")
+
+        @failing_server.tool()
+        async def account_info() -> dict[str, Any]:
+            raise RuntimeError("tool failed")
+
+        monkeypatch.setenv("OTEL_ENABLED", "true")
+        monkeypatch.setattr(tracing_module, "_tracer_provider", None)
+        monkeypatch.setattr(tracing_module, "_instrumented_servers", set())
+
+        provider = setup_tracing(load_config())
+        assert provider is not None
+        exporter = InMemorySpanExporter()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        instrument_mcp_tool_calls(failing_server)
+        app = create_http_server(failing_server)
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            payload = {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {"name": "account_info", "arguments": {}},
+            }
+            response = await client.post("/mcp", json=payload)
+            assert response.status_code == 500
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "account_info"
+        assert span.attributes["tool.outcome"] == "error"
+        assert span.attributes["tool.error_type"] == "ToolError"
 
 
 @pytest.mark.integration

--- a/uv.lock
+++ b/uv.lock
@@ -1741,6 +1741,8 @@ dependencies = [
     { name = "fastapi" },
     { name = "jsonrpclib-pelix" },
     { name = "mcp" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
@@ -1767,8 +1769,6 @@ docs = [
 ]
 tracing = [
     { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
 ]
 
 [package.dev-dependencies]
@@ -1801,8 +1801,8 @@ requires-dist = [
     { name = "nbformat", marker = "extra == 'dev'", specifier = ">=5.10" },
     { name = "nbformat", marker = "extra == 'docs'", specifier = ">=5.10" },
     { name = "opentelemetry-api", marker = "extra == 'tracing'", specifier = ">=1.20.0" },
-    { name = "opentelemetry-exporter-otlp", marker = "extra == 'tracing'", specifier = ">=1.20.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },


### PR DESCRIPTION
Closes #171

## Changes
- instrumented FastMCP `call_tool` once at server setup so every MCP `tools/call` is wrapped by `trace_tool_call`
- kept tracing disabled by default and preserved idempotent setup behavior
- moved `opentelemetry-sdk` and `opentelemetry-exporter-otlp` into runtime dependencies
- added HTTP transport tests that verify span emission for successful and failing `tools/call` requests
- added `docs/OPENTELEMETRY_TRACING.md` with opt-in config plus Jaeger/Tempo OTLP examples
- linked tracing docs from `README.md`

## Test plan
- `uv run pytest tests/unit/test_tracing.py tests/http_transport/test_http_server.py -q`
- `uv run ruff check pyproject.toml src/open_stocks_mcp/tracing.py src/open_stocks_mcp/server/app.py tests/http_transport/test_http_server.py tests/unit/test_tracing.py`
- `uv run ruff format src/open_stocks_mcp/tracing.py src/open_stocks_mcp/server/app.py tests/http_transport/test_http_server.py tests/unit/test_tracing.py --check`
- `uv run mypy src/open_stocks_mcp/tracing.py src/open_stocks_mcp/server/app.py`

## Notes
- `uv run pytest -m "journey_system"` currently fails during collection due to a pre-existing pytest deprecation in `tests/integration/conftest.py` (non-top-level `pytest_plugins`).