### PR TITLE
docs: reconcile Schwab roadmap

### DIFF
--- a/SCHWAB_STATUS.md
+++ b/SCHWAB_STATUS.md
@@ -15,6 +15,26 @@ The Schwab integration is **fully implemented and merged to main**. All code is 
 
 ---
 
+## Roadmap Reconciliation
+
+This status page describes the current Schwab core that was delivered with the multi-broker integration. The broader roadmap remains tracked separately: parent #187 owns reconciliation of the 67 parity plus 9 bonus target, while child issues route the remaining Schwab categories into task-shaped work.
+
+| Remaining category | Routing |
+|--------------------|---------|
+| Account/profile consolidation | #192 |
+| Portfolio computed helpers | #193 |
+| Expanded market data | #194 |
+| Options expansion | #195 |
+| Trading and order replacement | #196 |
+| Dividends and payment extraction | #197 |
+| Margin and notifications | #198 |
+| Streaming expansion | #199 |
+| Explicit deferral and not-applicable decisions | #201 |
+
+The existing Robinhood tool names and currently registered `schwab_*` names are backward-compatible surfaces. New parity tools should be added by the child issues above instead of renaming the current core.
+
+---
+
 ## What's Complete ✅
 
 ### Phase 1-4: Core Implementation (100% Complete)
@@ -116,12 +136,12 @@ docs/
 
 ---
 
-## Schwab Tools (24 Total)
+## Schwab Tools
 
 ### Account Tools (5)
 1. `schwab_account_numbers()` - Get account numbers and hashes
-2. `schwab_account_info(account_hash)` - Get account details
-3. `schwab_all_accounts()` - Get all accounts with positions
+2. `schwab_account(account_hash)` - Get account details
+3. `schwab_accounts()` - Get all accounts with positions
 4. `schwab_portfolio(account_hash)` - Get portfolio positions
 5. `schwab_account_balances(account_hash)` - Get account balances
 
@@ -139,16 +159,17 @@ docs/
 14. `schwab_sell_stock_limit(account_hash, symbol, quantity, price)` - Limit sell
 15. `schwab_orders(account_hash)` - Get orders
 16. `schwab_cancel_order(account_hash, order_id)` - Cancel order
-17. `schwab_order_details(account_hash, order_id)` - Get order details
-18. `schwab_place_order(account_hash, order_spec)` - Generic order placement
+17. `schwab_get_order(account_hash, order_id)` - Get order details
+18. `schwab_transactions_by_date(account_hash, start_date, end_date, ...)` - Get filtered transaction history by date
+19. `schwab_get_transaction(account_hash, transaction_id)` - Get transaction details
 
-### Options Tools (6)
-19. `schwab_option_chain(symbol, ...)` - Get options chain
-20. `schwab_option_chain_by_dates(symbol, from_date, to_date, ...)` - Filter by expiration
-21. `schwab_option_expirations(symbol)` - Get expiration dates
-22. `schwab_option_positions(account_hash)` - Get options positions
-23. `schwab_option_buy_to_open(account_hash, symbol, quantity, ...)` - Buy option
-24. `schwab_option_sell_to_close(account_hash, symbol, quantity, ...)` - Sell option
+### Options Tools (4)
+20. `schwab_option_chain(symbol, ...)` - Get options chain
+21. `schwab_option_chain_by_expiration(symbol, from_date, to_date, ...)` - Filter by expiration
+22. `schwab_option_expirations(symbol)` - Get expiration dates
+23. `schwab_options_positions(account_hash)` - Get options positions
+
+Additional roadmap tools, including generic order placement, option order helpers, richer transaction history, and computed portfolio helpers, are tracked by #127 and #192 through #199.
 
 ---
 

--- a/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
+++ b/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
@@ -306,6 +306,27 @@
 
 ---
 
+## Roadmap Reconciliation
+
+Issue #187 is the parent roadmap record for the broader 67-tool Schwab parity target plus 9 Schwab bonus capabilities. The current shipped Schwab surface is intentionally smaller; remaining work is routed to child issues rather than implemented in this parent documentation pass.
+
+| Roadmap category | Current decision | Tracking issue |
+|------------------|------------------|----------------|
+| Account/profile consolidation | Implement the missing Schwab user-preference and all-account aggregation tools as task-shaped work. | #192 |
+| Portfolio computed tools | Implement computed holdings, day-trade, aggregate-position, and option-position helpers. | #193 |
+| Expanded market data | Implement market-hours, movers, and CUSIP instrument lookup; defer Schwab-missing research feeds to explicit third-party integration. | #194, #201 |
+| Options expansion | Implement tradable-option filtering, enriched option positions, option quotes, and option-order helpers; keep historical option pricing documented as unavailable in Schwab. | #195, #201 |
+| Trading and order replacement | Implement stop orders, option orders, spread orders, bulk cancellation, open-order helpers, and Schwab order replacement. | #196 |
+| Dividends and payment extraction | Build dividend, interest, and stock-loan payment tools from Schwab transaction history. | #197 |
+| Margin and notifications | Implement Schwab margin-status derivation and margin-interest extraction; keep Robinhood referrals, subscriptions, Gold, and push notifications not applicable. | #198, #201 |
+| Transaction history bonus tools | Track Schwab transaction lookup and filtered transaction history as the data source for downstream dividend/payment work. | #127 |
+| Streaming bonus tools | Extend the broker capability baseline with Schwab level 2, option quote, and account-activity streaming. | #199 |
+| Watchlists, crypto, and other non-parity items | Record explicit defer/not-applicable decisions instead of treating them as open roadmap questions. | #201 |
+
+Backward compatibility remains unchanged: existing Robinhood tools keep their current names, and existing registered `schwab_*` tool names remain the public Schwab surface while child issues add new tools.
+
+---
+
 ## Implementation Priority
 
 ### Phase 1: Core Trading (80% user value)
@@ -432,22 +453,14 @@
 
 ---
 
-## Open Questions
+## Decisions
 
-1. **Watchlist Replacement**: Should we build a persistent watchlist storage layer?
-   - **Option A**: SQLite database for MCP server
-   - **Option B**: JSON file storage
-   - **Option C**: Let users manage externally
-
-2. **Missing Data Sources**: Should we integrate 3rd party APIs for news/earnings?
-   - **Option A**: Add as separate tools (e.g., `alpha_vantage_get_earnings`)
-   - **Option B**: Transparent fallback from Schwab tools
-   - **Option C**: Document as limitation
-
-3. **Streaming Architecture**: How to expose Schwab streaming in MCP?
-   - **Option A**: Use SSE endpoint for streaming quotes
-   - **Option B**: Polling with cached data
-   - **Option C**: WebSocket support (Phase 6+)
+1. **Watchlists**: Deferred to client-side storage. Schwab does not expose a watchlist API, so server-owned persistence would be a separate product feature rather than Schwab parity. Issue #201 tracks the documented limitation.
+2. **Missing research data**: Deferred to future third-party integration. Earnings, ratings, news, events, and splits should not silently fall back inside Schwab tools because that would mix broker data with unrelated provider data without an explicit contract. Issue #201 records the limitation; #194 covers Schwab-native market data expansion.
+3. **Historical options pricing**: Not available from Schwab for this roadmap. Current options parity work should focus on Schwab option chains, positions, quotes, and order helpers in #195.
+4. **Cryptocurrency**: Not applicable to Schwab parity because Schwab does not support crypto trading through the broker API. Issue #201 records this as a non-portable Robinhood category.
+5. **Robinhood-specific features**: Referrals, subscriptions, Robinhood Gold features, and Robinhood push notifications are not applicable to Schwab. Margin-related replacements remain tracked in #198.
+6. **Streaming exposure**: Track Schwab streaming through the broker capability baseline and #199. The roadmap should not choose a separate transport here until the capability contract is implemented.
 
 ---
 


### PR DESCRIPTION
Closes #187

## Changes
- Add a Roadmap Reconciliation section to the Schwab comparison doc that routes remaining roadmap categories to #127 and #192 through #201.
- Replace unresolved Open Questions / option lists with concrete deferral and not-applicable decisions.
- Add Schwab status roadmap routing and align documented registered `schwab_*` wrapper names with `src/open_stocks_mcp/server/app.py`.

## Test plan
- `uv run python - <<'PY' ...` comparison roadmap reconciliation check
- `uv run python - <<'PY' ...` Schwab status reconciliation check
- `uv run pytest tests/server/test_server_app.py::TestToolRegistration::test_tools_are_registered -q`
- `git diff --check`