### PR TITLE
tests: add watchlist and notification read-only ADK eval tranche

### DIFF
--- a/tests/evals/3_wth_all_watchlists_test.json
+++ b/tests/evals/3_wth_all_watchlists_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "all_watchlists_test_set",
+  "name": "All Watchlists Test",
+  "description": "Read-only test case for retrieving all Robinhood watchlists. Does not invoke any watchlist mutation, order-placement, or account-modification tools.",
+  "eval_cases": [
+    {
+      "eval_id": "all_watchlists_test",
+      "conversation": [
+        {
+          "invocation_id": "all-watchlists-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me all of my Robinhood watchlists."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Robinhood watchlists. The response lists the names and item counts of each watchlist without modifying any watchlist data."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "all_watchlists"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/3_wth_watchlist_by_name_test.json
+++ b/tests/evals/3_wth_watchlist_by_name_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "watchlist_by_name_test_set",
+  "name": "Watchlist By Name Test",
+  "description": "Read-only test case for retrieving the contents of a named Robinhood watchlist. Assumes a watchlist named 'Tech Stocks' exists in the live account; rename to an existing watchlist name before running against a real account. Does not invoke add_to_watchlist, remove_from_watchlist, or any trading tool.",
+  "eval_cases": [
+    {
+      "eval_id": "watchlist_by_name_test",
+      "conversation": [
+        {
+          "invocation_id": "watchlist-by-name-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me the contents of my Tech Stocks watchlist."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the contents of your Tech Stocks watchlist. The response summarizes the symbols included or notes that no data was returned if the watchlist is empty or does not exist."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"watchlist_name": "Tech Stocks"},
+                "name": "watchlist_by_name"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/3_wth_watchlist_performance_test.json
+++ b/tests/evals/3_wth_watchlist_performance_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "watchlist_performance_test_set",
+  "name": "Watchlist Performance Test",
+  "description": "Read-only test case for analyzing the performance of a named Robinhood watchlist. Assumes a watchlist named 'Tech Stocks' exists in the live account; rename to an existing watchlist name before running against a real account. Does not add or remove symbols or invoke any trading tool.",
+  "eval_cases": [
+    {
+      "eval_id": "watchlist_performance_test",
+      "conversation": [
+        {
+          "invocation_id": "watchlist-performance-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Analyze the performance of my Tech Stocks watchlist."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the performance analysis for your Tech Stocks watchlist. The response summarizes price changes and performance metrics for the symbols in the watchlist without adding or removing any symbols."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"watchlist_name": "Tech Stocks"},
+                "name": "watchlist_performance"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_account_features_test.json
+++ b/tests/evals/4_ntf_account_features_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "account_features_test_set",
+  "name": "Account Features Test",
+  "description": "Read-only test case for summarizing Robinhood account features (aggregates subscription, margin, notification, and referral data). May return partial_success if one data source is unavailable; the expected response describes available features without requiring every subsection to be populated. Does not invoke any order-placement, account-mutation, or watchlist-mutation tools.",
+  "eval_cases": [
+    {
+      "eval_id": "account_features_test",
+      "conversation": [
+        {
+          "invocation_id": "account-features-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Summarize my Robinhood account features."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is a summary of your Robinhood account features. The response covers available subscription details, margin status, notification settings, and referral program information. Sections with no data are noted as unavailable rather than omitted."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "account_features"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_latest_notification_test.json
+++ b/tests/evals/4_ntf_latest_notification_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "latest_notification_test_set",
+  "name": "Latest Notification Test",
+  "description": "Read-only test case for retrieving the single most recent Robinhood account notification. Does not invoke any order-placement, account-mutation, or watchlist-mutation tools.",
+  "eval_cases": [
+    {
+      "eval_id": "latest_notification_test",
+      "conversation": [
+        {
+          "invocation_id": "latest-notification-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my latest Robinhood notification."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your most recent Robinhood notification. The response describes the notification message or notes that no recent notification was found if the account has none."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "latest_notification"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_margin_calls_test.json
+++ b/tests/evals/4_ntf_margin_calls_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "margin_calls_test_set",
+  "name": "Margin Calls Test",
+  "description": "Read-only test case for checking Robinhood margin call status. Legitimately returns empty/no-data when the account has no active margin calls. Does not invoke any order-placement, account-mutation, or watchlist-mutation tools.",
+  "eval_cases": [
+    {
+      "eval_id": "margin_calls_test",
+      "conversation": [
+        {
+          "invocation_id": "margin-calls-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Check whether I have any margin calls."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I checked your Robinhood account for margin calls. The response reports active margin call details or confirms that you currently have no outstanding margin calls."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "margin_calls"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_margin_interest_test.json
+++ b/tests/evals/4_ntf_margin_interest_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "margin_interest_test_set",
+  "name": "Margin Interest Test",
+  "description": "Read-only test case for retrieving Robinhood margin interest charges and current rate. Legitimately returns empty/no-data if the account has no margin history. Does not invoke any order-placement, account-mutation, or watchlist-mutation tools.",
+  "eval_cases": [
+    {
+      "eval_id": "margin_interest_test",
+      "conversation": [
+        {
+          "invocation_id": "margin-interest-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my margin interest charges and current rate."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Robinhood margin interest details. The response shows current interest rate and any accrued charges, or notes that no margin interest data is available if the account is not a margin account."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "margin_interest"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_notifications_test.json
+++ b/tests/evals/4_ntf_notifications_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "notifications_test_set",
+  "name": "Notifications Test",
+  "description": "Read-only test case for retrieving recent Robinhood account notifications. Does not invoke any order-placement, account-mutation, or watchlist-mutation tools.",
+  "eval_cases": [
+    {
+      "eval_id": "notifications_test",
+      "conversation": [
+        {
+          "invocation_id": "notifications-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my five most recent account notifications."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your five most recent Robinhood account notifications. The response lists the notification messages or notes that no recent notifications were found if the account has none."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"count": 5},
+                "name": "notifications"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_referrals_test.json
+++ b/tests/evals/4_ntf_referrals_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "referrals_test_set",
+  "name": "Referrals Test",
+  "description": "Read-only test case for retrieving Robinhood referral program status and history. Legitimately returns empty/no-data if the account has no referral activity. Does not invoke any order-placement, account-mutation, or watchlist-mutation tools.",
+  "eval_cases": [
+    {
+      "eval_id": "referrals_test",
+      "conversation": [
+        {
+          "invocation_id": "referrals-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my Robinhood referral program status."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Robinhood referral program status. The response describes your referral history and any pending or completed rewards, or notes that no referral activity was found on this account."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "referrals"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_subscription_fees_test.json
+++ b/tests/evals/4_ntf_subscription_fees_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "subscription_fees_test_set",
+  "name": "Subscription Fees Test",
+  "description": "Read-only test case for retrieving Robinhood Gold subscription fee history. Legitimately returns empty/no-data if the account has no Gold subscription. Does not invoke any order-placement, account-mutation, or watchlist-mutation tools.",
+  "eval_cases": [
+    {
+      "eval_id": "subscription_fees_test",
+      "conversation": [
+        {
+          "invocation_id": "subscription-fees-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my Robinhood Gold subscription fee history."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Robinhood Gold subscription fee history. The response lists past subscription charges or notes that no subscription fee history is available if the account does not have a Gold membership."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "subscription_fees"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -150,7 +150,51 @@ adk eval examples/google_adk_agent tests/evals/0_sys_metrics_summary_test.json -
 adk eval examples/google_adk_agent tests/evals/0_sys_rate_limit_status_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 3. Schwab Market & Account Evals (`schwab_*`)
+### 3. Watchlist Read-Only Evaluations (`3_wth_*`)
+
+Read-only evals that exercise the three watchlist retrieval tools registered in `src/open_stocks_mcp/server/app.py`. None of these evals invoke `add_to_watchlist`, `remove_from_watchlist`, or any order-placement or account-mutation tool.
+
+- `tests/evals/3_wth_all_watchlists_test.json` — exercises `all_watchlists` with empty args; retrieves the list of all watchlist names and item counts.
+- `tests/evals/3_wth_watchlist_by_name_test.json` — exercises `watchlist_by_name` with `{"watchlist_name": "Tech Stocks"}`; retrieves the symbols in a named watchlist.
+- `tests/evals/3_wth_watchlist_performance_test.json` — exercises `watchlist_performance` with `{"watchlist_name": "Tech Stocks"}`; retrieves price-change and performance metrics for each symbol in a named watchlist.
+
+**Credential assumptions**: All three evals require `GOOGLE_API_KEY`, a reachable MCP server (`MCP_HTTP_URL`), and Robinhood credentials with read access. The `3_wth_watchlist_by_name_test.json` and `3_wth_watchlist_performance_test.json` evals assume a watchlist named `Tech Stocks` exists in the live account. Before running those two evals against a real account, update `watchlist_name` to a watchlist name that actually exists in the account.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/3_wth_all_watchlists_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/3_wth_watchlist_by_name_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/3_wth_watchlist_performance_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 4. Notifications and Account Features Read-Only Evaluations (`4_ntf_*`)
+
+Read-only evals that exercise the seven notification and account-feature retrieval tools registered in `src/open_stocks_mcp/server/app.py`. None of these evals invoke any order-placement, watchlist-mutation, or account-mutation tool. All seven tools may legitimately return empty or no-data responses when the live account has no relevant activity.
+
+- `tests/evals/4_ntf_notifications_test.json` — exercises `notifications` with `{"count": 5}`; retrieves the five most recent account notification messages.
+- `tests/evals/4_ntf_latest_notification_test.json` — exercises `latest_notification` with empty args; retrieves the single most recent account notification.
+- `tests/evals/4_ntf_margin_calls_test.json` — exercises `margin_calls` with empty args; reports active margin calls or confirms none are outstanding.
+- `tests/evals/4_ntf_margin_interest_test.json` — exercises `margin_interest` with empty args; retrieves margin interest charges and current rate (empty if account is not a margin account).
+- `tests/evals/4_ntf_subscription_fees_test.json` — exercises `subscription_fees` with empty args; retrieves Robinhood Gold subscription fee history (empty if no Gold membership).
+- `tests/evals/4_ntf_referrals_test.json` — exercises `referrals` with empty args; retrieves referral program status and history (empty if no referral activity).
+- `tests/evals/4_ntf_account_features_test.json` — exercises `account_features` with empty args; aggregates subscription, margin, notification, and referral data into a feature summary. May return `partial_success` if one data source is unavailable; expected responses describe available features without requiring every subsection to be populated.
+
+**Credential assumptions**: All seven evals require `GOOGLE_API_KEY`, a reachable MCP server (`MCP_HTTP_URL`), and Robinhood credentials with read access. Empty-data responses from the API are valid outcomes for notifications, margin, subscription fees, and referrals — the expected agent response should describe what was found or note that no data was returned.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/4_ntf_notifications_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_latest_notification_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_margin_calls_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_margin_interest_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_subscription_fees_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_referrals_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_account_features_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 5. Schwab Market & Account Evals (`schwab_*`)
 
 Evaluations for Schwab-specific tools. These typically require live Schwab OAuth credentials and a running MCP server.
 
@@ -176,7 +220,7 @@ adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_expirations_t
 adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 4. Creating Custom Evaluation Tests
+### 6. Creating Custom Evaluation Tests
 
 #### Test File Structure
 ```json


### PR DESCRIPTION
Closes #182

## Changes
- Add 3 read-only watchlist ADK eval files (`3_wth_all_watchlists_test.json`, `3_wth_watchlist_by_name_test.json`, `3_wth_watchlist_performance_test.json`) exercising `all_watchlists`, `watchlist_by_name`, and `watchlist_performance` tools respectively
- Add 7 read-only notification/account-feature ADK eval files (`4_ntf_notifications_test.json`, `4_ntf_latest_notification_test.json`, `4_ntf_margin_calls_test.json`, `4_ntf_margin_interest_test.json`, `4_ntf_subscription_fees_test.json`, `4_ntf_referrals_test.json`, `4_ntf_account_features_test.json`) exercising the corresponding tools
- Update `tests/evals/ADK-testing-evals.md` with new sections 3 (Watchlist Read-Only Evaluations) and 4 (Notifications and Account Features Read-Only Evaluations), documenting all 10 files, their tools, run commands, and credential assumptions

## Test plan
- All 10 new JSON files parse without error: `python -c "import json,glob; files=sorted(glob.glob('tests/evals/[34]_*_test.json')); assert len(files)==10, files; [json.load(open(p)) for p in files]; print('ok')"`
- No mutation tools (`add_to_watchlist`, `remove_from_watchlist`, `buy_*`, `sell_*`) appear in any new eval file
- All 10 file paths appear uniquely in `ADK-testing-evals.md`
- `watchlist_by_name` and `watchlist_performance` evals document the requirement that a `Tech Stocks` watchlist exists (or the name must be updated) before live ADK runs
- Notification/margin/fee/referral evals accept empty/no-data responses as valid outcomes