### PR TITLE
test: add read-only market/research ADK evals

### DIFF
--- a/tests/evals/2_mkt_price_history_test.json
+++ b/tests/evals/2_mkt_price_history_test.json
@@ -1,0 +1,49 @@
+{
+  "eval_set_id": "price_history_test_set",
+  "name": "Price History Test",
+  "description": "Test case for retrieving weekly historical pricing through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "price_history_test",
+      "conversation": [
+        {
+          "invocation_id": "price-history-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me the weekly price history for AAPL."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the weekly price history summary for AAPL. I retrieved recent OHLC data points and volume from the market data feed, which you can use to review trend direction over the last week."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "period": "week"
+                },
+                "name": "price_history"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_stock_earnings_test.json
+++ b/tests/evals/2_mkt_stock_earnings_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "stock_earnings_test_set",
+  "name": "Stock Earnings Test",
+  "description": "Test case for retrieving earnings history through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "stock_earnings_test",
+      "conversation": [
+        {
+          "invocation_id": "stock-earnings-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me Microsoft's (MSFT) recent earnings reports."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I pulled recent earnings information for Microsoft (MSFT), including report periods and headline results for quick review."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "MSFT"
+                },
+                "name": "stock_earnings"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_stock_news_test.json
+++ b/tests/evals/2_mkt_stock_news_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "stock_news_test_set",
+  "name": "Stock News Test",
+  "description": "Test case for retrieving stock news through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "stock_news_test",
+      "conversation": [
+        {
+          "invocation_id": "stock-news-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Get the latest news for Tesla (TSLA)."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I retrieved the latest available news items for Tesla (TSLA), including recent headlines and publisher metadata."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "TSLA"
+                },
+                "name": "stock_news"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_stock_ratings_test.json
+++ b/tests/evals/2_mkt_stock_ratings_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "stock_ratings_test_set",
+  "name": "Stock Ratings Test",
+  "description": "Test case for retrieving analyst ratings through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "stock_ratings_test",
+      "conversation": [
+        {
+          "invocation_id": "stock-ratings-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What do analysts say about Apple (AAPL)?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I retrieved analyst ratings data for Apple (AAPL), including consensus views and distribution across recommendation categories."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL"
+                },
+                "name": "stock_ratings"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_stock_splits_test.json
+++ b/tests/evals/2_mkt_stock_splits_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "stock_splits_test_set",
+  "name": "Stock Splits Test",
+  "description": "Test case for retrieving stock split history through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "stock_splits_test",
+      "conversation": [
+        {
+          "invocation_id": "stock-splits-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Has Apple (AAPL) had any stock splits?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I retrieved Apple (AAPL) stock split history, including split dates and split ratios where available."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL"
+                },
+                "name": "stock_splits"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_top_100_stocks_test.json
+++ b/tests/evals/2_mkt_top_100_stocks_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "top_100_stocks_test_set",
+  "name": "Top 100 Stocks Test",
+  "description": "Test case for retrieving the top 100 popular stocks through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "top_100_stocks_test",
+      "conversation": [
+        {
+          "invocation_id": "top-100-stocks-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "List the 100 most popular stocks on Robinhood."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I retrieved the top 100 popular Robinhood stocks. The list provides ranked symbols and associated market details, which you can use as a quick popularity snapshot."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "top_100_stocks"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_top_movers_sp500_test.json
+++ b/tests/evals/2_mkt_top_movers_sp500_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "top_movers_sp500_test_set",
+  "name": "Top Movers S&P 500 Test",
+  "description": "Test case for retrieving top S&P 500 movers through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "top_movers_sp500_test",
+      "conversation": [
+        {
+          "invocation_id": "top-movers-sp500-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What are today's top S&P 500 gainers?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I pulled the top S&P 500 gainers for today. The response includes leading symbols, price changes, and percentage moves so you can quickly see the strongest performers."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "direction": "up"
+                },
+                "name": "top_movers_sp500"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_top_movers_test.json
+++ b/tests/evals/2_mkt_top_movers_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "top_movers_test_set",
+  "name": "Top Movers Test",
+  "description": "Test case for retrieving top market movers through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "top_movers_test",
+      "conversation": [
+        {
+          "invocation_id": "top-movers-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me today's top 20 movers on Robinhood."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I fetched today's top movers list from Robinhood market data. The results include symbols and move percentages to help identify the biggest gainers and losers."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "top_movers"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -306,7 +306,38 @@ adk eval examples/google_adk_agent tests/evals/4_ntf_referrals_test.json --confi
 adk eval examples/google_adk_agent tests/evals/4_ntf_account_features_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 6. Creating Custom Evaluation Tests
+### 6. Market & Research Read-Only Evaluations (`2_mkt_*`)
+
+Read-only evals for market and research MCP tools. These scenarios must remain non-trading and non-mutating.
+
+Credential assumptions:
+- Requires `GOOGLE_API_KEY` and read-only `ROBINHOOD_USERNAME`/`ROBINHOOD_PASSWORD`.
+- No order placement, cancellation, watchlist mutation, or trading tool usage is permitted.
+
+Files and tool coverage:
+- `tests/evals/2_mkt_market_hours_test.json` - `market_hours`
+- `tests/evals/2_mkt_search_stocks_test.json` - `stocks_by_tag`
+- `tests/evals/2_mkt_stock_price_test.json` - `stock_price`
+- `tests/evals/2_mkt_stock_info_test.json` - `stock_info`
+- `tests/evals/2_mkt_price_history_test.json` - `price_history`
+- `tests/evals/2_mkt_top_movers_sp500_test.json` - `top_movers_sp500`
+- `tests/evals/2_mkt_top_100_stocks_test.json` - `top_100_stocks`
+- `tests/evals/2_mkt_top_movers_test.json` - `top_movers`
+- `tests/evals/2_mkt_stock_ratings_test.json` - `stock_ratings`
+- `tests/evals/2_mkt_stock_earnings_test.json` - `stock_earnings`
+- `tests/evals/2_mkt_stock_news_test.json` - `stock_news`
+- `tests/evals/2_mkt_stock_splits_test.json` - `stock_splits`
+- `tests/evals/2_mkt_schwab_quote_test.json` - `schwab_quote`
+- `tests/evals/2_mkt_schwab_price_history_test.json` - `schwab_price_history`
+- `tests/evals/2_mkt_schwab_search_instruments_test.json` - `schwab_search_instruments`
+
+Command pattern:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/2_mkt_stock_news_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 7. Creating Custom Evaluation Tests
 
 #### Test File Structure
 ```json


### PR DESCRIPTION
Closes #181

## Changes
- Added 8 new read-only ADK eval fixtures for market/research tools under `tests/evals/2_mkt_*_test.json`.
- Updated `tests/evals/ADK-testing-evals.md` with a dedicated Market & Research read-only section.
- Enumerated the full `2_mkt_*` eval set now present in this repository (including existing Schwab market evals).
- Kept scenarios strictly non-trading/non-mutating (no order or watchlist mutation tools).

## Test plan
- `uv run python -c "import glob; files=glob.glob('tests/evals/2_mkt_*_test.json'); assert len(files)>=15"` (pre-change, expected fail)
- `uv run python -c "import json,glob; files=sorted(glob.glob('tests/evals/2_mkt_*_test.json')); assert len(files)==15, files; [json.load(open(p)) for p in files]; print('ok', len(files))"`
- `rg --files tests/evals | rg '2_mkt_.*_test\\.json$'`
- `rg -l 'buy_|sell_|add_to_watchlist|remove_from_watchlist|order_' tests/evals/2_mkt_*_test.json` (expect no output)
- `uv run python - <<'PY' ...` (manifest includes every `2_mkt_*` eval file literal)
- `adk eval examples/google_adk_agent tests/evals/2_mkt_stock_news_test.json --config_file_path tests/evals/test_config.json` (fails in local environment with ADK MCP session/cancel-scope error; captured in verification evidence)