### PR TITLE
feat: add rate-limit queueing and symbol batching

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -158,6 +158,14 @@ class OtelConfig:
 
 
 @dataclass
+class BatchConfig:
+    """Configuration for request batching and queue wait behavior."""
+
+    batch_size: int = 10
+    queue_max_wait: float = 0.5
+
+
+@dataclass
 class ServerConfig:
     """Configuration for the MCP server"""
 
@@ -170,6 +178,7 @@ class ServerConfig:
     circuit_breaker: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
     broker_requests: BrokerRequestConfig = field(default_factory=BrokerRequestConfig)
     otel: OtelConfig = field(default_factory=OtelConfig)
+    batch: BatchConfig = field(default_factory=BatchConfig)
 
     def __post_init__(self) -> None:
         if self.retry is None:
@@ -257,6 +266,10 @@ def load_config() -> ServerConfig:
             enabled=otel_enabled,
             service_name=os.getenv("OTEL_SERVICE_NAME", "open-stocks-mcp"),
             exporter_endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
+        ),
+        batch=BatchConfig(
+            batch_size=_env_int("OPEN_STOCKS_MCP_BATCH_SIZE", 10),
+            queue_max_wait=_env_float("OPEN_STOCKS_MCP_QUEUE_MAX_WAIT", 0.5),
         ),
     )
 

--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -3,9 +3,11 @@
 import asyncio
 import time
 from collections import defaultdict, deque
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.exceptions import RateLimitError
 
 
 class RateLimiter:
@@ -39,12 +41,14 @@ class RateLimiter:
         self.broker_buckets: dict[str, deque[float]] = defaultdict(
             lambda: deque(maxlen=100)
         )
+        self._wait_queue: deque[object] = deque()
 
     async def acquire(
         self,
         endpoint: str | None = None,
         weight: float = 1.0,
         broker: str | None = None,
+        max_wait: float | None = None,
     ) -> None:
         """Acquire permission to make an API call.
 
@@ -52,67 +56,103 @@ class RateLimiter:
             endpoint: Optional endpoint identifier for per-endpoint limiting
             weight: Weight of this call (some calls may count more)
         """
+        request_weight = max(1, int(weight))
+        deadline = None if max_wait is None else time.time() + max_wait
+        token = object()
+
         async with self._lock:
-            now = time.time()
+            self._wait_queue.append(token)
 
-            # Remove old timestamps (older than 1 hour)
-            cutoff_hour = now - 3600
-            while self.call_times and self.call_times[0] < cutoff_hour:
-                self.call_times.popleft()
+        while True:
+            wait_time = 0.0
+            async with self._lock:
+                now = time.time()
+                self._prune_old_calls(now)
 
-            # Check hourly limit
-            if len(self.call_times) >= self.calls_per_hour:
-                # Calculate wait time
-                oldest_call = self.call_times[0]
-                wait_time = (oldest_call + 3600) - now
-                if wait_time > 0:
-                    logger.warning(
-                        f"Rate limit reached (hourly). Waiting {wait_time:.1f}s"
-                    )
-                    await asyncio.sleep(wait_time)
-                    # Recursive call after wait
-                    await self.acquire(endpoint, weight)
-                    return
-
-            # Check minute limit
-            cutoff_minute = now - 60
-            recent_calls = sum(1 for t in self.call_times if t > cutoff_minute)
-
-            if recent_calls >= self.calls_per_minute:
-                # Find the oldest call in the last minute
-                minute_calls = [t for t in self.call_times if t > cutoff_minute]
-                if minute_calls:
-                    wait_time = (minute_calls[0] + 60) - now
-                    if wait_time > 0:
-                        logger.warning(
-                            f"Rate limit reached (minute). Waiting {wait_time:.1f}s"
-                        )
-                        await asyncio.sleep(wait_time)
-                        # Recursive call after wait
-                        await self.acquire(endpoint, weight)
+                if self._wait_queue and self._wait_queue[0] is token:
+                    if self._has_capacity(now, request_weight):
+                        self._wait_queue.popleft()
+                        self._record_call(now, request_weight, endpoint, broker)
                         return
+                    wait_time = self._time_until_capacity(now)
 
-            # Check burst limit
-            cutoff_burst = now - 1  # 1 second window for burst
-            burst_calls = sum(1 for t in self.call_times if t > cutoff_burst)
+                if deadline is not None:
+                    remaining = deadline - now
+                    if remaining <= 0:
+                        self._remove_waiter(token)
+                        raise RateLimitError(
+                            "Rate limit exceeded while waiting for queued capacity"
+                        )
+                    if wait_time <= 0:
+                        wait_time = min(0.01, remaining)
+                    else:
+                        wait_time = min(wait_time, remaining)
+                elif wait_time <= 0:
+                    wait_time = 0.01
 
-            if burst_calls >= self.burst_size:
-                wait_time = 1.0 - (
-                    now - max(t for t in self.call_times if t > cutoff_burst)
+            if wait_time >= 1.0:
+                logger.warning(
+                    "Rate limit reached. Waiting %.1fs for available capacity",
+                    wait_time,
                 )
-                if wait_time > 0:
-                    logger.debug(f"Burst limit reached. Waiting {wait_time:.3f}s")
-                    await asyncio.sleep(wait_time)
+            await asyncio.sleep(wait_time)
 
-            # Record the call
-            for _ in range(int(weight)):
-                self.call_times.append(now)
+    def _prune_old_calls(self, now: float) -> None:
+        cutoff_hour = now - 3600
+        while self.call_times and self.call_times[0] < cutoff_hour:
+            self.call_times.popleft()
 
-            # Track per-endpoint if specified
-            if endpoint:
-                self.endpoint_buckets[endpoint].append(now)
-            if broker:
-                self.broker_buckets[broker].append(now)
+    def _has_capacity(self, now: float, weight: int) -> bool:
+        cutoff_minute = now - 60
+        cutoff_burst = now - 1
+        calls_last_minute = sum(1 for t in self.call_times if t > cutoff_minute)
+        calls_last_burst = sum(1 for t in self.call_times if t > cutoff_burst)
+        return (
+            len(self.call_times) + weight <= self.calls_per_hour
+            and calls_last_minute + weight <= self.calls_per_minute
+            and calls_last_burst + weight <= self.burst_size
+        )
+
+    def _time_until_capacity(self, now: float) -> float:
+        waits: list[float] = []
+        if len(self.call_times) >= self.calls_per_hour:
+            waits.append((self.call_times[0] + 3600) - now)
+
+        cutoff_minute = now - 60
+        minute_calls = [t for t in self.call_times if t > cutoff_minute]
+        if len(minute_calls) >= self.calls_per_minute:
+            waits.append((minute_calls[0] + 60) - now)
+
+        cutoff_burst = now - 1
+        burst_calls = [t for t in self.call_times if t > cutoff_burst]
+        if len(burst_calls) >= self.burst_size:
+            waits.append((burst_calls[0] + 1.0) - now)
+
+        positive_waits = [wait for wait in waits if wait > 0]
+        return max(positive_waits) if positive_waits else 0.01
+
+    def _record_call(
+        self, now: float, weight: int, endpoint: str | None, broker: str | None
+    ) -> None:
+        for _ in range(weight):
+            self.call_times.append(now)
+        if endpoint:
+            self.endpoint_buckets[endpoint].append(now)
+        if broker:
+            self.broker_buckets[broker].append(now)
+
+    def _remove_waiter(self, token: object) -> None:
+        try:
+            self._wait_queue.remove(token)
+        except ValueError:
+            return
+
+    def reset(self) -> None:
+        """Reset call tracking and queue state (primarily for tests)."""
+        self.call_times.clear()
+        self.endpoint_buckets.clear()
+        self.broker_buckets.clear()
+        self._wait_queue.clear()
 
     def get_stats(self) -> dict[str, Any]:
         """Get current rate limiter statistics.
@@ -172,6 +212,99 @@ def get_rate_limiter() -> RateLimiter:
             burst_size=5,  # Allow small bursts
         )
     return _rate_limiter
+
+
+class _BatchState:
+    """Per-loop batch state for coalescing symbol fetches."""
+
+    def __init__(self) -> None:
+        self.lock = asyncio.Lock()
+        self.pending: dict[str, list[asyncio.Future[Any]]] = defaultdict(list)
+        self.drain_task: asyncio.Task[None] | None = None
+
+
+_batch_states: dict[tuple[int, str], _BatchState] = {}
+
+
+def reset_batch_state() -> None:
+    """Clear global batching state for tests."""
+    _batch_states.clear()
+
+
+async def batch_fetch_symbols(
+    batch_name: str,
+    symbols: list[str],
+    fetch_many: Callable[[list[str]], Awaitable[list[dict[str, Any]] | None]],
+    *,
+    batch_size: int,
+    queue_max_wait: float,
+) -> list[dict[str, Any] | None]:
+    """Coalesce symbol requests into batched fetch_many invocations."""
+    normalized = [symbol.strip().upper() for symbol in symbols]
+    if not normalized:
+        return []
+
+    loop = asyncio.get_running_loop()
+    state_key = (id(loop), batch_name)
+    state = _batch_states.get(state_key)
+    if state is None:
+        state = _BatchState()
+        _batch_states[state_key] = state
+
+    futures_by_symbol: dict[str, asyncio.Future[Any]] = {}
+    async with state.lock:
+        for symbol in normalized:
+            fut = loop.create_future()
+            state.pending[symbol].append(fut)
+            futures_by_symbol[symbol] = fut
+        if state.drain_task is None or state.drain_task.done():
+            state.drain_task = loop.create_task(
+                _drain_batches(state, fetch_many, max(1, batch_size), queue_max_wait)
+            )
+
+    results_by_symbol = {
+        symbol: await fut
+        for symbol, fut in futures_by_symbol.items()
+        if fut is not None
+    }
+    return [results_by_symbol.get(symbol) for symbol in normalized]
+
+
+async def _drain_batches(
+    state: _BatchState,
+    fetch_many: Callable[[list[str]], Awaitable[list[dict[str, Any]] | None]],
+    batch_size: int,
+    queue_max_wait: float,
+) -> None:
+    try:
+        await asyncio.sleep(max(0.0, queue_max_wait))
+        while True:
+            async with state.lock:
+                if not state.pending:
+                    return
+                chunk_symbols = list(state.pending.keys())[:batch_size]
+                chunk = {symbol: state.pending.pop(symbol) for symbol in chunk_symbols}
+
+            rows = await fetch_many(chunk_symbols)
+            rows = rows or []
+            row_map: dict[str, dict[str, Any]] = {}
+            for row in rows:
+                symbol = str(row.get("symbol", "")).strip().upper()
+                if symbol:
+                    row_map[symbol] = row
+            if len(row_map) != len(chunk_symbols) and len(rows) == len(chunk_symbols):
+                for index, symbol in enumerate(chunk_symbols):
+                    if symbol not in row_map:
+                        row_map[symbol] = rows[index]
+
+            for symbol, waiters in chunk.items():
+                value = row_map.get(symbol)
+                for fut in waiters:
+                    if not fut.done():
+                        fut.set_result(value)
+    finally:
+        async with state.lock:
+            state.drain_task = None
 
 
 async def rate_limited_call(

--- a/src/open_stocks_mcp/tools/robinhood_stock_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_stock_tools.py
@@ -1,6 +1,6 @@
 """MCP tools for Robin Stocks stock market data operations."""
 
-from typing import Any
+from typing import Any, cast
 
 import robin_stocks.robinhood as rh
 
@@ -17,8 +17,27 @@ from open_stocks_mcp.tools.error_handling import (
     validate_period,
     validate_symbol,
 )
+from open_stocks_mcp.tools.rate_limiter import batch_fetch_symbols
 
 _cache_cfg = load_config().cache
+_batch_cfg = load_config().batch
+
+
+async def _fetch_instruments_batched(
+    symbols: list[str],
+) -> list[dict[str, Any]]:
+    async def _fetch_many(batch_symbols: list[str]) -> list[dict[str, Any]] | None:
+        result = await execute_with_retry(rh.get_instruments_by_symbols, batch_symbols)
+        return cast(list[dict[str, Any]] | None, result)
+
+    batched_rows = await batch_fetch_symbols(
+        "robinhood_instruments_by_symbols",
+        symbols,
+        _fetch_many,
+        batch_size=_batch_cfg.batch_size,
+        queue_max_wait=_batch_cfg.queue_max_wait,
+    )
+    return [row for row in batched_rows if row is not None]
 
 
 @handle_robin_stocks_errors
@@ -102,7 +121,7 @@ async def get_stock_info(symbol: str) -> dict[str, Any]:
 
     # Get fundamentals and instrument data with retry logic
     fundamentals = await execute_with_retry(rh.get_fundamentals, symbol)
-    instruments = await execute_with_retry(rh.get_instruments_by_symbols, symbol)
+    instruments = await _fetch_instruments_batched([symbol])
 
     if not fundamentals or not instruments:
         return create_no_data_response(
@@ -329,9 +348,7 @@ async def get_instruments_by_symbols(symbols: list[str]) -> dict[str, Any]:
     log_api_call("get_instruments_by_symbols", symbols=clean_symbols)
 
     # Get instruments data with retry logic
-    instruments_data = await execute_with_retry(
-        rh.get_instruments_by_symbols, clean_symbols
-    )
+    instruments_data = await _fetch_instruments_batched(clean_symbols)
 
     if not instruments_data:
         return create_no_data_response(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ except ImportError:
 import pytest
 
 from tests.fixtures import broker_payloads
+from open_stocks_mcp.tools.rate_limiter import get_rate_limiter, reset_batch_state
 from tests.integration.live_market_harness import (
     LIVE_MARKET_ENV_VAR,
     LIVE_MARKET_SKIP_REASON,
@@ -27,6 +28,12 @@ from tests.integration.live_market_harness import (
 RATE_LIMITED_SKIP_REASON = (
     "rate_limited test; set RUN_RATE_LIMITED=1 or pass '-m rate_limited' to enable"
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit_and_batch_state() -> None:
+    get_rate_limiter().reset()
+    reset_batch_state()
 
 
 def pytest_configure(config: Any) -> None:
@@ -105,7 +112,10 @@ def pytest_collection_modifyitems(config: Any, items: list[Any]) -> None:
             if list(item.iter_markers(name="rate_limited")):
                 item.add_marker(skip_rate_limited)
 
-    run_live = config.getoption("--run-live-market", default=False)
+    getoption = getattr(config, "getoption", None)
+    run_live = (
+        bool(getoption("--run-live-market", default=False)) if getoption else False
+    )
     env_live = bool(os.environ.get(LIVE_MARKET_ENV_VAR))
     if not (run_live and env_live):
         skip_live = pytest.mark.skip(reason=LIVE_MARKET_SKIP_REASON)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,8 @@ except ImportError:
 
 import pytest
 
-from tests.fixtures import broker_payloads
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter, reset_batch_state
+from tests.fixtures import broker_payloads
 from tests.integration.live_market_harness import (
     LIVE_MARKET_ENV_VAR,
     LIVE_MARKET_SKIP_REASON,

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -1,0 +1,73 @@
+"""Focused tests for queued rate limiting and symbol batching."""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from open_stocks_mcp.config import load_config
+from open_stocks_mcp.tools.rate_limiter import RateLimiter, batch_fetch_symbols
+
+
+class TestQueuedRateLimiter:
+    """Queue/drain behavior for the rate limiter."""
+
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch("open_stocks_mcp.tools.rate_limiter.asyncio.sleep", new_callable=AsyncMock)
+    @patch("open_stocks_mcp.tools.rate_limiter.time.time")
+    async def test_queue_drains_fifo(self, mock_time: Any, _mock_sleep: Any) -> None:
+        limiter = RateLimiter(calls_per_minute=1, calls_per_hour=10, burst_size=1)
+        time_values = iter([100.0, 100.0, 100.0, 100.0, 160.1, 160.1])
+        mock_time.side_effect = lambda: next(time_values)
+
+        await limiter.acquire(max_wait=0.5)
+        await limiter.acquire(max_wait=0.5)
+
+        assert len(limiter.call_times) == 2
+
+    @pytest.mark.journey_system
+    @pytest.mark.unit
+    def test_batch_config_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPEN_STOCKS_MCP_BATCH_SIZE", "3")
+        monkeypatch.setenv("OPEN_STOCKS_MCP_QUEUE_MAX_WAIT", "0.25")
+
+        config = load_config()
+
+        assert config.batch.batch_size == 3
+        assert config.batch.queue_max_wait == 0.25
+
+
+class TestBatchHelper:
+    """Symbol batching helper behavior."""
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_batch_helper_coalesces_symbol_burst(self) -> None:
+        calls: list[list[str]] = []
+
+        async def fetch_many(symbols: list[str]) -> list[dict[str, Any]]:
+            calls.append(symbols)
+            return [{"symbol": s, "id": f"id-{s}"} for s in symbols]
+
+        async def request_one(symbol: str) -> list[dict[str, Any] | None]:
+            return await batch_fetch_symbols(
+                "test-symbol-burst",
+                [symbol],
+                fetch_many,
+                batch_size=3,
+                queue_max_wait=0.01,
+            )
+
+        results = await asyncio.gather(
+            request_one("AAPL"), request_one("MSFT"), request_one("GOOGL")
+        )
+
+        assert len(calls) == 1
+        assert calls[0] == ["AAPL", "MSFT", "GOOGL"]
+        assert results[0][0] == {"symbol": "AAPL", "id": "id-AAPL"}
+        assert results[1][0] == {"symbol": "MSFT", "id": "id-MSFT"}
+        assert results[2][0] == {"symbol": "GOOGL", "id": "id-GOOGL"}

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for stock market and core tools."""
 
+import asyncio
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -639,6 +640,35 @@ class TestAdvancedInstrumentTools:
         assert result["result"]["instruments"][0]["name"] == "Apple Inc."
         assert result["result"]["instruments"][1]["symbol"] == "GOOGL"
         assert result["result"]["instruments"][1]["name"] == "Alphabet Inc. - Class A"
+        mock_get_instruments.assert_called_once()
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_name_by_symbol")
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_fundamentals")
+    @patch("open_stocks_mcp.tools.robinhood_stock_tools.rh.get_instruments_by_symbols")
+    @pytest.mark.asyncio
+    async def test_get_instruments_batched_concurrent_single_symbol_calls(
+        self, mock_get_instruments: Any, mock_get_fundamentals: Any, mock_get_name: Any
+    ) -> None:
+        """Concurrent symbol lookups should coalesce to one Robinhood API call."""
+        mock_get_fundamentals.return_value = [{"sector": "Tech"}]
+        mock_get_name.side_effect = ["Apple", "Microsoft", "Alphabet"]
+        mock_get_instruments.return_value = [
+            {"symbol": "AAPL", "id": "id-aapl", "name": "Apple"},
+            {"symbol": "MSFT", "id": "id-msft", "name": "Microsoft"},
+            {"symbol": "GOOGL", "id": "id-googl", "name": "Alphabet"},
+        ]
+
+        results = await asyncio.gather(
+            get_stock_info("AAPL"),
+            get_stock_info("MSFT"),
+            get_stock_info("GOOGL"),
+        )
+
+        assert mock_get_instruments.call_count == 1
+        for result in results:
+            assert result["result"]["status"] == "success"
 
     @pytest.mark.journey_market_data
     @pytest.mark.unit


### PR DESCRIPTION
Closes #168

## Changes
- added `BatchConfig` (`batch_size`, `queue_max_wait`) to runtime config with env parsing
- upgraded `RateLimiter.acquire()` to FIFO queued draining with optional `max_wait`, preserving stats/reset behavior
- added reusable `batch_fetch_symbols()` helper with per-loop/per-batch isolation and reset support
- wired stock instrument lookups (`get_stock_info`, `get_instruments_by_symbols`) to opt-in batching while preserving response schema
- added focused unit coverage for queue draining, config parsing, batching coalescing, and concurrent instrument lookups

## Test plan
- `uv run pytest tests/unit/test_rate_limiter.py tests/unit/test_simple_rate_limiter.py -q`
- `uv run pytest tests/unit/test_stock_market_tools.py -q -k 'stock_info or instruments or batch'`
- `uv run pytest tests/unit/ -m 'not slow and not exception_test' -q`
- `uv run ruff check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/tools/robinhood_stock_tools.py tests/conftest.py tests/unit/test_rate_limiter.py tests/unit/test_simple_rate_limiter.py tests/unit/test_stock_market_tools.py`
- `uv run ruff format --check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/tools/robinhood_stock_tools.py tests/conftest.py tests/unit/test_rate_limiter.py tests/unit/test_simple_rate_limiter.py tests/unit/test_stock_market_tools.py`
- `uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/tools/robinhood_stock_tools.py`
