### PR TITLE
feat: add watchlist and notification read-only ADK eval tranche

### DIFF
--- a/tests/evals/3_wth_all_watchlists_test.json
+++ b/tests/evals/3_wth_all_watchlists_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "wth_all_watchlists_test_set",
+  "name": "All Watchlists Test",
+  "description": "Read-only eval that exercises the all_watchlists tool to list all Robinhood watchlists. Does not invoke add_to_watchlist, remove_from_watchlist, or any trading/mutation tool.",
+  "eval_cases": [
+    {
+      "eval_id": "wth_all_watchlists_test",
+      "conversation": [
+        {
+          "invocation_id": "wth-all-watchlists-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me all of my Robinhood watchlists."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Robinhood watchlists. Each watchlist is listed with its name and the number of symbols it contains."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "all_watchlists"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/3_wth_watchlist_by_name_test.json
+++ b/tests/evals/3_wth_watchlist_by_name_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "wth_watchlist_by_name_test_set",
+  "name": "Watchlist By Name Test",
+  "description": "Read-only eval that exercises the watchlist_by_name tool to retrieve contents of a named watchlist. Assumes a watchlist named 'Tech Stocks' exists in the live account; rename the watchlist_name arg to an existing watchlist before running live. Does not invoke any mutation or trading tool.",
+  "eval_cases": [
+    {
+      "eval_id": "wth_watchlist_by_name_test",
+      "conversation": [
+        {
+          "invocation_id": "wth-watchlist-by-name-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me the contents of my Tech Stocks watchlist."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the contents of your Tech Stocks watchlist. The watchlist contains the following symbols."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"watchlist_name": "Tech Stocks"},
+                "name": "watchlist_by_name"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/3_wth_watchlist_performance_test.json
+++ b/tests/evals/3_wth_watchlist_performance_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "wth_watchlist_performance_test_set",
+  "name": "Watchlist Performance Test",
+  "description": "Read-only eval that exercises the watchlist_performance tool to analyze performance of a named watchlist. Assumes a watchlist named 'Tech Stocks' exists in the live account; rename the watchlist_name arg to an existing watchlist before running live. Does not invoke any mutation or trading tool.",
+  "eval_cases": [
+    {
+      "eval_id": "wth_watchlist_performance_test",
+      "conversation": [
+        {
+          "invocation_id": "wth-watchlist-performance-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Analyze the performance of my Tech Stocks watchlist."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the performance analysis of your Tech Stocks watchlist. The results include price and percentage change data for each symbol in the watchlist."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"watchlist_name": "Tech Stocks"},
+                "name": "watchlist_performance"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_account_features_test.json
+++ b/tests/evals/4_ntf_account_features_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "ntf_account_features_test_set",
+  "name": "Account Features Test",
+  "description": "Read-only eval that exercises the account_features tool to summarize Robinhood account features. This tool aggregates subscription, margin, notification, and referral data and may return partial_success if one source is unavailable. Does not invoke any trading or account-mutation tool.",
+  "eval_cases": [
+    {
+      "eval_id": "ntf_account_features_test",
+      "conversation": [
+        {
+          "invocation_id": "ntf-account-features-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Summarize my Robinhood account features."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is a summary of your Robinhood account features. The summary includes available subscription, margin, notification, and referral information for your account."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "account_features"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_latest_notification_test.json
+++ b/tests/evals/4_ntf_latest_notification_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "ntf_latest_notification_test_set",
+  "name": "Latest Notification Test",
+  "description": "Read-only eval that exercises the latest_notification tool to retrieve the most recent account notification. The live account may legitimately return no notification. Does not invoke any trading or account-mutation tool.",
+  "eval_cases": [
+    {
+      "eval_id": "ntf_latest_notification_test",
+      "conversation": [
+        {
+          "invocation_id": "ntf-latest-notification-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my latest Robinhood notification."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your latest Robinhood notification. The notification includes its type, message, and timestamp."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "latest_notification"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_margin_calls_test.json
+++ b/tests/evals/4_ntf_margin_calls_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "ntf_margin_calls_test_set",
+  "name": "Margin Calls Test",
+  "description": "Read-only eval that exercises the margin_calls tool to check for active margin calls. The live account may legitimately return no margin calls. Does not invoke any trading or account-mutation tool.",
+  "eval_cases": [
+    {
+      "eval_id": "ntf_margin_calls_test",
+      "conversation": [
+        {
+          "invocation_id": "ntf-margin-calls-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Check whether I have any margin calls."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I have checked your account for margin calls. Your account currently has no active margin calls, or the margin call details are listed above."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "margin_calls"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_margin_interest_test.json
+++ b/tests/evals/4_ntf_margin_interest_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "ntf_margin_interest_test_set",
+  "name": "Margin Interest Test",
+  "description": "Read-only eval that exercises the margin_interest tool to retrieve margin interest charges and current rate. The live account may legitimately return no margin interest data if the account does not use margin. Does not invoke any trading or account-mutation tool.",
+  "eval_cases": [
+    {
+      "eval_id": "ntf_margin_interest_test",
+      "conversation": [
+        {
+          "invocation_id": "ntf-margin-interest-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my margin interest charges and current rate."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your margin interest charges and current rate. The data includes any interest accrued on margin balances."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "margin_interest"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_notifications_test.json
+++ b/tests/evals/4_ntf_notifications_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "ntf_notifications_test_set",
+  "name": "Notifications Test",
+  "description": "Read-only eval that exercises the notifications tool to retrieve recent account notifications. The live account may legitimately return an empty list. Does not invoke any trading or account-mutation tool.",
+  "eval_cases": [
+    {
+      "eval_id": "ntf_notifications_test",
+      "conversation": [
+        {
+          "invocation_id": "ntf-notifications-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my five most recent account notifications."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your five most recent account notifications. Each notification includes its type, message, and timestamp."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"count": 5},
+                "name": "notifications"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_referrals_test.json
+++ b/tests/evals/4_ntf_referrals_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "ntf_referrals_test_set",
+  "name": "Referrals Test",
+  "description": "Read-only eval that exercises the referrals tool to retrieve Robinhood referral program status. The live account may legitimately return no referral data. Does not invoke any trading or account-mutation tool.",
+  "eval_cases": [
+    {
+      "eval_id": "ntf_referrals_test",
+      "conversation": [
+        {
+          "invocation_id": "ntf-referrals-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my Robinhood referral program status."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Robinhood referral program status. The data includes any referral rewards or pending referrals associated with your account."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "referrals"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/4_ntf_subscription_fees_test.json
+++ b/tests/evals/4_ntf_subscription_fees_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "ntf_subscription_fees_test_set",
+  "name": "Subscription Fees Test",
+  "description": "Read-only eval that exercises the subscription_fees tool to retrieve Robinhood Gold subscription fee history. The live account may legitimately return no fees if not subscribed to Gold. Does not invoke any trading or account-mutation tool.",
+  "eval_cases": [
+    {
+      "eval_id": "ntf_subscription_fees_test",
+      "conversation": [
+        {
+          "invocation_id": "ntf-subscription-fees-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show my Robinhood Gold subscription fee history."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Robinhood Gold subscription fee history. The data includes any subscription fees charged to your account."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "subscription_fees"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -176,7 +176,51 @@ adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_expirations_t
 adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 4. Creating Custom Evaluation Tests
+### 4. Watchlist Read-Only Evaluations (`3_wth_*`)
+
+Read-only evals that exercise the three Robinhood watchlist query tools. These do not invoke `add_to_watchlist`, `remove_from_watchlist`, or any order-placement or account-mutation tool.
+
+- `tests/evals/3_wth_all_watchlists_test.json` — exercises `all_watchlists` with empty args to list all account watchlists.
+- `tests/evals/3_wth_watchlist_by_name_test.json` — exercises `watchlist_by_name` with `{"watchlist_name": "Tech Stocks"}` to retrieve contents of a named watchlist.
+- `tests/evals/3_wth_watchlist_performance_test.json` — exercises `watchlist_performance` with `{"watchlist_name": "Tech Stocks"}` to analyze price and percentage changes for symbols in a named watchlist.
+
+**Credential assumptions**: Requires `GOOGLE_API_KEY`, a running MCP server, and Robinhood read credentials. The `watchlist_by_name` and `watchlist_performance` scenarios assume a watchlist named `Tech Stocks` exists in the live account. Rename `watchlist_name` to an existing watchlist before running those two evals against a live account.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/3_wth_all_watchlists_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/3_wth_watchlist_by_name_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/3_wth_watchlist_performance_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 5. Notifications and Account Features Read-Only Evaluations (`4_ntf_*`)
+
+Read-only evals that exercise seven notification and account-feature query tools. These do not invoke any order-placement, watchlist-mutation, or account-modification tool. The live account may legitimately return empty or no-data responses for notifications, margin, fees, or referrals.
+
+- `tests/evals/4_ntf_notifications_test.json` — exercises `notifications` with `{"count": 5}` to retrieve the five most recent account notifications.
+- `tests/evals/4_ntf_latest_notification_test.json` — exercises `latest_notification` with empty args to retrieve the single most recent notification.
+- `tests/evals/4_ntf_margin_calls_test.json` — exercises `margin_calls` with empty args to check for active margin calls.
+- `tests/evals/4_ntf_margin_interest_test.json` — exercises `margin_interest` with empty args to retrieve margin interest charges and current rate.
+- `tests/evals/4_ntf_subscription_fees_test.json` — exercises `subscription_fees` with empty args to retrieve Robinhood Gold subscription fee history.
+- `tests/evals/4_ntf_referrals_test.json` — exercises `referrals` with empty args to retrieve referral program status.
+- `tests/evals/4_ntf_account_features_test.json` — exercises `account_features` with empty args to summarize available subscription, margin, notification, and referral features; may return `partial_success` if one data source is unavailable.
+
+**Credential assumptions**: Requires `GOOGLE_API_KEY`, a running MCP server, and Robinhood read credentials. All tools may return empty data on accounts without margin, Gold subscriptions, or referrals — this is an expected valid outcome, not a failure.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/4_ntf_notifications_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_latest_notification_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_margin_calls_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_margin_interest_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_subscription_fees_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_referrals_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/4_ntf_account_features_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 6. Creating Custom Evaluation Tests
 
 #### Test File Structure
 ```json


### PR DESCRIPTION
Closes #182

## Changes
- Add 3 read-only watchlist eval JSONs (`3_wth_all_watchlists_test.json`, `3_wth_watchlist_by_name_test.json`, `3_wth_watchlist_performance_test.json`) covering `all_watchlists`, `watchlist_by_name`, and `watchlist_performance` tools
- Add 7 read-only notification/account-feature eval JSONs (`4_ntf_notifications_test.json`, `4_ntf_latest_notification_test.json`, `4_ntf_margin_calls_test.json`, `4_ntf_margin_interest_test.json`, `4_ntf_subscription_fees_test.json`, `4_ntf_referrals_test.json`, `4_ntf_account_features_test.json`) covering all seven notification tools
- Update `tests/evals/ADK-testing-evals.md` with "Watchlist Read-Only Evaluations" and "Notifications and Account Features Read-Only Evaluations" subsections documenting all 10 files, exact tools exercised, run commands, and credential assumptions
- No eval invokes `add_to_watchlist`, `remove_from_watchlist`, or any trading/mutation tool

## Test plan
- `python -c "import json,glob; files=sorted(glob.glob('tests/evals/[34]_*_test.json')); assert len(files)==10, files; [json.load(open(p)) for p in files]; print('ok')"` — confirms all 10 files exist and parse as valid JSON
- `grep -l '"name": "add_to_watchlist"...' tests/evals/3_wth_*_test.json tests/evals/4_ntf_*_test.json` — returns no files (no mutation tool refs)
- All 10 files reference unique tool names verified against `src/open_stocks_mcp/server/app.py` registrations
- ADK live runs require `GOOGLE_API_KEY`, a running MCP server, and Robinhood read credentials; `watchlist_by_name`/`watchlist_performance` assume a `Tech Stocks` watchlist exists