### PR TITLE
feat: implement Schwab account/profile consolidation tools (#192)

### DIFF
--- a/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
+++ b/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
@@ -24,14 +24,14 @@
 | `get_account_details` | ✅ Direct Match | `schwab_get_account_details` | Schwab provides more detailed balance info |
 | `get_portfolio` | ✅ Direct Match | `schwab_get_portfolio` | Calculated from account positions |
 | `get_positions` | ✅ Direct Match | `schwab_get_positions` | Part of account response |
-| `get_account_profile` | 🔄 Partial Match | `schwab_get_user_preferences` | Different structure but similar data |
-| `get_account_settings` | 🔄 Partial Match | `schwab_get_user_preferences` | Combined in user preferences |
-| `get_basic_profile` | 🔄 Partial Match | `schwab_get_user_preferences` | Subset of user preferences |
-| `get_user_profile` | 🔄 Partial Match | `schwab_get_user_preferences` | Subset of user preferences |
+| `get_account_profile` | 🔄 Partial Match (Implemented) | `schwab_get_user_preferences` | Different structure but similar data |
+| `get_account_settings` | 🔄 Partial Match (Implemented) | `schwab_get_user_preferences` | Combined in user preferences |
+| `get_basic_profile` | 🔄 Partial Match (Implemented) | `schwab_get_user_preferences` | Subset of user preferences |
+| `get_user_profile` | 🔄 Partial Match (Implemented) | `schwab_get_user_preferences` | Subset of user preferences |
 | `get_investment_profile` | ⚠️ Requires Mapping | `schwab_get_account` | Derive from account data |
 | `get_security_profile` | ⚠️ Requires Mapping | `schwab_get_account` | Derive from account data |
-| `get_complete_profile` | ⚠️ Requires Mapping | `schwab_get_all_account_data` | Aggregate multiple API calls |
-| `get_build_user_profile` | ⚠️ Requires Mapping | `schwab_build_user_profile` | Custom aggregation function |
+| `get_complete_profile` | ⚠️ Requires Mapping (Implemented) | `schwab_get_all_account_data` | Aggregate multiple API calls |
+| `get_build_user_profile` | ⚠️ Requires Mapping (Implemented) | `schwab_build_user_profile` | Custom aggregation function |
 | `get_account_features` | ❌ Not Available | N/A | Robinhood-specific feature flags |
 | `get_account_numbers` | ➕ Schwab Bonus | `schwab_get_account_numbers` | Hash value mapping |
 

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -133,11 +133,14 @@ from open_stocks_mcp.tools.robinhood_watchlist_tools import (
 
 # Schwab Tools
 from open_stocks_mcp.tools.schwab_account_tools import (
+    build_schwab_user_profile,
     get_schwab_account,
     get_schwab_account_balances,
     get_schwab_account_numbers,
     get_schwab_accounts,
+    get_schwab_all_account_data,
     get_schwab_portfolio,
+    get_schwab_user_preferences,
 )
 from open_stocks_mcp.tools.schwab_market_tools import (
     get_schwab_instrument,
@@ -1105,6 +1108,34 @@ async def schwab_account_balances(account_hash: str) -> dict[str, Any]:
         account_hash: Account hash from schwab_account_numbers
     """
     return await get_schwab_account_balances(account_hash)
+
+
+@mcp.tool()
+async def schwab_get_user_preferences() -> dict[str, Any]:
+    """Get Schwab user preferences including account list and streamer info.
+
+    Consolidates account profile, settings, and user profile data.
+    """
+    return await get_schwab_user_preferences()
+
+
+@mcp.tool()
+async def schwab_get_all_account_data() -> dict[str, Any]:
+    """Get a complete snapshot of all Schwab accounts and user preferences.
+
+    Aggregates user preferences, account numbers, and all account data with positions.
+    """
+    return await get_schwab_all_account_data()
+
+
+@mcp.tool()
+async def schwab_build_user_profile() -> dict[str, Any]:
+    """Build a normalized Schwab user profile from account and preference data.
+
+    Returns a complete financial profile including total equity, cash balances,
+    and position counts across all accounts.
+    """
+    return await build_schwab_user_profile()
 
 
 # Cross-Broker Tools

--- a/src/open_stocks_mcp/tools/schwab_account_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_account_tools.py
@@ -253,3 +253,154 @@ async def get_schwab_account_balances(account_hash: str) -> dict[str, Any]:
     except Exception as e:
         logger.error(f"Error getting Schwab account balances: {e}")
         return create_error_response(e)
+
+
+@handle_schwab_errors
+async def get_schwab_user_preferences() -> dict[str, Any]:
+    """Get Schwab user preferences including account list and streamer info.
+
+    Consolidates account profile, settings, and user profile data.
+
+    Returns:
+        Dict with result containing user preferences
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", "get user preferences"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_user_preferences() -> Any:
+            response = broker.client.get_user_preferences()
+            return response.json()
+
+        result = await execute_broker_request(_get_user_preferences, retry_safe=True)
+
+        return create_success_response({"user_preferences": result})
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab user preferences: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def get_schwab_all_account_data() -> dict[str, Any]:
+    """Get a complete snapshot of all Schwab accounts and user preferences.
+
+    Aggregates user preferences, account numbers, and all account data with positions.
+
+    Returns:
+        Dict with result containing aggregated account snapshot
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", "get all account data"
+    )
+    if error:
+        return error
+
+    try:
+        # 1. Get User Preferences
+        def _get_prefs() -> Any:
+            return broker.client.get_user_preferences().json()
+
+        user_preferences = await execute_broker_request(_get_prefs, retry_safe=True)
+
+        # 2. Get Account Numbers
+        def _get_numbers() -> Any:
+            return broker.client.get_account_numbers().json()
+
+        account_numbers = await execute_broker_request(_get_numbers, retry_safe=True)
+
+        # 3. Get All Accounts with Positions
+        def _get_accounts() -> Any:
+            return broker.client.get_accounts(
+                fields=Client.Account.Fields.POSITIONS
+            ).json()
+
+        accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)
+
+        return create_success_response(
+            {
+                "user_preferences": user_preferences,
+                "account_numbers": account_numbers,
+                "accounts": accounts_data,
+                "count": len(accounts_data) if isinstance(accounts_data, list) else 1,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error aggregating Schwab account data: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def build_schwab_user_profile() -> dict[str, Any]:
+    """Build a normalized Schwab user profile from account and preference data.
+
+    Returns:
+        Dict with result containing normalized user profile
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", "build user profile"
+    )
+    if error:
+        return error
+
+    try:
+        # Fetch required data
+        def _get_prefs() -> Any:
+            return broker.client.get_user_preferences().json()
+
+        user_preferences = await execute_broker_request(_get_prefs, retry_safe=True)
+
+        def _get_accounts() -> Any:
+            return broker.client.get_accounts(
+                fields=Client.Account.Fields.POSITIONS
+            ).json()
+
+        accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)
+
+        # Normalize data
+        accounts = []
+        total_equity = 0.0
+        total_cash = 0.0
+        total_positions = 0
+
+        for account in accounts_data:
+            sec_account = account.get("securitiesAccount", {})
+            balances = sec_account.get("currentBalances", {})
+
+            acct_equity = balances.get("liquidationValue", 0.0)
+            acct_cash = balances.get("cashBalance", 0.0)
+            acct_positions = len(sec_account.get("positions", []))
+
+            total_equity += acct_equity
+            total_cash += acct_cash
+            total_positions += acct_positions
+
+            accounts.append(
+                {
+                    "account_number": sec_account.get("accountNumber"),
+                    "type": sec_account.get("type"),
+                    "equity": acct_equity,
+                    "cash": acct_cash,
+                    "position_count": acct_positions,
+                }
+            )
+
+        user_profile = {
+            "user_preferences": user_preferences,
+            "accounts": accounts,
+            "account_count": len(accounts),
+            "total_equity": total_equity,
+            "total_cash": total_cash,
+            "total_positions_count": total_positions,
+        }
+
+        return create_success_response({"user_profile": user_profile})
+
+    except Exception as e:
+        logger.error(f"Error building Schwab user profile: {e}")
+        return create_error_response(e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,12 @@ def schwab_balances_payload() -> dict[str, Any]:
 
 
 @pytest.fixture
+def schwab_user_preferences_payload() -> dict[str, Any]:
+    """Representative Schwab user preferences payload."""
+    return broker_payloads.schwab_user_preferences_payload()
+
+
+@pytest.fixture
 def broker_auth_error_payload() -> dict[str, Any]:
     """Structured broker authentication error response."""
     return broker_payloads.broker_auth_error_payload()

--- a/tests/fixtures/broker_payloads.py
+++ b/tests/fixtures/broker_payloads.py
@@ -360,6 +360,42 @@ def schwab_balances_payload() -> dict[str, Any]:
     )
 
 
+def schwab_user_preferences_payload() -> dict[str, Any]:
+    """Return representative Schwab user preferences response."""
+    return _copy(
+        {
+            "accounts": [
+                {
+                    "accountNumber": "12345678",
+                    "primaryAccount": True,
+                    "type": "MARGIN",
+                    "nickName": "Main Trading",
+                    "accountColor": "GREEN",
+                    "displayAcctId": "12345678",
+                }
+            ],
+            "streamerInfo": [
+                {
+                    "streamerBinaryUrl": "https://streamer.schwab.com",
+                    "streamerSocketUrl": "wss://streamer.schwab.com",
+                    "token": "token123",
+                    "tokenTimestamp": "2023-01-01T00:00:00Z",
+                    "userGroup": "group1",
+                    "accessLevel": "full",
+                    "acl": "acl123",
+                    "appId": "app123",
+                    "authorized": "Y",
+                }
+            ],
+            "userProps": {
+                "firstName": "John",
+                "lastName": "Doe",
+                "email": "john.doe@example.com",
+            },
+        }
+    )
+
+
 def broker_auth_error_payload() -> dict[str, Any]:
     """Return a structured broker authentication error response."""
     return _copy({"result": {"error": "Not authenticated", "status": "error"}})

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -161,6 +161,21 @@ class TestToolRegistration:
             assert tool_name in tool_names, f"Tool {tool_name} not registered"
 
     @pytest.mark.asyncio
+    async def test_schwab_account_profile_tools_are_registered(self) -> None:
+        """Test that the three new Schwab account/profile tools are registered."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+
+        expected_tools = [
+            "schwab_get_user_preferences",
+            "schwab_get_all_account_data",
+            "schwab_build_user_profile",
+        ]
+
+        for tool_name in expected_tools:
+            assert tool_name in tool_names, f"Tool {tool_name} not registered"
+
+    @pytest.mark.asyncio
     async def test_account_info_tool_callable(self) -> None:
         """Test that account_info tool is callable."""
         tools_list = await mcp.list_tools()

--- a/tests/unit/test_schwab_account_tools.py
+++ b/tests/unit/test_schwab_account_tools.py
@@ -6,11 +6,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from open_stocks_mcp.tools.schwab_account_tools import (
+    build_schwab_user_profile,
     get_schwab_account,
     get_schwab_account_balances,
     get_schwab_account_numbers,
     get_schwab_accounts,
+    get_schwab_all_account_data,
     get_schwab_portfolio,
+    get_schwab_user_preferences,
 )
 
 
@@ -242,3 +245,106 @@ class TestSchwabAccountTools:
         result = await function(*args)
         assert result["result"]["status"] == "error"
         assert "API Error" in result["result"]["error"]
+
+    @pytest.mark.journey_account
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
+    async def test_get_user_preferences_success(
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_user_preferences_payload: dict[str, Any],
+    ) -> None:
+        """Test successful user preferences retrieval."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_to_thread.return_value = schwab_user_preferences_payload
+
+        result = await get_schwab_user_preferences()
+
+        assert "result" in result
+        assert "user_preferences" in result["result"]
+        assert (
+            result["result"]["user_preferences"]["userProps"]["firstName"] == "John"
+        )
+
+    @pytest.mark.journey_account
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.Client")
+    async def test_get_all_account_data_success(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_user_preferences_payload: dict[str, Any],
+        schwab_account_numbers_payload: list[dict[str, Any]],
+        schwab_accounts_payload: list[dict[str, Any]],
+    ) -> None:
+        """Test successful aggregation of all account data."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        # Mock Client.Account.Fields
+        mock_client.Account.Fields.POSITIONS = "positions"
+
+        # Mock sequential calls in execute_broker_request
+        mock_to_thread.side_effect = [
+            schwab_user_preferences_payload,
+            schwab_account_numbers_payload,
+            schwab_accounts_payload,
+        ]
+
+        result = await get_schwab_all_account_data()
+
+        assert "result" in result
+        assert "user_preferences" in result["result"]
+        assert "account_numbers" in result["result"]
+        assert "accounts" in result["result"]
+        assert result["result"]["count"] == 2
+
+    @pytest.mark.journey_account
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.Client")
+    async def test_build_user_profile_success(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_user_preferences_payload: dict[str, Any],
+        schwab_accounts_payload: list[dict[str, Any]],
+    ) -> None:
+        """Test successful normalized user profile building."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        # Mock Client.Account.Fields
+        mock_client.Account.Fields.POSITIONS = "positions"
+
+        # Mock sequential calls
+        mock_to_thread.side_effect = [
+            schwab_user_preferences_payload,
+            schwab_accounts_payload,
+        ]
+
+        result = await build_schwab_user_profile()
+
+        assert "result" in result
+        assert "user_profile" in result["result"]
+        profile = result["result"]["user_profile"]
+        assert profile["account_count"] == 2
+        assert "accounts" in profile
+        assert "user_preferences" in profile


### PR DESCRIPTION
Closes #192

## Changes
- Implemented schwab_get_user_preferences tool to consolidate account profile, settings, and user profile data.
- Implemented schwab_get_all_account_data tool to aggregate multiple API calls into a complete account snapshot.
- Implemented schwab_build_user_profile tool to construct a normalized user profile dictionary.
- Registered the three new tools in src/open_stocks_mcp/server/app.py as schwab_get_user_preferences, schwab_get_all_account_data, and schwab_build_user_profile.
- Added unit tests in tests/unit/test_schwab_account_tools.py with journey_account markers.
- Added server registration smoke tests in tests/server/test_server_app.py.
- Updated docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md to reflect implementation status.
- Added schwab_user_preferences_payload to test fixtures.

## Test plan
- Run unit tests and server registration tests to verify implementation.
- Run journey_account tests to ensure no regressions.
- Run mypy and ruff for quality checks.