### PR TITLE
test: add read-only ADK eval tranches for profiles advanced options

### DIFF
--- a/tests/evals/6_prf_account_profile_test.json
+++ b/tests/evals/6_prf_account_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "account_profile_test_set",
+  "name": "Account Profile Test",
+  "description": "Retrieve detailed account profile information.",
+  "eval_cases": [
+    {
+      "eval_id": "account_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "account-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my account profile details in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "account_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_basic_profile_test.json
+++ b/tests/evals/6_prf_basic_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "basic_profile_test_set",
+  "name": "Basic Profile Test",
+  "description": "Retrieve basic profile information.",
+  "eval_cases": [
+    {
+      "eval_id": "basic_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "basic-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my basic user profile information."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "basic_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_complete_profile_test.json
+++ b/tests/evals/6_prf_complete_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "complete_profile_test_set",
+  "name": "Complete Profile Test",
+  "description": "Retrieve the complete combined profile.",
+  "eval_cases": [
+    {
+      "eval_id": "complete_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "complete-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Give me a complete profile summary for my account."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "complete_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_investment_profile_test.json
+++ b/tests/evals/6_prf_investment_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "investment_profile_test_set",
+  "name": "Investment Profile Test",
+  "description": "Retrieve investment profile preferences.",
+  "eval_cases": [
+    {
+      "eval_id": "investment_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "investment-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Summarize my investment profile and preferences."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "investment_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_security_profile_test.json
+++ b/tests/evals/6_prf_security_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "security_profile_test_set",
+  "name": "Security Profile Test",
+  "description": "Retrieve account security profile details.",
+  "eval_cases": [
+    {
+      "eval_id": "security_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "security-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my security profile details and verification settings."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "security_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_user_profile_test.json
+++ b/tests/evals/6_prf_user_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "user_profile_test_set",
+  "name": "User Profile Test",
+  "description": "Retrieve the user profile record.",
+  "eval_cases": [
+    {
+      "eval_id": "user_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "user-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Provide my user profile details."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "user_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_aggregate_option_positions_test.json
+++ b/tests/evals/8_opt_aggregate_option_positions_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "aggregate_option_positions_test_set",
+  "name": "Aggregate Option Positions Test",
+  "description": "Retrieve aggregate option positions grouped by underlying.",
+  "eval_cases": [
+    {
+      "eval_id": "aggregate_option_positions_test",
+      "conversation": [
+        {
+          "invocation_id": "aggregate-option-positions-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Summarize my aggregate option exposure grouped by underlying symbol."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "aggregate_option_positions"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_open_option_positions_with_details_test.json
+++ b/tests/evals/8_opt_open_option_positions_with_details_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "open_option_positions_with_details_test_set",
+  "name": "Open Option Positions With Details Test",
+  "description": "Retrieve open option positions with enriched call/put details.",
+  "eval_cases": [
+    {
+      "eval_id": "open_option_positions_with_details_test",
+      "conversation": [
+        {
+          "invocation_id": "open-option-positions-with-details-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my currently open option positions with call/put details and Greeks."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "open_option_positions_with_details"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_option_historicals_test.json
+++ b/tests/evals/8_opt_option_historicals_test.json
@@ -1,0 +1,59 @@
+{
+  "eval_set_id": "option_historicals_test_set",
+  "name": "Option Historicals Test",
+  "description": "Retrieve historical data for a specific option contract via options chain discovery.",
+  "eval_cases": [
+    {
+      "eval_id": "option_historicals_test",
+      "conversation": [
+        {
+          "invocation_id": "option-historicals-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Use AAPL options chain data and show me historical pricing for a call option contract."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the historical option pricing summary for the selected AAPL call contract."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL"
+                },
+                "name": "options_chains"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "expiration_date": "2025-08-08",
+                  "strike_price": "225.00",
+                  "option_type": "call",
+                  "interval": "day"
+                },
+                "name": "option_historicals"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_option_market_data_test.json
+++ b/tests/evals/8_opt_option_market_data_test.json
@@ -1,0 +1,55 @@
+{
+  "eval_set_id": "option_market_data_test_set",
+  "name": "Option Market Data Test",
+  "description": "Retrieve market data for a specific option contract via options chain discovery.",
+  "eval_cases": [
+    {
+      "eval_id": "option_market_data_test",
+      "conversation": [
+        {
+          "invocation_id": "option-market-data-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Find a tradable AAPL call option and show me its latest market data."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the option market data for a tradable AAPL call contract identified from the options chain."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL"
+                },
+                "name": "options_chains"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "option_id": "REPLACE_WITH_OPTION_ID"
+                },
+                "name": "option_market_data"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_account_features_test.json
+++ b/tests/evals/9_adv_account_features_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "account_features_test_set",
+  "name": "Account Features Test",
+  "description": "Retrieve enabled account features and permissions.",
+  "eval_cases": [
+    {
+      "eval_id": "account_features_test",
+      "conversation": [
+        {
+          "invocation_id": "account-features-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What account features and permissions are enabled for me?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "account_features"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_account_settings_test.json
+++ b/tests/evals/9_adv_account_settings_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "account_settings_test_set",
+  "name": "Account Settings Test",
+  "description": "Retrieve current account configuration settings.",
+  "eval_cases": [
+    {
+      "eval_id": "account_settings_test",
+      "conversation": [
+        {
+          "invocation_id": "account-settings-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my current account settings and configuration."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "account_settings"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_broker_status_test.json
+++ b/tests/evals/9_adv_broker_status_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "broker_status_test_set",
+  "name": "Broker Status Test",
+  "description": "Retrieve status of connected broker integrations.",
+  "eval_cases": [
+    {
+      "eval_id": "broker_status_test",
+      "conversation": [
+        {
+          "invocation_id": "broker-status-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "List connected brokers and show their current status."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "broker_status"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_build_user_profile_test.json
+++ b/tests/evals/9_adv_build_user_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "build_user_profile_test_set",
+  "name": "Build User Profile Test",
+  "description": "Build an aggregated user financial profile.",
+  "eval_cases": [
+    {
+      "eval_id": "build_user_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "build-user-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Build my complete financial profile including equity, cash, and dividends."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the information you requested in a concise summary."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "build_user_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -176,7 +176,65 @@ adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_expirations_t
 adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 4. Creating Custom Evaluation Tests
+### 4. Profiles Tests (`6_prf_*`)
+
+Read-only evals for Robinhood profile endpoints. These require `GOOGLE_API_KEY` and live Robinhood credentials (`ROBINHOOD_USERNAME` and `ROBINHOOD_PASSWORD`).
+
+- `tests/evals/6_prf_account_profile_test.json` — exercises `account_profile` to retrieve account profile details.
+- `tests/evals/6_prf_basic_profile_test.json` — exercises `basic_profile` for basic user profile data.
+- `tests/evals/6_prf_investment_profile_test.json` — exercises `investment_profile` for risk and investing preferences.
+- `tests/evals/6_prf_security_profile_test.json` — exercises `security_profile` for security settings/profile context.
+- `tests/evals/6_prf_user_profile_test.json` — exercises `user_profile` for user-level profile metadata.
+- `tests/evals/6_prf_complete_profile_test.json` — exercises `complete_profile` for combined profile information.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/6_prf_account_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_basic_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_investment_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_security_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_user_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_complete_profile_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 5. Advanced Tests (`9_adv_*`)
+
+Read-only evals for advanced account/broker tooling. `build_user_profile`, `account_settings`, and `account_features` require Robinhood credentials; `broker_status` does not.
+
+- `tests/evals/9_adv_build_user_profile_test.json` — exercises `build_user_profile` for aggregated financial profile totals.
+- `tests/evals/9_adv_account_settings_test.json` — exercises `account_settings` for account configuration values.
+- `tests/evals/9_adv_account_features_test.json` — exercises `account_features` for feature/permission availability.
+- `tests/evals/9_adv_broker_status_test.json` — exercises `broker_status` to inspect connected broker status.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/9_adv_build_user_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/9_adv_account_settings_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/9_adv_account_features_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/9_adv_broker_status_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 6. Options Data Tests (`8_opt_*`)
+
+Read-only evals for options data tools. `option_market_data` and `option_historicals` use `options_chains` first to identify a contract; account-scoped position tools require Robinhood credentials.
+
+- `tests/evals/8_opt_option_market_data_test.json` — exercises `options_chains` then `option_market_data` using a resolved option contract id.
+- `tests/evals/8_opt_option_historicals_test.json` — exercises `options_chains` then `option_historicals` for historical option pricing.
+- `tests/evals/8_opt_aggregate_option_positions_test.json` — exercises `aggregate_option_positions` for grouped options exposure.
+- `tests/evals/8_opt_open_option_positions_with_details_test.json` — exercises `open_option_positions_with_details` for enriched open-option details.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/8_opt_option_market_data_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_option_historicals_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_aggregate_option_positions_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_open_option_positions_with_details_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 7. Creating Custom Evaluation Tests
 
 #### Test File Structure
 ```json


### PR DESCRIPTION
Closes #183

## Changes
- add six new `6_prf_*` read-only ADK eval JSON scenarios for profile tools
- add four new `9_adv_*` read-only ADK eval JSON scenarios for advanced tools
- add four new `8_opt_*` read-only ADK eval JSON scenarios for options data tools
- extend `tests/evals/ADK-testing-evals.md` with Profiles, Advanced, and Options Data sections including exact `adk eval` commands and credential notes

## Test plan
- `python3 -c "import json; json.load(open('tests/evals/1_acc_account_info_test.json'))"`
- `python3 -c "import json,sys; [json.load(open(p)) for p in sys.argv[1:]]" tests/evals/6_prf_account_profile_test.json tests/evals/6_prf_basic_profile_test.json tests/evals/6_prf_investment_profile_test.json tests/evals/6_prf_security_profile_test.json tests/evals/6_prf_user_profile_test.json tests/evals/6_prf_complete_profile_test.json`
- `python3 -c "import json,sys; [json.load(open(p)) for p in sys.argv[1:]]" tests/evals/9_adv_build_user_profile_test.json tests/evals/9_adv_account_settings_test.json tests/evals/9_adv_account_features_test.json tests/evals/9_adv_broker_status_test.json`
- `python3 -c "import json,sys; [json.load(open(p)) for p in sys.argv[1:]]" tests/evals/8_opt_option_market_data_test.json tests/evals/8_opt_option_historicals_test.json tests/evals/8_opt_aggregate_option_positions_test.json tests/evals/8_opt_open_option_positions_with_details_test.json`
- `python3 -c "import json,glob; [json.load(open(p)) for p in glob.glob('tests/evals/6_prf_*_test.json')+glob.glob('tests/evals/9_adv_*_test.json')+glob.glob('tests/evals/8_opt_*_test.json')]"`
- `grep -n "async def \\(account_profile\\|basic_profile\\|investment_profile\\|security_profile\\|user_profile\\|complete_profile\\)" src/open_stocks_mcp/server/app.py`
- `grep -n "async def \\(build_user_profile\\|account_settings\\|account_features\\|broker_status\\)" src/open_stocks_mcp/server/app.py`
- `grep -n "async def \\(option_market_data\\|option_historicals\\|aggregate_option_positions\\|open_option_positions_with_details\\)" src/open_stocks_mcp/server/app.py`
- `grep -lE '"(buy_|sell_|cancel_|add_to_watchlist|remove_from_watchlist)' tests/evals/6_prf_*_test.json tests/evals/9_adv_*_test.json tests/evals/8_opt_*_test.json | grep -vE '(find_options_test|options_chains_test)\\.json'`
- `pytest -q tests/evals/__init__.py` (returns exit code 5: no tests collected)
- `ruff check .` (fails on pre-existing repo issues outside this change)
- `mypy .` (fails on pre-existing repo issue outside this change)