### PR TITLE
tests: add market/research read-only ADK eval tranche

### DIFF
--- a/tests/evals/2_mkt_price_history_test.json
+++ b/tests/evals/2_mkt_price_history_test.json
@@ -1,0 +1,49 @@
+{
+  "eval_set_id": "price_history_test_set",
+  "name": "Price History Test",
+  "description": "Test case for retrieving historical price data for a stock through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "price_history_test",
+      "conversation": [
+        {
+          "invocation_id": "price-history-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me the weekly price history for AAPL."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the weekly price history for Apple (AAPL):\n\nThe data shows OHLC (open, high, low, close) candlestick records for AAPL over the past week. Each entry includes the opening price, the intraday high and low, the closing price, and trading volume. This data can be used to identify short-term price trends and volatility patterns.\n\n**Note:** This is read-only historical market data. No orders were placed."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "period": "week"
+                },
+                "name": "price_history"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_stock_earnings_test.json
+++ b/tests/evals/2_mkt_stock_earnings_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "stock_earnings_test_set",
+  "name": "Stock Earnings Test",
+  "description": "Test case for retrieving earnings report data for a stock through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "stock_earnings_test",
+      "conversation": [
+        {
+          "invocation_id": "stock-earnings-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me Microsoft's (MSFT) recent earnings reports."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are Microsoft's (MSFT) recent earnings reports:\n\nThe data includes quarterly earnings per share (EPS) results, with both actual reported EPS and the analyst consensus estimate for each period. Recent quarters show Microsoft's revenue and profit trends across its Productivity and Business Processes, Intelligent Cloud, and More Personal Computing segments.\n\nKey figures from recent quarters:\n- EPS actual vs. estimate comparisons\n- Report dates for each fiscal quarter\n- Year-over-year growth indicators\n\n**Note:** This is read-only fundamental research data. No orders were placed."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "MSFT"
+                },
+                "name": "stock_earnings"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_stock_news_test.json
+++ b/tests/evals/2_mkt_stock_news_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "stock_news_test_set",
+  "name": "Stock News Test",
+  "description": "Test case for retrieving recent news articles for a stock through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "stock_news_test",
+      "conversation": [
+        {
+          "invocation_id": "stock-news-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Get the latest news for Tesla (TSLA)."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the latest news articles for Tesla (TSLA):\n\nRecent headlines cover Tesla's production updates, delivery numbers, new product announcements, and any regulatory or competitive developments. Each article includes the headline, publication source, publish date, and a brief summary.\n\nThis news feed is sourced from Robinhood's aggregated financial news and provides timely context for monitoring TSLA's market-moving events.\n\n**Note:** This is read-only news data. No orders were placed."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "TSLA"
+                },
+                "name": "stock_news"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_stock_ratings_test.json
+++ b/tests/evals/2_mkt_stock_ratings_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "stock_ratings_test_set",
+  "name": "Stock Ratings Test",
+  "description": "Test case for retrieving analyst ratings for a stock through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "stock_ratings_test",
+      "conversation": [
+        {
+          "invocation_id": "stock-ratings-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What do analysts say about Apple (AAPL)?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the analyst rating summary for Apple (AAPL):\n\n**Analyst Consensus:** Buy\n\nThe breakdown of analyst ratings shows:\n- **Buy** ratings: majority of covering analysts\n- **Hold** ratings: some analysts\n- **Sell** ratings: few analysts\n\nAnalysts generally cite Apple's strong ecosystem lock-in, services revenue growth, and iPhone upgrade cycle as key bullish factors. Price targets vary by firm, but the consensus reflects a positive outlook on AAPL's near-term performance.\n\n**Note:** This is read-only research data. No orders were placed."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL"
+                },
+                "name": "stock_ratings"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_stock_splits_test.json
+++ b/tests/evals/2_mkt_stock_splits_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "stock_splits_test_set",
+  "name": "Stock Splits Test",
+  "description": "Test case for retrieving stock split history for a company through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "stock_splits_test",
+      "conversation": [
+        {
+          "invocation_id": "stock-splits-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Has Apple (AAPL) had any stock splits?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the stock split history for Apple (AAPL):\n\nApple has had several stock splits over the years. Each split entry includes the ex-date (the date shareholders of record receive additional shares), the split ratio (e.g., 4-for-1 means each existing share became 4 shares), and the execution date.\n\nNotable splits include Apple's most recent 4-for-1 split and earlier 7-for-1 and 2-for-1 splits. These splits increase the number of outstanding shares while proportionally reducing the per-share price, making shares more accessible to retail investors.\n\n**Note:** This is read-only corporate action data. No orders were placed."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL"
+                },
+                "name": "stock_splits"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_top_100_stocks_test.json
+++ b/tests/evals/2_mkt_top_100_stocks_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "top_100_stocks_test_set",
+  "name": "Top 100 Stocks Test",
+  "description": "Test case for retrieving the 100 most popular stocks on Robinhood through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "top_100_stocks_test",
+      "conversation": [
+        {
+          "invocation_id": "top-100-stocks-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "List the 100 most popular stocks on Robinhood."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the 100 most popular stocks on Robinhood:\n\nThe list shows 100 stocks ranked by popularity among Robinhood users. Each entry includes the ticker symbol, company name, and current price. Popular names typically include large-cap technology and consumer companies. The full list of 100 tickers is returned in popularity order.\n\n**Note:** This is read-only discovery data reflecting current user popularity rankings. No orders were placed."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "top_100_stocks"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_top_movers_sp500_test.json
+++ b/tests/evals/2_mkt_top_movers_sp500_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "top_movers_sp500_test_set",
+  "name": "Top Movers S&P 500 Test",
+  "description": "Test case for retrieving the top gaining or losing S&P 500 stocks through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "top_movers_sp500_test",
+      "conversation": [
+        {
+          "invocation_id": "top-movers-sp500-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What are today's top S&P 500 gainers?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are today's top S&P 500 gainers:\n\nThe list shows S&P 500 stocks with the largest percentage gains today. Each entry includes the ticker symbol, company name, current price, and percentage change. These are the strongest upward movers among S&P 500 components as of the latest market data.\n\n**Note:** This is read-only market data. No orders were placed."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "direction": "up"
+                },
+                "name": "top_movers_sp500"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_top_movers_test.json
+++ b/tests/evals/2_mkt_top_movers_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "top_movers_test_set",
+  "name": "Top Movers Test",
+  "description": "Test case for retrieving today's top 20 movers on Robinhood through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "top_movers_test",
+      "conversation": [
+        {
+          "invocation_id": "top-movers-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me today's top 20 movers on Robinhood."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are today's top 20 movers on Robinhood:\n\nThe list shows up to 20 stocks with the largest price movements today across all Robinhood-listed equities. Each entry includes the ticker symbol, company name, current price, and percentage change. These represent the most active and volatile names of the trading session.\n\n**Note:** This is read-only market data. No orders were placed."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "top_movers"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -150,7 +150,44 @@ adk eval examples/google_adk_agent tests/evals/0_sys_metrics_summary_test.json -
 adk eval examples/google_adk_agent tests/evals/0_sys_rate_limit_status_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 3. Schwab Market & Account Evals (`schwab_*`)
+### 3. Market & Research Read-Only Evaluations (`2_mkt_*`)
+
+Read-only evaluations covering Robinhood market-data and research tools. These evals exercise price, discovery, and fundamental research paths without invoking any order-placement, watchlist-mutation, or trading tools.
+
+> **Credential assumption**: Requires `GOOGLE_API_KEY` and read-only `ROBINHOOD_USERNAME`/`ROBINHOOD_PASSWORD`. No order placement occurs.
+
+#### Price History & Discovery Evals
+
+- `tests/evals/2_mkt_stock_price_test.json` — exercises `stock_price` to retrieve the current price for a given ticker.
+- `tests/evals/2_mkt_price_history_test.json` — exercises `price_history` with `{"symbol": "AAPL", "period": "week"}` to retrieve weekly OHLC data.
+- `tests/evals/2_mkt_top_movers_sp500_test.json` — exercises `top_movers_sp500` with `{"direction": "up"}` to list the top S&P 500 gainers.
+- `tests/evals/2_mkt_top_100_stocks_test.json` — exercises `top_100_stocks` to retrieve the 100 most popular Robinhood equities.
+- `tests/evals/2_mkt_top_movers_test.json` — exercises `top_movers` to list today's top 20 movers across all Robinhood-listed stocks.
+- `tests/evals/2_mkt_market_hours_test.json` — exercises `market_hours` to check current market open/close status.
+- `tests/evals/2_mkt_search_stocks_test.json` — exercises `search_stocks` to find instruments by keyword.
+- `tests/evals/2_mkt_stock_info_test.json` — exercises `stock_info` to retrieve detailed fundamental company data.
+
+#### Research & Fundamentals Evals
+
+- `tests/evals/2_mkt_stock_ratings_test.json` — exercises `stock_ratings` with `{"symbol": "AAPL"}` to retrieve analyst buy/hold/sell breakdown.
+- `tests/evals/2_mkt_stock_earnings_test.json` — exercises `stock_earnings` with `{"symbol": "MSFT"}` to retrieve quarterly EPS actuals vs. estimates.
+- `tests/evals/2_mkt_stock_news_test.json` — exercises `stock_news` with `{"symbol": "TSLA"}` to retrieve recent news headlines.
+- `tests/evals/2_mkt_stock_splits_test.json` — exercises `stock_splits` with `{"symbol": "AAPL"}` to retrieve historical split ratios and ex-dates.
+
+Run individual evals with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/2_mkt_price_history_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_top_movers_sp500_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_top_100_stocks_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_top_movers_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_stock_ratings_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_stock_earnings_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_stock_news_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_stock_splits_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 5. Schwab Market & Account Evals (`schwab_*`)
 
 Evaluations for Schwab-specific tools. These typically require live Schwab OAuth credentials and a running MCP server.
 
@@ -176,7 +213,7 @@ adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_expirations_t
 adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 4. Creating Custom Evaluation Tests
+### 6. Creating Custom Evaluation Tests
 
 #### Test File Structure
 ```json


### PR DESCRIPTION
Closes #181

## Changes
- Add 8 new read-only ADK eval JSON files under `tests/evals/2_mkt_*`:
  - `2_mkt_price_history_test.json` — exercises `price_history` tool (AAPL, week period)
  - `2_mkt_top_movers_sp500_test.json` — exercises `top_movers_sp500` (direction: up)
  - `2_mkt_top_100_stocks_test.json` — exercises `top_100_stocks`
  - `2_mkt_top_movers_test.json` — exercises `top_movers`
  - `2_mkt_stock_ratings_test.json` — exercises `stock_ratings` (AAPL)
  - `2_mkt_stock_earnings_test.json` — exercises `stock_earnings` (MSFT)
  - `2_mkt_stock_news_test.json` — exercises `stock_news` (TSLA)
  - `2_mkt_stock_splits_test.json` — exercises `stock_splits` (AAPL)
- Update `tests/evals/ADK-testing-evals.md` with new "Market & Research Read-Only Evaluations" section (§3) enumerating all 15 `2_mkt_*` eval files across price/discovery and research/fundamentals subsections

## Notes
- The `FOREMAN_IMPLEMENTATION_PLAN` cited "4 existing + 8 new = 12 total" but 7 `2_mkt_*_test.json` files already existed at implementation time (the Schwab market evals had been added since the plan was authored). This PR adds the 8 specified files, yielding 15 total. The manifest enumerates all 15.
- All new evals are strictly read-only: verified zero `buy_`, `sell_`, `add_to_watchlist`, `remove_from_watchlist`, or `order_` references in any new file.
- Tool names verified against `src/open_stocks_mcp/server/app.py` async function signatures before committing.

## Test plan
- `python -c "import json,glob; files=sorted(glob.glob('tests/evals/2_mkt_*_test.json')); print(len(files)); [json.load(open(p)) for p in files]; print('ok')"` — 15 files, all parse
- `rg -l 'buy_|sell_|add_to_watchlist|remove_from_watchlist|order_' tests/evals/2_mkt_*_test.json` — returns no matches
- `rg '2_mkt_.*_test\.json' tests/evals/ADK-testing-evals.md -o | sort -u | wc -l` — returns 15