### PR TITLE
feat: add proactive monitoring alert hooks

### DIFF
--- a/src/open_stocks_mcp/alerting.py
+++ b/src/open_stocks_mcp/alerting.py
@@ -1,0 +1,92 @@
+"""Alerting primitives for monitoring health and metric threshold events."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from open_stocks_mcp.logging_config import logger
+
+AlertHook = Callable[["AlertEvent"], Awaitable[None]]
+
+
+@dataclass
+class AlertConfig:
+    """Configuration values controlling alert behavior."""
+
+    enabled: bool = False
+    webhook_url: str | None = None
+    error_rate_threshold_percent: float = 50.0
+    latency_p95_threshold_ms: float = 10000.0
+    webhook_timeout_seconds: float = 5.0
+
+
+@dataclass
+class AlertEvent:
+    """A normalized alert event payload."""
+
+    alert_type: str
+    status: str
+    message: str
+    timestamp: str
+    metric_values: dict[str, float]
+    threshold_values: dict[str, float]
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-safe payload."""
+        return {
+            "alert_type": self.alert_type,
+            "status": self.status,
+            "message": self.message,
+            "timestamp": self.timestamp,
+            "metric_values": self.metric_values,
+            "threshold_values": self.threshold_values,
+        }
+
+
+class AlertManager:
+    """Dispatches alert events to registered hooks."""
+
+    def __init__(
+        self, config: AlertConfig, hooks: list[AlertHook] | None = None
+    ) -> None:
+        self.config = config
+        self.hooks = hooks or []
+
+    async def dispatch(self, event: AlertEvent) -> None:
+        """Fire all hooks for a single event, suppressing hook failures."""
+        if not self.config.enabled:
+            return
+        for hook in self.hooks:
+            try:
+                await hook(event)
+            except Exception:
+                logger.exception(
+                    "Alert hook failed while dispatching %s", event.alert_type
+                )
+
+
+def create_webhook_alerter(
+    webhook_url: str,
+    *,
+    timeout_seconds: float = 5.0,
+) -> AlertHook:
+    """Create a hook that POSTs alert events to a webhook endpoint."""
+
+    async def _send_webhook(event: AlertEvent) -> None:
+        payload = event.to_payload()
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    webhook_url,
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+                response.raise_for_status()
+        except Exception:
+            logger.exception("Webhook alert dispatch failed to %s", webhook_url)
+
+    return _send_webhook

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -158,6 +158,17 @@ class OtelConfig:
 
 
 @dataclass
+class AlertConfig:
+    """Alerting configuration for proactive monitoring notifications."""
+
+    enabled: bool = False
+    webhook_url: str | None = None
+    error_rate_threshold_percent: float = 50.0
+    latency_p95_threshold_ms: float = 10000.0
+    webhook_timeout_seconds: float = 5.0
+
+
+@dataclass
 class ServerConfig:
     """Configuration for the MCP server"""
 
@@ -170,6 +181,7 @@ class ServerConfig:
     circuit_breaker: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
     broker_requests: BrokerRequestConfig = field(default_factory=BrokerRequestConfig)
     otel: OtelConfig = field(default_factory=OtelConfig)
+    alerting: AlertConfig = field(default_factory=AlertConfig)
 
     def __post_init__(self) -> None:
         if self.retry is None:
@@ -257,6 +269,17 @@ def load_config() -> ServerConfig:
             enabled=otel_enabled,
             service_name=os.getenv("OTEL_SERVICE_NAME", "open-stocks-mcp"),
             exporter_endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
+        ),
+        alerting=AlertConfig(
+            enabled=_env_bool("ALERTING_ENABLED", False),
+            webhook_url=os.getenv("ALERT_WEBHOOK_URL") or None,
+            error_rate_threshold_percent=_env_float(
+                "ALERT_ERROR_RATE_THRESHOLD_PERCENT", 50.0
+            ),
+            latency_p95_threshold_ms=_env_float(
+                "ALERT_LATENCY_P95_THRESHOLD_MS", 10000.0
+            ),
+            webhook_timeout_seconds=_env_float("ALERT_WEBHOOK_TIMEOUT_SECONDS", 5.0),
         ),
     )
 

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -7,13 +7,26 @@ from collections import defaultdict, deque
 from datetime import datetime, timedelta
 from typing import Any
 
+from open_stocks_mcp.alerting import (
+    AlertConfig,
+    AlertEvent,
+    AlertHook,
+    AlertManager,
+    create_webhook_alerter,
+)
 from open_stocks_mcp.logging_config import logger
 
 
 class MetricsCollector:
     """Collects and tracks metrics for monitoring."""
 
-    def __init__(self, window_size_minutes: int = 60):
+    def __init__(
+        self,
+        window_size_minutes: int = 60,
+        *,
+        alert_config: AlertConfig | None = None,
+        alert_hooks: list[AlertHook] | None = None,
+    ):
         """Initialize metrics collector.
 
         Args:
@@ -40,6 +53,19 @@ class MetricsCollector:
         # Cache hit/miss counters, keyed by cache name
         self.cache_hits: dict[str, int] = defaultdict(int)
         self.cache_misses: dict[str, int] = defaultdict(int)
+        self._last_health_status = "healthy"
+        self._active_threshold_alerts: set[str] = set()
+
+        self.alert_config = alert_config or AlertConfig()
+        hooks = list(alert_hooks or [])
+        if self.alert_config.enabled and self.alert_config.webhook_url:
+            hooks.append(
+                create_webhook_alerter(
+                    self.alert_config.webhook_url,
+                    timeout_seconds=self.alert_config.webhook_timeout_seconds,
+                )
+            )
+        self.alert_manager = AlertManager(config=self.alert_config, hooks=hooks)
 
         self._lock = asyncio.Lock()
 
@@ -105,9 +131,7 @@ class MetricsCollector:
             now = datetime.now()
             self._clean_old_entries(now)
             duration_ms_val = (
-                duration_ms
-                if duration_ms is not None
-                else ((duration or 0.0) * 1000.0)
+                duration_ms if duration_ms is not None else ((duration or 0.0) * 1000.0)
             )
             self.broker_operations.append(
                 {
@@ -158,7 +182,9 @@ class MetricsCollector:
             while tool_durations and tool_durations[0][0] < cutoff:
                 tool_durations.popleft()
 
-        while self.broker_operations and self.broker_operations[0]["timestamp"] < cutoff:
+        while (
+            self.broker_operations and self.broker_operations[0]["timestamp"] < cutoff
+        ):
             self.broker_operations.popleft()
 
     @staticmethod
@@ -413,6 +439,8 @@ class MetricsCollector:
             health = "degraded" if health == "healthy" else health
             issues.append(f"High response time: {avg_response_time}ms")
 
+        await self._emit_alerts(metrics=metrics, health=health)
+
         return {
             "status": health,
             "issues": issues,
@@ -422,6 +450,67 @@ class MetricsCollector:
                 "calls_last_hour": metrics["calls_in_window"],
             },
         }
+
+    async def _emit_alerts(self, *, metrics: dict[str, Any], health: str) -> None:
+        """Emit alert events for health transitions and threshold breaches."""
+        if not self.alert_config.enabled:
+            return
+
+        now = datetime.now().isoformat()
+
+        if health in {"degraded", "unhealthy"} and health != self._last_health_status:
+            await self.alert_manager.dispatch(
+                AlertEvent(
+                    alert_type="health_transition",
+                    status=health,
+                    message=f"Health transitioned to {health}",
+                    timestamp=now,
+                    metric_values={
+                        "error_rate_percent": float(metrics["error_rate_percent"]),
+                        "p95_response_time_ms": float(metrics["p95_response_time_ms"]),
+                    },
+                    threshold_values={},
+                )
+            )
+        self._last_health_status = health
+
+        breached: dict[str, tuple[float, float]] = {}
+        error_rate = float(metrics["error_rate_percent"])
+        p95_latency = float(metrics["p95_response_time_ms"])
+
+        if error_rate > self.alert_config.error_rate_threshold_percent:
+            breached["error_rate_threshold_percent"] = (
+                error_rate,
+                self.alert_config.error_rate_threshold_percent,
+            )
+        if p95_latency > self.alert_config.latency_p95_threshold_ms:
+            breached["latency_p95_threshold_ms"] = (
+                p95_latency,
+                self.alert_config.latency_p95_threshold_ms,
+            )
+
+        current_keys = set(breached.keys())
+        new_breaches = current_keys - self._active_threshold_alerts
+        self._active_threshold_alerts = current_keys
+
+        for breach_key in new_breaches:
+            observed, threshold = breached[breach_key]
+            await self.alert_manager.dispatch(
+                AlertEvent(
+                    alert_type="threshold_breach",
+                    status="warning",
+                    message=f"Threshold breached: {breach_key}",
+                    timestamp=now,
+                    metric_values={
+                        "error_rate_percent": error_rate,
+                        "p95_response_time_ms": p95_latency,
+                    },
+                    threshold_values={
+                        breach_key: threshold,
+                        "observed_value": observed,
+                    },
+                )
+            )
 
 
 # Global metrics collector instance

--- a/tests/unit/test_alerting.py
+++ b/tests/unit/test_alerting.py
@@ -1,0 +1,134 @@
+"""Unit tests for alerting hooks and webhook dispatch."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from open_stocks_mcp.alerting import (
+    AlertConfig,
+    AlertEvent,
+    AlertManager,
+    create_webhook_alerter,
+)
+from open_stocks_mcp.monitoring import MetricsCollector
+
+
+@pytest.mark.asyncio
+async def test_alert_manager_disabled_by_default_noop() -> None:
+    events: list[AlertEvent] = []
+
+    async def hook(event: AlertEvent) -> None:
+        events.append(event)
+
+    manager = AlertManager(config=AlertConfig(), hooks=[hook])
+    event = AlertEvent(
+        alert_type="health_transition",
+        status="degraded",
+        message="Health transitioned to degraded",
+        timestamp=datetime.now().isoformat(),
+        metric_values={"error_rate_percent": 12.0},
+        threshold_values={},
+    )
+
+    await manager.dispatch(event)
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_webhook_alerter_posts_json_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post_mock = Mock()
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+    class _Client:
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url: str, json: dict, timeout: float) -> _Response:
+            post_mock(url, json, timeout)
+            return _Response()
+
+    monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+    event = AlertEvent(
+        alert_type="threshold_breach",
+        status="warning",
+        message="Error rate threshold breached",
+        timestamp=datetime.now().isoformat(),
+        metric_values={"error_rate_percent": 55.0, "p95_response_time_ms": 1200.0},
+        threshold_values={"error_rate_threshold_percent": 50.0},
+    )
+
+    webhook = create_webhook_alerter("https://alerts.example.test/hook")
+    await webhook(event)
+
+    assert post_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_health_transition_alert_emitted_once_per_state_change() -> None:
+    events: list[AlertEvent] = []
+
+    async def hook(event: AlertEvent) -> None:
+        events.append(event)
+
+    collector = MetricsCollector(
+        alert_config=AlertConfig(enabled=True),
+        alert_hooks=[hook],
+    )
+    now = datetime.now()
+    collector.api_calls.extend([(now, "tool", True) for _ in range(10)])
+
+    collector.errors.extend([(now, "tool", "err"), (now, "tool", "err")])
+    first = await collector.get_health_status()
+    second = await collector.get_health_status()
+
+    assert first["status"] == "degraded"
+    assert second["status"] == "degraded"
+    health_events = [e for e in events if e.alert_type == "health_transition"]
+    assert len(health_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_threshold_alerts_fire_only_on_breach() -> None:
+    events: list[AlertEvent] = []
+
+    async def hook(event: AlertEvent) -> None:
+        events.append(event)
+
+    collector = MetricsCollector(
+        alert_config=AlertConfig(
+            enabled=True,
+            error_rate_threshold_percent=20.0,
+            latency_p95_threshold_ms=1000.0,
+        ),
+        alert_hooks=[hook],
+    )
+    now = datetime.now()
+
+    collector.api_calls.extend([(now, "tool", True) for _ in range(20)])
+    collector.response_times.extend([(now, 0.25) for _ in range(20)])
+    await collector.get_health_status()
+
+    threshold_events = [e for e in events if e.alert_type == "threshold_breach"]
+    assert threshold_events == []
+
+    collector.errors.extend([(now, "tool", "err") for _ in range(8)])
+    collector.response_times.clear()
+    collector.response_times.extend([(now, 2.0) for _ in range(20)])
+
+    await collector.get_health_status()
+    await collector.get_health_status()
+
+    threshold_events = [e for e in events if e.alert_type == "threshold_breach"]
+    assert len(threshold_events) == 2


### PR DESCRIPTION
Closes #172

## Changes
- add `src/open_stocks_mcp/alerting.py` with `AlertEvent`, `AlertManager`, and built-in webhook alerter support
- add `ServerConfig.alerting` and env-driven alert thresholds/webhook settings in `src/open_stocks_mcp/config.py` (disabled by default)
- wire `MetricsCollector` alert hooks into health transition + threshold breach detection with deduping in `src/open_stocks_mcp/monitoring.py`
- add `tests/unit/test_alerting.py` for disabled defaults, health transition emission, threshold breach behavior, and webhook dispatch (mocked HTTP)

## Test plan
- `uv run pytest tests/unit/test_alerting.py tests/unit/test_monitoring.py -v`
- `uv run pytest tests/unit/test_stock_market_tools.py::TestServerTools::test_metrics_summary_success tests/unit/test_analytics_tools.py::TestServerMetrics::test_metrics_summary_success -v`
- `uv run ruff check src/open_stocks_mcp/alerting.py src/open_stocks_mcp/config.py src/open_stocks_mcp/monitoring.py tests/unit/test_alerting.py`
- `uv run ruff format --check src/open_stocks_mcp/alerting.py src/open_stocks_mcp/config.py src/open_stocks_mcp/monitoring.py tests/unit/test_alerting.py`
- `uv run mypy .`

Note: issue comment plan referenced `TestServerMetrics` in `test_stock_market_tools.py`; that class is `TestServerTools` in current main, so the equivalent test node was used.