### PR TITLE
feat: add computed schwab portfolio tools

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -152,6 +152,13 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_expirations,
     get_schwab_options_positions,
 )
+from open_stocks_mcp.tools.schwab_portfolio_tools import (
+    get_schwab_aggregate_positions,
+    get_schwab_all_option_positions,
+    get_schwab_build_holdings,
+    get_schwab_day_trades,
+    get_schwab_open_option_positions,
+)
 from open_stocks_mcp.tools.schwab_trading_tools import (
     cancel_schwab_order,
     get_schwab_order_by_id,
@@ -1391,6 +1398,36 @@ async def schwab_options_positions(account_hash: str) -> dict[str, Any]:
         account_hash: Account hash from schwab_account_numbers
     """
     return await get_schwab_options_positions(account_hash)
+
+
+@mcp.tool()
+async def schwab_get_build_holdings() -> dict[str, Any]:
+    """Build enriched holdings from Schwab positions and quotes."""
+    return await get_schwab_build_holdings()
+
+
+@mcp.tool()
+async def schwab_get_day_trades() -> dict[str, Any]:
+    """Get day-trade counts derived from Schwab transaction history."""
+    return await get_schwab_day_trades()
+
+
+@mcp.tool()
+async def schwab_get_aggregate_positions() -> dict[str, Any]:
+    """Aggregate Schwab positions across all linked accounts."""
+    return await get_schwab_aggregate_positions()
+
+
+@mcp.tool()
+async def schwab_get_all_option_positions() -> dict[str, Any]:
+    """Get all Schwab option positions across linked accounts."""
+    return await get_schwab_all_option_positions()
+
+
+@mcp.tool()
+async def schwab_get_open_option_positions() -> dict[str, Any]:
+    """Get open Schwab option positions with non-zero net quantity."""
+    return await get_schwab_open_option_positions()
 
 
 def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:

--- a/src/open_stocks_mcp/tools/schwab_portfolio_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_portfolio_tools.py
@@ -1,0 +1,371 @@
+"""Computed Schwab portfolio MCP tools."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from schwab.client import Client
+
+from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.broker_utils import (
+    execute_broker_request,
+    get_authenticated_broker_or_error,
+)
+from open_stocks_mcp.tools.error_handling import (
+    create_error_response,
+    create_success_response,
+    handle_schwab_errors,
+)
+
+
+def _to_float(value: Any) -> float:
+    try:
+        if value is None:
+            return 0.0
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _extract_accounts(accounts_data: Any) -> list[dict[str, Any]]:
+    if isinstance(accounts_data, list):
+        return [item for item in accounts_data if isinstance(item, dict)]
+    if isinstance(accounts_data, dict):
+        return [accounts_data]
+    return []
+
+
+def _position_row(account_hash: str, position: dict[str, Any]) -> dict[str, Any]:
+    instrument = position.get("instrument", {})
+    long_qty = _to_float(position.get("longQuantity"))
+    short_qty = _to_float(position.get("shortQuantity"))
+    return {
+        "account_hash": account_hash,
+        "symbol": instrument.get("symbol"),
+        "asset_type": instrument.get("assetType"),
+        "long_quantity": long_qty,
+        "short_quantity": short_qty,
+        "net_quantity": long_qty + short_qty,
+        "average_price": _to_float(position.get("averagePrice")),
+        "market_value": _to_float(position.get("marketValue")),
+        "current_day_pl": _to_float(position.get("currentDayProfitLoss")),
+        "instrument": instrument,
+        "raw_position": position,
+    }
+
+
+def _normalize_option_position(row: dict[str, Any]) -> dict[str, Any]:
+    instrument = row.get("instrument", {})
+    return {
+        "account_hash": row.get("account_hash"),
+        "symbol": instrument.get("symbol"),
+        "underlying_symbol": instrument.get("underlyingSymbol"),
+        "option_type": instrument.get("putCall"),
+        "strike_price": instrument.get("strikePrice"),
+        "expiration_date": instrument.get("expirationDate"),
+        "long_quantity": row.get("long_quantity", 0.0),
+        "short_quantity": row.get("short_quantity", 0.0),
+        "net_quantity": row.get("net_quantity", 0.0),
+        "average_price": row.get("average_price", 0.0),
+        "market_value": row.get("market_value", 0.0),
+        "current_day_pl": row.get("current_day_pl", 0.0),
+    }
+
+
+@handle_schwab_errors
+async def get_schwab_build_holdings() -> dict[str, Any]:
+    """Build holdings from all Schwab account positions and quote enrichment."""
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", "build holdings across accounts"
+    )
+    if error:
+        return error
+
+    try:
+        def _get_accounts() -> Any:
+            response = broker.client.get_accounts(fields=Client.Account.Fields.POSITIONS)
+            return response.json()
+
+        accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)
+        accounts = _extract_accounts(accounts_data)
+
+        all_rows: list[dict[str, Any]] = []
+        symbols: set[str] = set()
+        for account_entry in accounts:
+            account = account_entry.get("securitiesAccount", {})
+            account_hash = account.get("hashValue", "")
+            for position in account.get("positions", []):
+                row = _position_row(account_hash, position)
+                symbol = row.get("symbol")
+                if symbol:
+                    all_rows.append(row)
+                    symbols.add(str(symbol))
+
+        quotes: dict[str, Any] = {}
+        if symbols:
+            def _get_quotes() -> Any:
+                response = broker.client.get_quotes(sorted(symbols))
+                return response.json()
+
+            quotes_data = await execute_broker_request(_get_quotes, retry_safe=True)
+            if isinstance(quotes_data, dict):
+                quotes = quotes_data
+
+        holdings: dict[str, dict[str, Any]] = {}
+        for row in all_rows:
+            symbol = str(row.get("symbol"))
+            quote = quotes.get(symbol, {})
+            quote_price = _to_float(
+                quote.get("quote", {}).get("lastPrice") or quote.get("lastPrice")
+            )
+            holdings[symbol] = {
+                "symbol": symbol,
+                "quantity": row["net_quantity"],
+                "average_buy_price": row["average_price"],
+                "equity": row["market_value"],
+                "market_value": row["market_value"],
+                "price": quote_price,
+                "day_change": _to_float(
+                    quote.get("quote", {}).get("netChange")
+                    or quote.get("netChange")
+                ),
+                "day_change_percent": _to_float(
+                    quote.get("quote", {}).get("netPercentChangeInDouble")
+                    or quote.get("netPercentChangeInDouble")
+                ),
+                "account_hash": row.get("account_hash"),
+            }
+
+        return create_success_response(
+            {
+                "holdings": holdings,
+                "total_positions": len(all_rows),
+                "status": "ok",
+            }
+        )
+    except Exception as exc:
+        logger.error(f"Error building Schwab holdings: {exc}")
+        return create_error_response(exc)
+
+
+@handle_schwab_errors
+async def get_schwab_day_trades() -> dict[str, Any]:
+    """Compute day trades from recent Schwab trade transactions."""
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", "compute day trades"
+    )
+    if error:
+        return error
+
+    try:
+        def _get_account_numbers() -> Any:
+            response = broker.client.get_account_numbers()
+            return response.json()
+
+        account_numbers = await execute_broker_request(
+            _get_account_numbers, retry_safe=True
+        )
+        account_hashes = [
+            item.get("hashValue")
+            for item in account_numbers
+            if isinstance(item, dict) and item.get("hashValue")
+        ]
+
+        end_date = datetime.now(UTC).date()
+        start_date = end_date - timedelta(days=6)
+        day_trade_count = 0
+        trades: list[dict[str, Any]] = []
+
+        for account_hash in account_hashes:
+            def _get_transactions(account_hash: str = account_hash) -> Any:
+                response = broker.client.get_transactions(
+                    account_hash,
+                    start_date=start_date,
+                    end_date=end_date,
+                    transaction_types=Client.Transactions.TransactionType.TRADE,
+                )
+                return response.json()
+
+            txns = await execute_broker_request(_get_transactions, retry_safe=True)
+            bucket: dict[tuple[str, str], set[str]] = defaultdict(set)
+            for txn in txns if isinstance(txns, list) else []:
+                if not isinstance(txn, dict):
+                    continue
+                symbol = str(txn.get("symbol") or "").upper()
+                if not symbol:
+                    continue
+                txn_date = str(txn.get("transactionDate") or "")[:10]
+                if not txn_date:
+                    continue
+                instruction = str(txn.get("instruction") or "").upper()
+                side = "BUY" if "BUY" in instruction else "SELL" if "SELL" in instruction else ""
+                if not side:
+                    continue
+                bucket[(txn_date, symbol)].add(side)
+                trades.append(
+                    {
+                        "account_hash": account_hash,
+                        "date": txn_date,
+                        "symbol": symbol,
+                        "instruction": instruction,
+                    }
+                )
+
+            for sides in bucket.values():
+                if "BUY" in sides and "SELL" in sides:
+                    day_trade_count += 1
+
+        remaining_day_trades = max(0, 3 - day_trade_count)
+        return create_success_response(
+            {
+                "day_trade_count": day_trade_count,
+                "remaining_day_trades": remaining_day_trades,
+                "pattern_day_trader": day_trade_count >= 4,
+                "trades": trades,
+                "status": "ok",
+            }
+        )
+    except Exception as exc:
+        logger.error(f"Error computing Schwab day trades: {exc}")
+        return create_error_response(exc)
+
+
+@handle_schwab_errors
+async def get_schwab_aggregate_positions() -> dict[str, Any]:
+    """Aggregate position totals across all linked Schwab accounts."""
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", "aggregate positions"
+    )
+    if error:
+        return error
+
+    try:
+        def _get_accounts() -> Any:
+            response = broker.client.get_accounts(fields=Client.Account.Fields.POSITIONS)
+            return response.json()
+
+        accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)
+        accounts = _extract_accounts(accounts_data)
+
+        grouped: dict[tuple[str, str], dict[str, Any]] = {}
+        for account_entry in accounts:
+            account = account_entry.get("securitiesAccount", {})
+            account_hash = account.get("hashValue", "")
+            for position in account.get("positions", []):
+                row = _position_row(account_hash, position)
+                symbol = str(row.get("symbol") or "")
+                asset_type = str(row.get("asset_type") or "")
+                if not symbol:
+                    continue
+                key = (symbol, asset_type)
+                if key not in grouped:
+                    grouped[key] = {
+                        "symbol": symbol,
+                        "asset_type": asset_type,
+                        "long_quantity": 0.0,
+                        "short_quantity": 0.0,
+                        "net_quantity": 0.0,
+                        "market_value": 0.0,
+                        "current_day_pl": 0.0,
+                        "accounts": [],
+                    }
+                item = grouped[key]
+                item["long_quantity"] += row["long_quantity"]
+                item["short_quantity"] += row["short_quantity"]
+                item["net_quantity"] += row["net_quantity"]
+                item["market_value"] += row["market_value"]
+                item["current_day_pl"] += row["current_day_pl"]
+                item["accounts"].append(
+                    {
+                        "account_hash": row["account_hash"],
+                        "long_quantity": row["long_quantity"],
+                        "short_quantity": row["short_quantity"],
+                        "net_quantity": row["net_quantity"],
+                        "market_value": row["market_value"],
+                    }
+                )
+
+        aggregates = list(grouped.values())
+        return create_success_response(
+            {
+                "positions": aggregates,
+                "count": len(aggregates),
+                "status": "ok",
+            }
+        )
+    except Exception as exc:
+        logger.error(f"Error aggregating Schwab positions: {exc}")
+        return create_error_response(exc)
+
+
+@handle_schwab_errors
+async def get_schwab_all_option_positions() -> dict[str, Any]:
+    """Return all option positions across all Schwab accounts."""
+    aggregate = await get_schwab_aggregate_positions()
+    if "result" not in aggregate or aggregate["result"].get("status") == "error":
+        return aggregate
+
+    try:
+        broker, error = await get_authenticated_broker_or_error(
+            "schwab", "all option positions"
+        )
+        if error:
+            return error
+
+        def _get_accounts() -> Any:
+            response = broker.client.get_accounts(fields=Client.Account.Fields.POSITIONS)
+            return response.json()
+
+        accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)
+        accounts = _extract_accounts(accounts_data)
+
+        rows: list[dict[str, Any]] = []
+        for account_entry in accounts:
+            account = account_entry.get("securitiesAccount", {})
+            account_hash = account.get("hashValue", "")
+            for position in account.get("positions", []):
+                row = _position_row(account_hash, position)
+                if str(row.get("asset_type") or "").upper() == "OPTION":
+                    rows.append(_normalize_option_position(row))
+
+        open_positions = [
+            row for row in rows if abs(_to_float(row.get("net_quantity"))) > 0.0
+        ]
+        return create_success_response(
+            {
+                "positions": rows,
+                "total_positions": len(rows),
+                "open_positions": len(open_positions),
+                "closed_positions": len(rows) - len(open_positions),
+                "status": "ok",
+            }
+        )
+    except Exception as exc:
+        logger.error(f"Error getting all Schwab option positions: {exc}")
+        return create_error_response(exc)
+
+
+@handle_schwab_errors
+async def get_schwab_open_option_positions() -> dict[str, Any]:
+    """Return open option positions (non-zero net quantity) across accounts."""
+    all_positions = await get_schwab_all_option_positions()
+    if "result" not in all_positions:
+        return all_positions
+
+    result = all_positions["result"]
+    if result.get("status") == "error":
+        return all_positions
+
+    positions = result.get("positions", [])
+    open_positions = [
+        row for row in positions if abs(_to_float(row.get("net_quantity"))) > 0.0
+    ]
+    return create_success_response(
+        {
+            "positions": open_positions,
+            "total_positions": len(open_positions),
+            "status": "ok",
+        }
+    )

--- a/src/open_stocks_mcp/tools/schwab_portfolio_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_portfolio_tools.py
@@ -167,11 +167,13 @@ async def get_schwab_day_trades() -> dict[str, Any]:
         account_numbers = await execute_broker_request(
             _get_account_numbers, retry_safe=True
         )
-        account_hashes = [
-            item.get("hashValue")
-            for item in account_numbers
-            if isinstance(item, dict) and item.get("hashValue")
-        ]
+        account_hashes: list[str] = []
+        for item in account_numbers if isinstance(account_numbers, list) else []:
+            if not isinstance(item, dict):
+                continue
+            hash_value = item.get("hashValue")
+            if isinstance(hash_value, str) and hash_value:
+                account_hashes.append(hash_value)
 
         end_date = datetime.now(UTC).date()
         start_date = end_date - timedelta(days=6)
@@ -179,9 +181,9 @@ async def get_schwab_day_trades() -> dict[str, Any]:
         trades: list[dict[str, Any]] = []
 
         for account_hash in account_hashes:
-            def _get_transactions(account_hash: str = account_hash) -> Any:
+            def _get_transactions(current_account_hash: str = account_hash) -> Any:
                 response = broker.client.get_transactions(
-                    account_hash,
+                    current_account_hash,
                     start_date=start_date,
                     end_date=end_date,
                     transaction_types=Client.Transactions.TransactionType.TRADE,

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -155,6 +155,11 @@ class TestToolRegistration:
             "unified_add_to_watchlist",
             "unified_remove_from_watchlist",
             "broker_comparison",
+            "schwab_get_build_holdings",
+            "schwab_get_day_trades",
+            "schwab_get_aggregate_positions",
+            "schwab_get_all_option_positions",
+            "schwab_get_open_option_positions",
         ]
 
         for tool_name in expected_tools:

--- a/tests/unit/test_schwab_portfolio_tools.py
+++ b/tests/unit/test_schwab_portfolio_tools.py
@@ -1,0 +1,262 @@
+"""Unit tests for computed Schwab portfolio tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.schwab_portfolio_tools import (
+    get_schwab_aggregate_positions,
+    get_schwab_all_option_positions,
+    get_schwab_build_holdings,
+    get_schwab_day_trades,
+    get_schwab_open_option_positions,
+)
+
+
+@pytest.mark.journey_portfolio
+@pytest.mark.unit
+class TestSchwabPortfolioTools:
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_portfolio_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.Client")
+    async def test_schwab_get_build_holdings_enriches_positions_with_quotes(
+        self,
+        mock_client: MagicMock,
+        mock_execute_broker_request: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+
+        accounts_payload = [
+            {
+                "securitiesAccount": {
+                    "hashValue": "hash-1",
+                    "positions": [
+                        {
+                            "longQuantity": 10,
+                            "shortQuantity": 0,
+                            "averagePrice": 100.0,
+                            "marketValue": 1100.0,
+                            "instrument": {"symbol": "AAPL", "assetType": "EQUITY"},
+                        }
+                    ],
+                }
+            }
+        ]
+        quotes_payload = {
+            "AAPL": {"quote": {"lastPrice": 110.0, "netChange": 2.0}},
+        }
+        mock_execute_broker_request.side_effect = [accounts_payload, quotes_payload]
+
+        result = await get_schwab_build_holdings()
+
+        assert result["result"]["status"] == "ok"
+        assert result["result"]["total_positions"] == 1
+        assert result["result"]["holdings"]["AAPL"]["price"] == 110.0
+        assert result["result"]["holdings"]["AAPL"]["quantity"] == 10.0
+
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_portfolio_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.Client")
+    async def test_schwab_get_day_trades_counts_same_day_trade_pairs(
+        self,
+        mock_client: MagicMock,
+        mock_execute_broker_request: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Transactions.TransactionType.TRADE = "TRADE"
+
+        accounts_payload = [{"hashValue": "hash-1"}]
+        trades_payload = [
+            {"symbol": "AAPL", "transactionDate": "2026-01-01T10:00:00Z", "instruction": "BUY"},
+            {"symbol": "AAPL", "transactionDate": "2026-01-01T11:00:00Z", "instruction": "SELL"},
+            {"symbol": "MSFT", "transactionDate": "2026-01-01T11:00:00Z", "instruction": "BUY"},
+            {"symbol": "AAPL", "transactionDate": "2026-01-02T11:00:00Z", "instruction": "BUY"},
+        ]
+        mock_execute_broker_request.side_effect = [accounts_payload, trades_payload]
+
+        result = await get_schwab_day_trades()
+
+        assert result["result"]["status"] == "ok"
+        assert result["result"]["day_trade_count"] == 1
+        assert result["result"]["remaining_day_trades"] == 2
+        assert result["result"]["pattern_day_trader"] is False
+
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_portfolio_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.Client")
+    async def test_schwab_get_aggregate_positions_sums_matching_symbols_across_accounts(
+        self,
+        mock_client: MagicMock,
+        mock_execute_broker_request: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+
+        accounts_payload = [
+            {
+                "securitiesAccount": {
+                    "hashValue": "hash-1",
+                    "positions": [
+                        {
+                            "longQuantity": 5,
+                            "shortQuantity": 0,
+                            "marketValue": 500.0,
+                            "currentDayProfitLoss": 5.0,
+                            "instrument": {"symbol": "AAPL", "assetType": "EQUITY"},
+                        }
+                    ],
+                }
+            },
+            {
+                "securitiesAccount": {
+                    "hashValue": "hash-2",
+                    "positions": [
+                        {
+                            "longQuantity": 3,
+                            "shortQuantity": 0,
+                            "marketValue": 300.0,
+                            "currentDayProfitLoss": 3.0,
+                            "instrument": {"symbol": "AAPL", "assetType": "EQUITY"},
+                        },
+                        {
+                            "longQuantity": 2,
+                            "shortQuantity": 0,
+                            "marketValue": 200.0,
+                            "currentDayProfitLoss": 2.0,
+                            "instrument": {"symbol": "TSLA", "assetType": "EQUITY"},
+                        },
+                    ],
+                }
+            },
+        ]
+        mock_execute_broker_request.return_value = accounts_payload
+
+        result = await get_schwab_aggregate_positions()
+
+        assert result["result"]["status"] == "ok"
+        assert result["result"]["count"] == 2
+        by_symbol = {item["symbol"]: item for item in result["result"]["positions"]}
+        assert by_symbol["AAPL"]["net_quantity"] == 8.0
+        assert by_symbol["AAPL"]["market_value"] == 800.0
+
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_portfolio_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.Client")
+    async def test_schwab_get_all_option_positions_filters_option_asset_type_across_accounts(
+        self,
+        mock_client: MagicMock,
+        mock_execute_broker_request: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+
+        accounts_payload = [
+            {
+                "securitiesAccount": {
+                    "hashValue": "hash-1",
+                    "positions": [
+                        {
+                            "longQuantity": 1,
+                            "shortQuantity": 0,
+                            "marketValue": 200.0,
+                            "instrument": {
+                                "symbol": "AAPL_011926C150",
+                                "assetType": "OPTION",
+                                "putCall": "CALL",
+                            },
+                        },
+                        {
+                            "longQuantity": 1,
+                            "shortQuantity": 0,
+                            "marketValue": 150.0,
+                            "instrument": {"symbol": "AAPL", "assetType": "EQUITY"},
+                        },
+                    ],
+                }
+            }
+        ]
+        mock_execute_broker_request.side_effect = [accounts_payload, accounts_payload]
+
+        result = await get_schwab_all_option_positions()
+
+        assert result["result"]["status"] == "ok"
+        assert result["result"]["total_positions"] == 1
+        assert result["result"]["positions"][0]["symbol"] == "AAPL_011926C150"
+
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_portfolio_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_portfolio_tools.Client")
+    async def test_schwab_get_open_option_positions_returns_only_nonzero_option_quantity(
+        self,
+        mock_client: MagicMock,
+        mock_execute_broker_request: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+
+        accounts_payload = [
+            {
+                "securitiesAccount": {
+                    "hashValue": "hash-1",
+                    "positions": [
+                        {
+                            "longQuantity": 2,
+                            "shortQuantity": 0,
+                            "marketValue": 200.0,
+                            "instrument": {
+                                "symbol": "AAPL_011926C150",
+                                "assetType": "OPTION",
+                                "putCall": "CALL",
+                            },
+                        },
+                        {
+                            "longQuantity": 0,
+                            "shortQuantity": 0,
+                            "marketValue": 0.0,
+                            "instrument": {
+                                "symbol": "AAPL_011926P100",
+                                "assetType": "OPTION",
+                                "putCall": "PUT",
+                            },
+                        },
+                    ],
+                }
+            }
+        ]
+        mock_execute_broker_request.side_effect = [
+            accounts_payload,
+            accounts_payload,
+            accounts_payload,
+        ]
+
+        result = await get_schwab_open_option_positions()
+
+        assert result["result"]["status"] == "ok"
+        assert result["result"]["total_positions"] == 1
+        assert result["result"]["positions"][0]["symbol"] == "AAPL_011926C150"


### PR DESCRIPTION
Closes #193

## Changes
- add new `src/open_stocks_mcp/tools/schwab_portfolio_tools.py` with five computed Schwab portfolio helpers
- register new MCP tools in `src/open_stocks_mcp/server/app.py`:
  - `schwab_get_build_holdings`
  - `schwab_get_day_trades`
  - `schwab_get_aggregate_positions`
  - `schwab_get_all_option_positions`
  - `schwab_get_open_option_positions`
- add `tests/unit/test_schwab_portfolio_tools.py` journey-portfolio unit coverage for holdings enrichment, day-trade counting, aggregation, and option-position filtering
- update `tests/server/test_server_app.py` registration expectations for the five new `schwab_get_*` tools

## Test plan
- `uv run pytest tests/unit/test_schwab_portfolio_tools.py tests/server/test_server_app.py -q -m "journey_portfolio or journey_system" -k "schwab_get_" -o addopts=''`
- `uv run pytest tests/unit/test_schwab_portfolio_tools.py -q -m "journey_portfolio" -o addopts=''`
- `uv run pytest -m journey_portfolio tests/unit/ -q -o addopts=''`
- `uv run mypy src/open_stocks_mcp/tools/schwab_portfolio_tools.py src/open_stocks_mcp/server/app.py`
- `uv run ruff check src/open_stocks_mcp/tools/schwab_portfolio_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_schwab_portfolio_tools.py tests/server/test_server_app.py`