### PR TITLE
feat: register 3 missing Schwab MCP tools (place_order, option_buy_to_open, option_sell_to_close)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ ROBINHOOD_PASSWORD="password"
 ## Current Development Status
 
 ### Completed (v0.6.4)
-- ✅ **Phases 0-7**: 79 MCP tools with complete trading functionality (4 deprecated)
+- ✅ **Phases 0-7**: 80 Robinhood + 27 Schwab = 107 MCP tools total (4 deprecated)
 - ✅ **Enhanced Options Tools**: New `get_open_option_positions_with_details()` with call/put enrichment
 - ✅ **Journey Testing**: 11 user journey categories for organized testing
 - ✅ **HTTP Transport**: Server-Sent Events (SSE) on port 3001

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ An MCP (Model Context Protocol) server providing access to stock market data and
 ## Features
 
 **🚀 Current Status: v0.7.0-dev - Multi-Broker Support (Robinhood + Schwab)**
-- ✅ **104 MCP tools** total - 80 Robinhood + 24 Schwab (4 deprecated)
+- ✅ **107 MCP tools** total - 80 Robinhood + 27 Schwab (4 deprecated)
 - ✅ **Multi-broker architecture** - Support for Robinhood and Charles Schwab
 - ✅ **Complete trading functionality** - stocks, options, order management
 - ✅ **Live trading validated** - Robinhood stock and options trading tested with real orders
 - ✅ **Production-ready** - HTTP transport, Docker support, comprehensive testing
-- ✅ **Schwab integration complete** - OAuth authentication, 24 tools ready for testing
+- ✅ **Schwab integration complete** - OAuth authentication, 27 tools ready for testing
 - 🔧 **Account details fixed** - Real financial data instead of N/A values
 
 ## Installation
@@ -155,10 +155,10 @@ Reference docs and runnable examples:
 - All existing Robinhood functionality maintained
 - No breaking changes to existing API
 
-**Schwab Tools (24 tools)**:
+**Schwab Tools (27 tools)**:
 - Account & Portfolio (5 tools) - account numbers, balances, positions
 - Market Data (5 tools) - quotes, price history, instrument search
-- Trading (8 tools) - market/limit buy/sell, order management
+- Trading (11 tools) - market/limit buy/sell, order management, generic order placement, transactions
 - Options (6 tools) - chains, expirations, positions, buy/sell
 
 All Schwab tools use `schwab_` prefix (e.g., `schwab_get_portfolio`, `schwab_buy_stock_market`).
@@ -292,7 +292,7 @@ MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent test
 
 **Completed in v0.7.0-dev:**
 - ✅ **Multi-broker architecture** - Abstract broker layer supporting multiple brokers
-- ✅ **Schwab integration** - 24 tools across account, market data, trading, and options
+- ✅ **Schwab integration** - 27 tools across account, market data, trading, and options
 - ✅ **OAuth authentication** - Schwab OAuth 2.0 flow with automatic token refresh
 - ✅ **Graceful degradation** - Server starts even if broker authentication fails
 - ✅ **Backward compatibility** - All Robinhood tools unchanged, no breaking changes

--- a/SCHWAB_STATUS.md
+++ b/SCHWAB_STATUS.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-The Schwab integration is **fully implemented and merged to main**. All code is production-ready and tested. The integration adds **24 new Schwab MCP tools** alongside the existing **80 Robinhood tools** for a total of **104 tools**.
+The Schwab integration is **fully implemented and merged to main**. All code is production-ready and tested. The integration adds **27 Schwab MCP tools** alongside the existing **80 Robinhood tools** for a total of **107 tools**.
 
 **Next Step**: Apply for Schwab Developer API credentials at https://developer.schwab.com/
 
@@ -38,10 +38,10 @@ The Schwab integration is **fully implemented and merged to main**. All code is 
    - Interactive browser-based OAuth flow
 
 4. **Tool Registration** (Phase 4) ✅
-   - **24 Schwab MCP tools** registered:
+   - **27 Schwab MCP tools** registered:
      - 5 account tools (account_numbers, balances, portfolio, etc.)
      - 5 market data tools (quotes, price history, search)
-     - 8 trading tools (buy/sell market/limit, order management)
+     - 11 trading tools (buy/sell market/limit, order management, generic order, transactions)
      - 6 options tools (chains, expirations, positions, buy/sell)
    - All tools use `schwab_` prefix
    - Clear tool descriptions indicating broker
@@ -102,7 +102,7 @@ docs/
 ```
 
 ### Modified Files (6 files)
-- `src/open_stocks_mcp/server/app.py` - Added 24 Schwab tool registrations (+481 lines)
+- `src/open_stocks_mcp/server/app.py` - Added 27 Schwab tool registrations
 - `src/open_stocks_mcp/tools/error_handling.py` - Added `handle_schwab_errors` decorator
 - `pyproject.toml` - Added `schwab-py>=1.5.0` dependency
 - `README.md` - Updated for multi-broker support
@@ -240,7 +240,7 @@ open-stocks-mcp-server --transport http --port 3001
 ```python
 # List all tools (includes both brokers)
 await list_available_tools()
-# Returns: 104 tools (80 robinhood, 24 schwab)
+# Returns: 107 tools (80 robinhood, 27 schwab)
 
 # Schwab tools are prefixed with "schwab_"
 # Robinhood tools have no prefix (backward compatible)
@@ -306,7 +306,7 @@ if error:
 
 ### When API Approved
 5. Test OAuth authentication flow
-6. Live test all 24 Schwab tools
+6. Live test all 27 Schwab tools
 7. Create Schwab journey tests
 8. Validate multi-broker scenarios
 9. Performance testing with real data

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -152,6 +152,12 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_expirations,
     get_schwab_options_positions,
 )
+from open_stocks_mcp.tools.schwab_options_tools import (
+    schwab_option_buy_to_open as _schwab_option_buy_to_open_impl,
+)
+from open_stocks_mcp.tools.schwab_options_tools import (
+    schwab_option_sell_to_close as _schwab_option_sell_to_close_impl,
+)
 from open_stocks_mcp.tools.schwab_trading_tools import (
     cancel_schwab_order,
     get_schwab_order_by_id,
@@ -163,6 +169,9 @@ from open_stocks_mcp.tools.schwab_trading_tools import (
     schwab_get_transactions_by_date,
     schwab_sell_limit,
     schwab_sell_market,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    place_schwab_order as _place_schwab_order_impl,
 )
 from open_stocks_mcp.tools.session_manager import get_session_manager
 from open_stocks_mcp.tools.unified_watchlist_tools import (
@@ -1292,6 +1301,19 @@ async def schwab_get_order(account_hash: str, order_id: str) -> dict[str, Any]:
     return await get_schwab_order_by_id(account_hash, order_id)
 
 
+@mcp.tool()
+async def schwab_place_order(
+    account_hash: str, order_spec: dict[str, Any]
+) -> dict[str, Any]:
+    """Place a generic order with Schwab.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        order_spec: Order specification dict (use schwab-py order builder functions)
+    """
+    return await _place_schwab_order_impl(account_hash, order_spec)
+
+
 async def schwab_transactions(
     account_hash: str,
     start_date: str | None = None,
@@ -1391,6 +1413,54 @@ async def schwab_options_positions(account_hash: str) -> dict[str, Any]:
         account_hash: Account hash from schwab_account_numbers
     """
     return await get_schwab_options_positions(account_hash)
+
+
+@mcp.tool()
+async def schwab_option_buy_to_open(
+    account_hash: str,
+    symbol: str,
+    quantity: int,
+    option_type: str,
+    strike: float,
+    expiration: str,
+) -> dict[str, Any]:
+    """Buy to open an option position with Schwab (simplified).
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Underlying stock symbol (e.g., 'AAPL')
+        quantity: Number of contracts
+        option_type: 'CALL' or 'PUT'
+        strike: Strike price
+        expiration: Expiration date (YYYY-MM-DD)
+    """
+    return await _schwab_option_buy_to_open_impl(
+        account_hash, symbol, quantity, option_type, strike, expiration
+    )
+
+
+@mcp.tool()
+async def schwab_option_sell_to_close(
+    account_hash: str,
+    symbol: str,
+    quantity: int,
+    option_type: str,
+    strike: float,
+    expiration: str,
+) -> dict[str, Any]:
+    """Sell to close an option position with Schwab (simplified).
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Underlying stock symbol (e.g., 'AAPL')
+        quantity: Number of contracts
+        option_type: 'CALL' or 'PUT'
+        strike: Strike price
+        expiration: Expiration date (YYYY-MM-DD)
+    """
+    return await _schwab_option_sell_to_close_impl(
+        account_hash, symbol, quantity, option_type, strike, expiration
+    )
 
 
 def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -394,3 +394,51 @@ class TestSchwabOptionsTools:
         assert "API Error" in result["result"]["error"]
         if function in {schwab_option_buy_to_open, schwab_option_sell_to_close}:
             _assert_retry_safe(mock_to_thread, False)
+
+
+class TestSchwabOptionMCPWrappers:
+    """Test schwab_option_buy_to_open and schwab_option_sell_to_close MCP wrappers."""
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch("open_stocks_mcp.server.app._schwab_option_buy_to_open_impl")
+    async def test_schwab_option_buy_to_open_mcp_wrapper(
+        self, mock_impl: AsyncMock
+    ) -> None:
+        """Test schwab_option_buy_to_open wrapper delegates to impl with exact args."""
+        from open_stocks_mcp.server.app import schwab_option_buy_to_open
+
+        expected = {"result": {"status": "order_placed", "action": "buy_to_open"}}
+        mock_impl.return_value = expected
+
+        result = await schwab_option_buy_to_open(
+            "hash123", "AAPL", 1, "CALL", 175.0, "2024-01-19"
+        )
+
+        mock_impl.assert_awaited_once_with(
+            "hash123", "AAPL", 1, "CALL", 175.0, "2024-01-19"
+        )
+        assert result == expected
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch("open_stocks_mcp.server.app._schwab_option_sell_to_close_impl")
+    async def test_schwab_option_sell_to_close_mcp_wrapper(
+        self, mock_impl: AsyncMock
+    ) -> None:
+        """Test schwab_option_sell_to_close wrapper delegates to impl with exact args."""
+        from open_stocks_mcp.server.app import schwab_option_sell_to_close
+
+        expected = {"result": {"status": "order_placed", "action": "sell_to_close"}}
+        mock_impl.return_value = expected
+
+        result = await schwab_option_sell_to_close(
+            "hash123", "AAPL", 1, "PUT", 170.0, "2024-01-19"
+        )
+
+        mock_impl.assert_awaited_once_with(
+            "hash123", "AAPL", 1, "PUT", 170.0, "2024-01-19"
+        )
+        assert result == expected

--- a/tests/unit/test_schwab_trading_tools.py
+++ b/tests/unit/test_schwab_trading_tools.py
@@ -645,3 +645,26 @@ class TestSchwabTradingTools:
 
         assert "result" in result
         assert "error" in result["result"]
+
+
+class TestSchwabPlaceOrderMCPWrapper:
+    """Test schwab_place_order MCP wrapper in server app."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch("open_stocks_mcp.server.app._place_schwab_order_impl")
+    async def test_schwab_place_order_mcp_wrapper(
+        self, mock_impl: AsyncMock
+    ) -> None:
+        """Test schwab_place_order wrapper delegates to impl with exact args."""
+        from open_stocks_mcp.server.app import schwab_place_order
+
+        expected = {"result": {"status": "order_placed", "order_id": "1"}}
+        mock_impl.return_value = expected
+
+        order_spec: dict = {"orderType": "MARKET", "quantity": 1}
+        result = await schwab_place_order("hash123", order_spec)
+
+        mock_impl.assert_awaited_once_with("hash123", order_spec)
+        assert result == expected


### PR DESCRIPTION
Closes #188
Closes #205
Closes #206
Closes #207

## Changes

- Import `place_schwab_order`, `schwab_option_buy_to_open`, `schwab_option_sell_to_close` from their respective tool modules under private aliases (`_*_impl`) to prevent name shadowing by the `@mcp.tool()` wrappers
- Add `@mcp.tool()` wrapper `schwab_place_order` after `schwab_get_order` in the Schwab trading section of `server/app.py`
- Add `@mcp.tool()` wrappers `schwab_option_buy_to_open` and `schwab_option_sell_to_close` after `schwab_options_positions` in the Schwab options section
- `grep -cE "^async def schwab_" src/open_stocks_mcp/server/app.py` now returns `27` (was 24)
- Update README.md, SCHWAB_STATUS.md, CLAUDE.md to reflect 80 Robinhood + 27 Schwab = 107 total tools

## Test plan

- [ ] 3 new MCP wrapper tests pass: `pytest tests/unit/test_schwab_trading_tools.py tests/unit/test_schwab_options_tools.py -k mcp_wrapper`
- [ ] Full Schwab test suites pass: `pytest tests/unit/test_schwab_trading_tools.py tests/unit/test_schwab_options_tools.py -m "not exception_test"`
- [ ] Journey tests pass: `pytest tests/unit tests/server -m "journey_trading or journey_options" --ignore=tests/integration`
- [ ] `mypy src/open_stocks_mcp/server/app.py` — zero errors
- [ ] `ruff check src/open_stocks_mcp/server/app.py` — zero issues