### PR TITLE
feat: add ADK eval JSONs for profiles, advanced, and options-data tools

### DIFF
--- a/tests/evals/6_prf_account_profile_test.json
+++ b/tests/evals/6_prf_account_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "account_profile_test_set",
+  "name": "Account Profile Test",
+  "description": "Test case for retrieving Robinhood account profile data through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "account_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "account-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Robinhood account profile in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Robinhood account profile:\n\n*   **Account Number**: ...\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "account_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_basic_profile_test.json
+++ b/tests/evals/6_prf_basic_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "basic_profile_test_set",
+  "name": "Basic Profile Test",
+  "description": "Test case for retrieving Robinhood basic user profile data through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "basic_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "basic-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What is my basic profile information on Robinhood? Show it as a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your basic Robinhood profile:\n\n*   **Name**: ...\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "basic_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_complete_profile_test.json
+++ b/tests/evals/6_prf_complete_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "complete_profile_test_set",
+  "name": "Complete Profile Test",
+  "description": "Test case for retrieving all Robinhood profile data in a single consolidated response through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "complete_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "complete-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my complete Robinhood profile including account, basic info, and investment settings in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your complete Robinhood profile:\n\n*   **Account Profile**: ...\n*   **Basic Profile**: ...\n*   **Investment Profile**: ...\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "complete_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_investment_profile_test.json
+++ b/tests/evals/6_prf_investment_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "investment_profile_test_set",
+  "name": "Investment Profile Test",
+  "description": "Test case for retrieving Robinhood investment profile and risk tolerance data through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "investment_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "investment-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my investment profile and risk tolerance settings in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your investment profile:\n\n*   **Investment Objective**: ...\n*   **Risk Tolerance**: ...\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "investment_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_security_profile_test.json
+++ b/tests/evals/6_prf_security_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "security_profile_test_set",
+  "name": "Security Profile Test",
+  "description": "Test case for retrieving Robinhood account security profile data through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "security_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "security-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Robinhood security profile information in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Robinhood security profile:\n\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "security_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/6_prf_user_profile_test.json
+++ b/tests/evals/6_prf_user_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "user_profile_test_set",
+  "name": "User Profile Test",
+  "description": "Test case for retrieving Robinhood user profile details through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "user_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "user-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Robinhood user profile details in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Robinhood user profile:\n\n*   **Username**: ...\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "user_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_aggregate_option_positions_test.json
+++ b/tests/evals/8_opt_aggregate_option_positions_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "aggregate_option_positions_test_set",
+  "name": "Aggregate Option Positions Test",
+  "description": "Test case for retrieving aggregated options exposure grouped by underlying stock through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "aggregate_option_positions_test",
+      "conversation": [
+        {
+          "invocation_id": "aggregate-option-positions-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my aggregate options exposure grouped by underlying stock in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your aggregate option positions by underlying:\n\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "aggregate_option_positions"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_open_option_positions_with_details_test.json
+++ b/tests/evals/8_opt_open_option_positions_with_details_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "open_option_positions_with_details_test_set",
+  "name": "Open Option Positions With Details Test",
+  "description": "Test case for retrieving currently-open option positions enriched with call/put details and Greeks through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "open_option_positions_with_details_test",
+      "conversation": [
+        {
+          "invocation_id": "open-option-positions-with-details-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my currently open option positions with full details including call/put type and Greeks in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your open option positions with details:\n\n*   **Option Type**: call/put\n*   **Greeks**: delta, gamma, theta, vega\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "open_option_positions_with_details"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_option_historicals_test.json
+++ b/tests/evals/8_opt_option_historicals_test.json
@@ -38,8 +38,8 @@
                 "id": "adk-tool-use-id",
                 "args": {
                   "symbol": "AAPL",
-                  "expiration_date": "2025-08-15",
-                  "strike_price": "200",
+                  "expiration_date": "resolved-expiration-date",
+                  "strike_price": "resolved-strike-price",
                   "option_type": "call",
                   "interval": "hour",
                   "span": "week"

--- a/tests/evals/8_opt_option_historicals_test.json
+++ b/tests/evals/8_opt_option_historicals_test.json
@@ -1,0 +1,61 @@
+{
+  "eval_set_id": "option_historicals_test_set",
+  "name": "Option Historicals Test",
+  "description": "Test case for retrieving historical price data for an AAPL call option contract through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "option_historicals_test",
+      "conversation": [
+        {
+          "invocation_id": "option-historicals-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me historical price data for an AAPL call option. First find an available expiration and strike from the options chain, then retrieve the historical data."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the historical price data for the AAPL call option:\n\n*   **Symbol**: AAPL\n*   **Option Type**: call\n*   **Interval**: hour\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "option_type": "call"
+                },
+                "name": "options_chains"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "expiration_date": "2025-08-15",
+                  "strike_price": "200",
+                  "option_type": "call",
+                  "interval": "hour",
+                  "span": "week"
+                },
+                "name": "option_historicals"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_option_market_data_test.json
+++ b/tests/evals/8_opt_option_market_data_test.json
@@ -1,0 +1,56 @@
+{
+  "eval_set_id": "option_market_data_test_set",
+  "name": "Option Market Data Test",
+  "description": "Test case for retrieving market data for a specific option contract by first resolving an option ID from the options chain",
+  "eval_cases": [
+    {
+      "eval_id": "option_market_data_test",
+      "conversation": [
+        {
+          "invocation_id": "option-market-data-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Get me the current market data for an AAPL call option. First look up the options chain to find a valid option, then show me its market data."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the market data for the AAPL call option:\n\n*   **Symbol**: AAPL\n*   **Option Type**: call\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "option_type": "call"
+                },
+                "name": "options_chains"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "option_id": "resolved-option-id"
+                },
+                "name": "option_market_data"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_account_features_test.json
+++ b/tests/evals/9_adv_account_features_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "account_features_test_set",
+  "name": "Account Features Test",
+  "description": "Test case for retrieving which Robinhood account features and permissions are enabled through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "account_features_test",
+      "conversation": [
+        {
+          "invocation_id": "account-features-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Which features and permissions are enabled on my Robinhood account? Show them in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the features enabled on your Robinhood account:\n\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "account_features"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_account_settings_test.json
+++ b/tests/evals/9_adv_account_settings_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "account_settings_test_set",
+  "name": "Account Settings Test",
+  "description": "Test case for retrieving Robinhood account settings and configuration through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "account_settings_test",
+      "conversation": [
+        {
+          "invocation_id": "account-settings-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my current Robinhood account settings and configuration in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Robinhood account settings:\n\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "account_settings"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_broker_status_test.json
+++ b/tests/evals/9_adv_broker_status_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "broker_status_test_set",
+  "name": "Broker Status Test",
+  "description": "Test case for checking which brokers are connected and their current status through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "broker_status_test",
+      "conversation": [
+        {
+          "invocation_id": "broker-status-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Which brokers are currently connected and what is their status? Show in a bulleted list."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the status of your connected brokers:\n\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "broker_status"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_build_user_profile_test.json
+++ b/tests/evals/9_adv_build_user_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "build_user_profile_test_set",
+  "name": "Build User Profile Test",
+  "description": "Test case for retrieving an aggregated financial profile including equity, cash, and dividends through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "build_user_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "build-user-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Give me a complete financial summary of my portfolio including total equity, cash, and dividend income."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your aggregated portfolio totals:\n\n*   **Total Equity**: ...\n*   **Cash**: ...\n*   **Total Dividends**: ...\n*   **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "build_user_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -150,7 +150,93 @@ adk eval examples/google_adk_agent tests/evals/0_sys_metrics_summary_test.json -
 adk eval examples/google_adk_agent tests/evals/0_sys_rate_limit_status_test.json --config_file_path tests/evals/test_config.json
 ```
 
-### 3. Schwab Market & Account Evals (`schwab_*`)
+### 3. Account Evals (`1_acc_*`)
+
+Read-only account evaluations for Robinhood portfolio, positions, and dividend tools. Require `ROBINHOOD_USERNAME` and `ROBINHOOD_PASSWORD`.
+
+- `tests/evals/1_acc_account_info_test.json` — exercises `account_info`.
+- `tests/evals/1_acc_account_details_test.json` — exercises `account_details`.
+- `tests/evals/1_acc_portfolio_test.json` — exercises `portfolio`.
+- `tests/evals/1_acc_positions_test.json` — exercises `positions`.
+- `tests/evals/1_acc_build_holdings_test.json` — exercises `build_holdings`.
+- `tests/evals/1_acc_dividends_test.json` — exercises `dividends`.
+- `tests/evals/1_acc_total_dividends_test.json` — exercises `total_dividends`.
+- `tests/evals/1_acc_dividends_by_instrument_test.json` — exercises `dividends_by_instrument`.
+- `tests/evals/1_acc_day_trades_test.json` — exercises `day_trades`.
+- `tests/evals/1_acc_interest_payments_test.json` — exercises `interest_payments`.
+- `tests/evals/1_acc_stock_loan_payments_test.json` — exercises `stock_loan_payments`.
+- `tests/evals/1_acc_health_check_test.json` — exercises the account-level `health_check`.
+
+### 4. Market Data Evals (`2_mkt_*`)
+
+Read-only market data evaluations for stock quotes, search, and info tools. Do not require Robinhood credentials.
+
+- `tests/evals/2_mkt_stock_price_test.json` — exercises `stock_price`.
+- `tests/evals/2_mkt_stock_info_test.json` — exercises `stock_info`.
+- `tests/evals/2_mkt_search_stocks_test.json` — exercises `search_stocks`.
+- `tests/evals/2_mkt_market_hours_test.json` — exercises `market_hours`.
+
+### 5. Profiles Tests (`6_prf_*`)
+
+Read-only evaluations for Robinhood profile tools. All require `ROBINHOOD_USERNAME` and `ROBINHOOD_PASSWORD`.
+
+- `tests/evals/6_prf_account_profile_test.json` — exercises `account_profile` to retrieve Robinhood account profile data.
+- `tests/evals/6_prf_basic_profile_test.json` — exercises `basic_profile` to retrieve basic user information.
+- `tests/evals/6_prf_investment_profile_test.json` — exercises `investment_profile` to retrieve investment objectives and risk tolerance.
+- `tests/evals/6_prf_security_profile_test.json` — exercises `security_profile` to retrieve security/authentication profile data.
+- `tests/evals/6_prf_user_profile_test.json` — exercises `user_profile` to retrieve user profile details.
+- `tests/evals/6_prf_complete_profile_test.json` — exercises `complete_profile` to retrieve all profile data in one call.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/6_prf_account_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_basic_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_investment_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_security_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_user_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/6_prf_complete_profile_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 6. Options Data Evals (`8_opt_*`)
+
+Evaluations for Robinhood options tools. Multi-step evals for `option_market_data` and `option_historicals` resolve an option contract via `options_chains` first (public data). The `aggregate_option_positions` and `open_option_positions_with_details` evals require `ROBINHOOD_USERNAME` and `ROBINHOOD_PASSWORD`.
+
+- `tests/evals/8_opt_find_options_test.json` — exercises `find_options` and `options_chains`.
+- `tests/evals/8_opt_options_chains_test.json` — exercises `options_chains` for TSLA.
+- `tests/evals/8_opt_option_market_data_test.json` — multi-step: `options_chains` then `option_market_data` to retrieve live market data for a specific AAPL call option contract.
+- `tests/evals/8_opt_option_historicals_test.json` — multi-step: `options_chains` then `option_historicals` to retrieve historical price data for an AAPL call option.
+- `tests/evals/8_opt_aggregate_option_positions_test.json` — exercises `aggregate_option_positions` to show options exposure grouped by underlying (requires Robinhood credentials).
+- `tests/evals/8_opt_open_option_positions_with_details_test.json` — exercises `open_option_positions_with_details` to list open positions with call/put details and Greeks (requires Robinhood credentials).
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/8_opt_option_market_data_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_option_historicals_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_aggregate_option_positions_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_open_option_positions_with_details_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 7. Advanced Tests (`9_adv_*`)
+
+Read-only evaluations for advanced aggregation and account management tools. `build_user_profile`, `account_settings`, and `account_features` require `ROBINHOOD_USERNAME` and `ROBINHOOD_PASSWORD`. `broker_status` does not require Robinhood credentials.
+
+- `tests/evals/9_adv_build_user_profile_test.json` — exercises `build_user_profile` to retrieve aggregated equity, cash, and dividend totals.
+- `tests/evals/9_adv_account_settings_test.json` — exercises `account_settings` to retrieve current account settings and configuration.
+- `tests/evals/9_adv_account_features_test.json` — exercises `account_features` to list enabled account features and permissions.
+- `tests/evals/9_adv_broker_status_test.json` — exercises `broker_status` to show connected brokers and their status.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/9_adv_build_user_profile_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/9_adv_account_settings_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/9_adv_account_features_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/9_adv_broker_status_test.json --config_file_path tests/evals/test_config.json
+```
+
+### 8. Schwab Market & Account Evals (`schwab_*`)
 
 Evaluations for Schwab-specific tools. These typically require live Schwab OAuth credentials and a running MCP server.
 


### PR DESCRIPTION
Closes #183

## Changes
- Added 6 profile eval JSONs (`6_prf_*`): `account_profile`, `basic_profile`, `investment_profile`, `security_profile`, `user_profile`, `complete_profile`
- Added 4 advanced eval JSONs (`9_adv_*`): `build_user_profile`, `account_settings`, `account_features`, `broker_status`
- Added 4 options-data eval JSONs (`8_opt_*`): `option_market_data`, `option_historicals`, `aggregate_option_positions`, `open_option_positions_with_details`
- Updated `tests/evals/ADK-testing-evals.md` with new sections for Profiles Tests, Options Data Evals, and Advanced Tests, including credential requirements and exact `adk eval` commands for each file

## Test plan
- All 14 new JSON files validated as parseable (`python -c "import json,glob; ..."` — exit 0)
- All `tool_uses[].name` values confirmed registered via `@mcp.tool()` in `src/open_stocks_mcp/server/app.py`
- No mutating tools (`buy_*`, `sell_*`, `cancel_*`, `add_to_watchlist`, `remove_from_watchlist`) present in any new file
- `mypy .` passes with zero errors
- Multi-step options evals (`option_market_data`, `option_historicals`) use `options_chains` first to mirror existing `8_opt_find_options_test.json` pattern