### PR TITLE
test: add exception-scenario auth/network coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,6 +251,30 @@ def broker_auth_error_payload() -> dict[str, Any]:
     return broker_payloads.broker_auth_error_payload()
 
 
+@pytest.fixture
+def network_timeout_error() -> TimeoutError:
+    """Timeout exception fixture classified as a network error."""
+    return TimeoutError("request timeout")
+
+
+@pytest.fixture
+def connection_refused_error() -> ConnectionError:
+    """Connection exception fixture classified as a network error."""
+    return ConnectionError("connection refused")
+
+
+@pytest.fixture
+def expired_token_error() -> Exception:
+    """Authentication-like expired token exception fixture."""
+    return Exception("token expired")
+
+
+@pytest.fixture
+def invalid_credentials_error() -> Exception:
+    """Authentication-like invalid credentials exception fixture."""
+    return Exception("invalid credentials")
+
+
 # Journey-specific fixtures
 
 

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -690,12 +690,14 @@ def test_log_api_call_excludes_sensitive_kwargs(
 # --- Failure-mode regression tests ---
 
 
+@pytest.mark.exception_test
 def test_classify_timeout_error_as_network_error() -> None:
     """TimeoutError should classify as NetworkError."""
     error = classify_error(TimeoutError("request timed out"))
     assert isinstance(error, NetworkError)
 
 
+@pytest.mark.exception_test
 def test_classify_connection_refused_as_network_error() -> None:
     """ConnectionError 'connection refused' should classify as NetworkError."""
     error = classify_error(ConnectionError("connection refused"))
@@ -703,6 +705,7 @@ def test_classify_connection_refused_as_network_error() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.exception_test
 async def test_execute_with_retry_succeeds_after_transient_network_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -725,6 +728,7 @@ async def test_execute_with_retry_succeeds_after_transient_network_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.exception_test
 async def test_execute_with_retry_raises_network_error_on_repeated_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_network_failures.py
+++ b/tests/unit/test_network_failures.py
@@ -1,0 +1,45 @@
+"""Exception-scenario tests for network failures in representative tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+from open_stocks_mcp.tools.schwab_market_tools import get_schwab_quote
+
+pytestmark = [pytest.mark.unit, pytest.mark.journey_system, pytest.mark.exception_test]
+
+
+@pytest.mark.asyncio
+async def test_robinhood_stock_price_timeout_returns_structured_error() -> None:
+    with patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.execute_with_retry",
+        new=AsyncMock(side_effect=TimeoutError("request timeout")),
+    ):
+        result = await get_stock_price("AAPL")
+
+    assert result["result"]["status"] == "error"
+    assert result["result"]["error_type"] == "network"
+    assert result["result"]["error"] == "Network connectivity issue"
+
+
+@pytest.mark.asyncio
+async def test_schwab_quote_connection_refused_returns_structured_error() -> None:
+    fake_broker = MagicMock()
+    fake_broker.client = MagicMock()
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error",
+            new=AsyncMock(return_value=(fake_broker, None)),
+        ),
+        patch(
+            "open_stocks_mcp.tools.schwab_market_tools.execute_broker_request",
+            new=AsyncMock(side_effect=ConnectionError("connection refused")),
+        ),
+    ):
+        result = await get_schwab_quote("AAPL")
+
+    assert result["result"]["status"] == "error"
+    assert result["result"]["error_type"] == "network"
+    assert result["result"]["error"] == "Network connectivity issue"

--- a/tests/unit/test_schwab_broker.py
+++ b/tests/unit/test_schwab_broker.py
@@ -110,8 +110,10 @@ class TestSchwabBroker:
         with (
             patch("schwab.auth.easy_client") as mock_easy_client,
             patch("os.isatty", return_value=True),
-            patch.dict("os.environ", {"OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS": "2.5"}),
-            patch("open_stocks_mcp.config._global_config", None), # Reset config
+            patch.dict(
+                "os.environ", {"OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS": "2.5"}
+            ),
+            patch("open_stocks_mcp.config._global_config", None),  # Reset config
         ):
             mock_client = MagicMock()
             mock_easy_client.return_value = mock_client
@@ -248,6 +250,57 @@ class TestSchwabBroker:
                 "Interactive authentication required"
                 in schwab_broker._auth_info.error_message
             )
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.exception_test
+    @pytest.mark.asyncio
+    async def test_authenticate_expired_token_marks_auth_failed(
+        self, schwab_broker: SchwabBroker, tmp_path: Path
+    ) -> None:
+        """Expired token plus failed OAuth fallback should set AUTH_FAILED cleanly."""
+        token_dir = Path.home() / ".tokens"
+        token_dir.mkdir(parents=True, exist_ok=True)
+        token_file = token_dir / "schwab_token_expired_test.json"
+        token_file.write_text('{"access_token":"expired"}')
+        schwab_broker.token_path = str(token_file)
+
+        try:
+            with (
+                patch(
+                    "schwab.auth.client_from_token_file",
+                    side_effect=Exception("token expired"),
+                ),
+                patch("schwab.auth.easy_client", side_effect=Exception("oauth failed")),
+                patch("os.isatty", return_value=True),
+            ):
+                result = await schwab_broker.authenticate()
+        finally:
+            if token_file.exists():
+                token_file.unlink()
+
+        assert result is False
+        assert schwab_broker.client is None
+        assert schwab_broker._auth_info.status == BrokerAuthStatus.AUTH_FAILED
+        assert "oauth failed" in (schwab_broker._auth_info.error_message or "")
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.exception_test
+    @pytest.mark.asyncio
+    async def test_authenticate_bad_credentials_non_interactive_returns_error(
+        self, schwab_broker: SchwabBroker
+    ) -> None:
+        """Non-interactive auth should fail with structured guidance."""
+        with patch("os.isatty", return_value=False):
+            result = await schwab_broker.authenticate()
+
+        assert result is False
+        assert schwab_broker.client is None
+        assert schwab_broker._auth_info.status == BrokerAuthStatus.AUTH_FAILED
+        assert "Interactive authentication required" in (
+            schwab_broker._auth_info.error_message or ""
+        )
 
     @pytest.mark.asyncio
     async def test_authenticate_import_error(self, schwab_broker: SchwabBroker) -> None:

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -8,7 +8,10 @@ from unittest.mock import patch
 
 import pytest
 
-from open_stocks_mcp.tools.session_manager import SessionManager
+from open_stocks_mcp.tools.session_manager import (
+    SessionManager,
+    ensure_authenticated_session,
+)
 
 
 def test_logout_clears_session_state() -> None:
@@ -127,3 +130,68 @@ def test_interactive_mfa_prompt_uses_original_stderr_when_stderr_is_redirected()
     assert "ROBINHOOD MFA REQUIRED" in original_stderr.getvalue()
     assert "Enter verification code:" in original_stderr.getvalue()
     assert "ROBINHOOD MFA REQUIRED" not in redirected_stderr.getvalue()
+
+
+@pytest.mark.unit
+@pytest.mark.journey_account
+@pytest.mark.exception_test
+def test_ensure_authenticated_handles_expired_session_without_exception() -> None:
+    """Expired Robinhood session should fail cleanly without unhandled exception."""
+    manager = SessionManager(session_timeout_hours=0)
+    manager.set_credentials("test_user", "test_pass")
+    manager._is_authenticated = True
+    manager.login_time = datetime.now()
+
+    with patch.object(manager, "_authenticate", return_value=False):
+        result = asyncio.run(manager.ensure_authenticated())
+
+    assert result is False
+
+
+@pytest.mark.unit
+@pytest.mark.journey_account
+@pytest.mark.exception_test
+def test_ensure_authenticated_invalid_credentials_returns_false() -> None:
+    """Invalid credentials should return False and increment failed attempts."""
+    manager = SessionManager()
+    manager.set_credentials("test_user", "test_pass")
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.rh.login",
+            side_effect=Exception("invalid credentials"),
+        ),
+        patch(
+            "open_stocks_mcp.tools.session_manager.rh.load_user_profile",
+            return_value={"id": "123"},
+        ),
+    ):
+        result = asyncio.run(manager.ensure_authenticated())
+
+    assert result is False
+    assert manager._failed_login_attempts == 1
+    assert manager._is_authenticated is False
+
+
+@pytest.mark.unit
+@pytest.mark.journey_account
+@pytest.mark.exception_test
+def test_ensure_authenticated_session_catches_auth_exceptions() -> None:
+    """Public session helper should return tuple instead of propagating errors."""
+    manager = SessionManager()
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.get_session_manager",
+            return_value=manager,
+        ),
+        patch.object(
+            manager,
+            "ensure_authenticated",
+            side_effect=Exception("invalid credentials"),
+        ),
+    ):
+        success, error = asyncio.run(ensure_authenticated_session())
+
+    assert success is False
+    assert error == "invalid credentials"


### PR DESCRIPTION
Closes #173

## Changes
- add reusable exception fixtures for timeout/connection/auth failures in test conftest
- add new exception test module covering Robinhood + Schwab network failure structured responses
- extend session manager tests for expired session, invalid credentials, and helper exception handling
- extend Schwab broker tests for expired token fallback failure and non-interactive auth-failure behavior
- mark relevant error-handling retry/classification scenarios as exception tests

## Test plan
- uv run pytest tests/unit/test_error_handling.py tests/unit/test_network_failures.py -m exception_test -v
- uv run pytest tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py -m exception_test -v
- uv run pytest tests/unit/test_error_handling.py tests/unit/test_network_failures.py tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py -m exception_test -v
- uv run pytest tests/unit/test_error_handling.py tests/unit/test_network_failures.py tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py -m "not slow and not exception_test" -q
- uv run ruff check tests/conftest.py tests/unit/test_error_handling.py tests/unit/test_network_failures.py tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py --fix
- uv run ruff format tests/conftest.py tests/unit/test_error_handling.py tests/unit/test_network_failures.py tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py