### PR TITLE
docs: reconcile schwab roadmap documentation

### DIFF
--- a/SCHWAB_STATUS.md
+++ b/SCHWAB_STATUS.md
@@ -13,6 +13,24 @@ The Schwab integration is **fully implemented and merged to main**. All code is 
 
 **Next Step**: Apply for Schwab Developer API credentials at https://developer.schwab.com/
 
+
+## Roadmap Reconciliation
+
+This status page documents the currently implemented **24 Schwab MCP tools** as the shipped core surface.
+
+The broader comparison-roadmap target (67 parity tools plus 9 Schwab bonus tools) is tracked as decomposition work under parent issue #187 and child issues:
+- #192 account/profile consolidation
+- #193 portfolio computed tools
+- #194 market data expansion
+- #195 options expansion
+- #196 trading expansion (including order replacement coverage)
+- #197 dividends and payment extraction
+- #198 margin and notifications mapping
+- #199 streaming tools expansion
+- #127 Schwab transaction history bonus tools
+
+Roadmap deferral and not-applicable scope decisions are tracked in #201 and mirrored in `docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md`.
+
 ---
 
 ## What's Complete ✅

--- a/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
+++ b/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
@@ -432,24 +432,31 @@
 
 ---
 
-## Open Questions
+## Roadmap Reconciliation
 
-1. **Watchlist Replacement**: Should we build a persistent watchlist storage layer?
-   - **Option A**: SQLite database for MCP server
-   - **Option B**: JSON file storage
-   - **Option C**: Let users manage externally
+The current implementation remains a 24-tool Schwab core. The broader parity roadmap from this document is tracked as decomposition work under parent issue #187.
 
-2. **Missing Data Sources**: Should we integrate 3rd party APIs for news/earnings?
-   - **Option A**: Add as separate tools (e.g., `alpha_vantage_get_earnings`)
-   - **Option B**: Transparent fallback from Schwab tools
-   - **Option C**: Document as limitation
+| Category | Decision | Tracking |
+|---|---|---|
+| Account/profile consolidation | Implement in dedicated follow-up issue | #192 |
+| Portfolio computed tools | Implement in dedicated follow-up issue | #193 |
+| Expanded market data | Implement in dedicated follow-up issue | #194 |
+| Options expansion | Implement in dedicated follow-up issue | #195 |
+| Trading expansion and order replacement | Implement in dedicated follow-up issue | #196 |
+| Dividends and payment extraction | Implement in dedicated follow-up issue | #197 |
+| Margin and notifications mapping | Implement in dedicated follow-up issue | #198 |
+| Streaming expansion | Implement in dedicated follow-up issue | #199 |
+| Transaction history Schwab bonus tools | Implement in dedicated follow-up issue | #127 |
+| Remaining roadmap deferrals and not-applicable scope | Documented as explicit decisions | #201 |
 
-3. **Streaming Architecture**: How to expose Schwab streaming in MCP?
-   - **Option A**: Use SSE endpoint for streaming quotes
-   - **Option B**: Polling with cached data
-   - **Option C**: WebSocket support (Phase 6+)
+## Decisions
 
----
+- Watchlists: deferred to client-side storage patterns; no Schwab-native watchlist API is available.
+- Missing research data (earnings, ratings, news, events, splits): deferred to a future third-party integration; we will not add a transparent Schwab fallback that implies this data exists in Schwab.
+- Historical options pricing: unavailable in the Schwab API; this remains a documented gap unless a new external data source is added.
+- Cryptocurrency tools: not applicable to Schwab scope because Schwab does not expose crypto trading in this MCP surface.
+- Robinhood-specific referrals, subscriptions, and account-feature flags: not applicable to Schwab scope.
+- Streaming exposure: tracked through broker capability baseline work and the dedicated Schwab streaming expansion issue #199.
 
 ## Conclusion
 


### PR DESCRIPTION
Closes #187

## Changes
- Added a `Roadmap Reconciliation` section to `docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md` that maps remaining Schwab categories to child issues (#192, #193, #194, #195, #196, #197, #198, #199, #127, #201).
- Replaced the prior `Open Questions` option list with explicit `Decisions` for watchlists, missing research data sources, historical options pricing, crypto scope, Robinhood-only features, and streaming expansion routing.
- Added a `Roadmap Reconciliation` section to `SCHWAB_STATUS.md` clarifying the current 24-tool core and linking broader roadmap ownership to #187 and child issues.

## Test plan
- `uv run python - <<'PY'
from pathlib import Path
text = Path('docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md').read_text()
required = ['#192', '#193', '#194', '#195', '#196', '#197', '#198', '#199', '#201', '#127', 'Roadmap Reconciliation', '## Decisions']
missing = [item for item in required if item not in text]
forbidden = ['## Open Questions', 'Option A', 'Option B', 'Option C']
leftovers = [item for item in forbidden if item in text]
if missing or leftovers:
    raise SystemExit(f'missing={missing} leftovers={leftovers}')
PY`
- `uv run python - <<'PY'
from pathlib import Path
text = Path('SCHWAB_STATUS.md').read_text()
required = ['24 Schwab MCP tools', 'Roadmap Reconciliation', '#187', '#192', '#194', '#196', '#197', '#199', '#201']
missing = [item for item in required if item not in text]
forbidden = ['docs/SCHWAB_STATUS.md']
leftovers = [item for item in forbidden if item in text]
if missing or leftovers:
    raise SystemExit(f'missing={missing} leftovers={leftovers}')
PY`
- `uv run pytest tests/server/test_server_app.py::TestToolRegistration::test_tools_are_registered -q`
