### PR TITLE
fix: restore MFA code prompt handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ All Schwab tools use `schwab_` prefix (e.g., `schwab_get_portfolio`, `schwab_buy
 
 The server handles Robinhood's authentication requirements:
 - **App-Push Approval**: Automatic handling of app-based device approval (approve via Robinhood mobile app).
-- **SMS/Email MFA**: Support for code-based verification using the `ROBINHOOD_MFA_CODE` environment variable or interactive terminal input.
+- **SMS/Email MFA Code**: Set `ROBINHOOD_MFA_CODE` before login attempts to complete code-based verification (time-sensitive, typically 5-10 minutes).
 - **Session Persistence**: Cached and encrypted authentication to reduce re-verification.
 
 ## Development

--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -392,10 +392,12 @@ docker-compose restart
 *MFA/2FA Issues:*
 The server supports two primary authentication flows for Robinhood:
 
-1.  **App-Push Approval (Recommended)**: Check your Robinhood mobile app and approve the login notification. This is the only flow that works with detached containers without additional configuration.
-2.  **SMS/Email MFA Code**: Detached Docker containers cannot interactively prompt for codes. To use a code-based flow:
-    -   Set `ROBINHOOD_MFA_CODE=123456` in your `.env` file and restart.
-    -   Note: MFA codes expire quickly. Once the session is successfully cached (check `docker-compose logs`), remove the code from your `.env` file and restart to avoid unnecessary login attempts.
+1.  **App-Push Approval (Recommended)**: Passive default flow. Approve the login notification in your Robinhood mobile app; no MFA env vars are needed.
+2.  **SMS/Email MFA Code**: Detached Docker containers cannot do interactive code entry. For code-based challenges:
+    -   Set `ROBINHOOD_MFA_CODE=<current_code>` in `.env` or under `environment:` in `docker-compose.yml`.
+    -   Run `docker-compose restart` before retrying login so the container receives the current code.
+    -   Codes are single-use and time-sensitive; update the env var each attempt.
+    -   If `ROBINHOOD_MFA_CODE` is unset during an SMS/email challenge, login will wait for verification and eventually time out.
 
 ### Debug Mode
 

--- a/src/open_stocks_mcp/tools/session_manager.py
+++ b/src/open_stocks_mcp/tools/session_manager.py
@@ -262,6 +262,44 @@ class SessionManager:
 
         return ""
 
+    def _handle_login_prompt(self, prompt: str = "") -> str:
+        """Handle Robin Stocks login prompts for MFA and device approval."""
+        logger.info(f"Robin Stocks prompt: {prompt}")
+
+        prompt_lower = prompt.lower()
+
+        if any(
+            keyword in prompt_lower
+            for keyword in ["code", "sms", "email", "verification", "mfa", "2fa"]
+        ):
+            logger.warning(f"MFA/Verification code required: {prompt}")
+            mfa_code = os.environ.get("ROBINHOOD_MFA_CODE", "").strip()
+            if mfa_code:
+                logger.info("Using ROBINHOOD_MFA_CODE from environment for MFA prompt")
+                return mfa_code
+
+            logger.info("Authentication requires MFA. This may indicate:")
+            logger.info("1. A new device needs verification")
+            logger.info("2. Session cache may be corrupted")
+            logger.info("3. Account has enhanced security enabled")
+            logger.info("Suggestion: Clear session cache and try fresh login")
+            logger.warning(
+                "Set ROBINHOOD_MFA_CODE env var with the time-sensitive code before retrying."
+            )
+            return ""
+
+        if any(
+            keyword in prompt_lower
+            for keyword in ["app", "device", "approval", "notification", "push"]
+        ):
+            logger.info(f"Device approval required: {prompt}")
+            logger.info("Please check your Robinhood mobile app and approve the device")
+            logger.info("Waiting for approval...")
+            return ""
+
+        logger.debug(f"Returning empty string for prompt: {prompt}")
+        return ""
+
     async def ensure_authenticated(self) -> bool:
         """Ensure session is authenticated, re-authenticating if necessary.
 
@@ -372,53 +410,7 @@ class SessionManager:
 
                 def mock_input(prompt: str = "") -> str:
                     """Mock input function that handles various Robin Stocks prompts."""
-                    logger.info(f"Robin Stocks prompt: {prompt}")
-
-                    # Handle MFA code requests more gracefully
-                    if any(
-                        keyword in prompt.lower()
-                        for keyword in [
-                            "code",
-                            "sms",
-                            "email",
-                            "verification",
-                            "mfa",
-                            "2fa",
-                        ]
-                    ):
-                        logger.warning(f"MFA/Verification code required: {prompt}")
-                        logger.info("Authentication requires MFA. This may indicate:")
-                        logger.info("1. A new device needs verification")
-                        logger.info("2. Session cache may be corrupted")
-                        logger.info("3. Account has enhanced security enabled")
-                        logger.info(
-                            "Suggestion: Clear session cache and try fresh login"
-                        )
-
-                        # Attempt to resolve the code
-                        return self._resolve_mfa_code()
-
-                    # Handle device approval prompts
-                    if any(
-                        keyword in prompt.lower()
-                        for keyword in [
-                            "app",
-                            "device",
-                            "approval",
-                            "notification",
-                            "push",
-                        ]
-                    ):
-                        logger.info(f"Device approval required: {prompt}")
-                        logger.info(
-                            "Please check your Robinhood mobile app and approve the device"
-                        )
-                        logger.info("Waiting for approval...")
-                        return ""
-
-                    # Handle any other prompts
-                    logger.debug(f"Returning empty string for prompt: {prompt}")
-                    return ""
+                    return self._handle_login_prompt(prompt)
 
                 # Temporarily replace input function
                 if isinstance(__builtins__, dict):

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -11,6 +11,39 @@ import pytest
 from open_stocks_mcp.tools.session_manager import SessionManager
 
 
+def test_handle_login_prompt_returns_mfa_code_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MFA code prompts should return ROBINHOOD_MFA_CODE when set."""
+    manager = SessionManager()
+    monkeypatch.setenv("ROBINHOOD_MFA_CODE", "123456")
+
+    result = manager._handle_login_prompt("Please enter the verification code: ")
+
+    assert result == "123456"
+
+
+def test_handle_login_prompt_returns_empty_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MFA prompts should return empty string when code env var is missing."""
+    manager = SessionManager()
+    monkeypatch.delenv("ROBINHOOD_MFA_CODE", raising=False)
+
+    result = manager._handle_login_prompt("Enter SMS code: ")
+
+    assert result == ""
+
+
+def test_handle_login_prompt_returns_empty_for_device_approval() -> None:
+    """Device approval prompts should continue returning empty string."""
+    manager = SessionManager()
+
+    result = manager._handle_login_prompt("Approve this device in the Robinhood app")
+
+    assert result == ""
+
+
 def test_logout_clears_session_state() -> None:
     """Logout should clear authentication state and timestamps."""
     manager = SessionManager()


### PR DESCRIPTION
Closes #486

## Changes
- extracted SessionManager._handle_login_prompt() so login prompt behavior is testable without calling rh.login
- added explicit ROBINHOOD_MFA_CODE environment lookup for SMS/email/code MFA prompts and kept empty-string fallback with clear warning when unset
- preserved existing app/device approval behavior (logs guidance and returns empty string)
- added unit tests for code-based prompt (env set/unset) and app/device approval prompt handling
- updated authentication docs in root README and Docker README to distinguish app-push approval vs ROBINHOOD_MFA_CODE workflow

## Test plan
- uv run pytest tests/unit/test_session_manager.py -v
- uv run pytest -m "not slow and not exception_test" (currently fails at collection due existing repo issue in tests/integration/conftest.py defining non-top-level pytest_plugins)
- uv run ruff check . (currently fails due pre-existing unrelated lint findings in broker/request-policy and other files)
- uv run ruff format --check . (currently fails due pre-existing formatting drift in unrelated files)
- uv run mypy .
- grep -n "ROBINHOOD_MFA_CODE" README.md examples/open-stocks-mcp-docker/README.md
