### PR TITLE
feat: add schwab market hours, movers, and CUSIP instrument lookup tools

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -144,6 +144,10 @@ from open_stocks_mcp.tools.schwab_account_tools import (
 )
 from open_stocks_mcp.tools.schwab_market_tools import (
     get_schwab_instrument,
+    get_schwab_instrument_by_cusip,
+    get_schwab_market_hours,
+    get_schwab_movers,
+    get_schwab_movers_sp500,
     get_schwab_price_history,
     get_schwab_quote,
     get_schwab_quotes,
@@ -1236,6 +1240,63 @@ async def schwab_search_instruments(query: str) -> dict[str, Any]:
         query: Symbol or company name to search
     """
     return await search_schwab_instruments(query)
+
+
+@mcp.tool()
+async def schwab_get_market_hours(
+    market: str = "equity", date: str | None = None
+) -> dict[str, Any]:
+    """Get market hours for a given market and optional date.
+
+    Args:
+        market: Market type ('equity', 'option', 'bond', 'forex', 'future')
+        date: Optional ISO date string (e.g. '2026-05-20'). Defaults to today.
+    """
+    return await get_schwab_market_hours(market, date)
+
+
+@mcp.tool()
+async def schwab_get_movers(
+    index: str,
+    sort_order: str | None = None,
+    frequency: int | None = None,
+) -> dict[str, Any]:
+    """Get market movers for a given index.
+
+    Args:
+        index: Index to query (e.g. '$DJI', '$SPX', 'NASDAQ', 'NYSE', '$COMPX',
+               'EQUITY_ALL', 'INDEX_ALL', 'OPTION_ALL', 'OPTION_CALL', 'OPTION_PUT',
+               'OTCBB')
+        sort_order: Optional sort order ('PERCENT_CHANGE_UP', 'PERCENT_CHANGE_DOWN',
+                    'VOLUME', 'TRADES')
+        frequency: Optional frequency in minutes (0, 1, 5, 10, 30, 60)
+    """
+    return await get_schwab_movers(index, sort_order, frequency)
+
+
+@mcp.tool()
+async def schwab_get_movers_sp500(
+    sort_order: str | None = None,
+    frequency: int | None = None,
+) -> dict[str, Any]:
+    """Get market movers for the S&P 500 index ($SPX).
+
+    Args:
+        sort_order: Optional sort order ('PERCENT_CHANGE_UP', 'PERCENT_CHANGE_DOWN',
+                    'VOLUME', 'TRADES')
+        frequency: Optional frequency in minutes (0, 1, 5, 10, 30, 60)
+    """
+    return await get_schwab_movers_sp500(sort_order, frequency)
+
+
+@mcp.tool()
+async def schwab_get_instrument_by_cusip(cusip: str) -> dict[str, Any]:
+    """Get instrument details by CUSIP identifier.
+
+    Args:
+        cusip: CUSIP identifier (leading zeros are preserved, e.g. '037833100')
+    """
+    return await get_schwab_instrument_by_cusip(cusip)
 
 
 # Schwab Trading Tools

--- a/src/open_stocks_mcp/tools/schwab_market_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_market_tools.py
@@ -1,5 +1,6 @@
 """Schwab market data MCP tools using schwab-py library."""
 
+import datetime
 from typing import Any
 
 from schwab.client import Client
@@ -304,3 +305,221 @@ async def search_schwab_instruments(query: str) -> dict[str, Any]:
                 f"No results found for '{query}'. Try using exact ticker symbol."
             )
         )
+
+
+@handle_schwab_errors
+async def get_schwab_market_hours(
+    market: str = "equity", date: str | None = None
+) -> dict[str, Any]:
+    """Get market hours for a given market and optional date.
+
+    Args:
+        market: Market type ('equity', 'option', 'bond', 'forex', 'future')
+        date: Optional ISO date string (e.g. '2026-05-20'). Defaults to today.
+
+    Returns:
+        Dict with market hours data.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get market hours for {market}"
+    )
+    if error:
+        return error
+
+    market_map = {
+        "equity": Client.MarketHours.Market.EQUITY,
+        "option": Client.MarketHours.Market.OPTION,
+        "bond": Client.MarketHours.Market.BOND,
+        "forex": Client.MarketHours.Market.FOREX,
+        "future": Client.MarketHours.Market.FUTURE,
+    }
+
+    mapped_market = market_map.get(market.lower())
+    if mapped_market is None:
+        return create_error_response(
+            ValueError(
+                f"Invalid market '{market}'. Valid markets: {list(market_map.keys())}"
+            )
+        )
+
+    parsed_date: datetime.date | None = None
+    if date is not None:
+        try:
+            parsed_date = datetime.date.fromisoformat(date)
+        except ValueError:
+            return create_error_response(
+                ValueError(f"Invalid date format '{date}'. Use ISO format: YYYY-MM-DD")
+            )
+
+    try:
+
+        def _get_market_hours() -> Any:
+            response = broker.client.get_market_hours([mapped_market], date=parsed_date)
+            return response.json()
+
+        hours_data = await execute_broker_request(_get_market_hours, retry_safe=True)
+
+        return create_success_response(
+            {
+                "market": market.lower(),
+                "date": date,
+                "hours": hours_data,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab market hours for {market}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def get_schwab_movers(
+    index: str,
+    sort_order: str | None = None,
+    frequency: int | None = None,
+) -> dict[str, Any]:
+    """Get market movers for a given index.
+
+    Args:
+        index: Index to query (e.g. '$DJI', '$SPX', 'NASDAQ', 'NYSE', '$COMPX',
+               'EQUITY_ALL', 'INDEX_ALL', 'OPTION_ALL', 'OPTION_CALL', 'OPTION_PUT',
+               'OTCBB')
+        sort_order: Optional sort order ('PERCENT_CHANGE_UP', 'PERCENT_CHANGE_DOWN',
+                    'VOLUME', 'TRADES')
+        frequency: Optional frequency in minutes (0, 1, 5, 10, 30, 60)
+
+    Returns:
+        Dict with movers data.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get movers for {index}"
+    )
+    if error:
+        return error
+
+    index_map = {
+        "$compx": Client.Movers.Index.COMPX,
+        "$dji": Client.Movers.Index.DJI,
+        "equity_all": Client.Movers.Index.EQUITY_ALL,
+        "index_all": Client.Movers.Index.INDEX_ALL,
+        "nasdaq": Client.Movers.Index.NASDAQ,
+        "nyse": Client.Movers.Index.NYSE,
+        "option_all": Client.Movers.Index.OPTION_ALL,
+        "option_call": Client.Movers.Index.OPTION_CALL,
+        "option_put": Client.Movers.Index.OPTION_PUT,
+        "otcbb": Client.Movers.Index.OTCBB,
+        "$spx": Client.Movers.Index.SPX,
+    }
+
+    mapped_index = index_map.get(index.lower())
+    if mapped_index is None:
+        return create_error_response(
+            ValueError(
+                f"Invalid index '{index}'. Valid indexes: {list(index_map.keys())}"
+            )
+        )
+
+    sort_order_map = {
+        "percent_change_up": Client.Movers.SortOrder.PERCENT_CHANGE_UP,
+        "percent_change_down": Client.Movers.SortOrder.PERCENT_CHANGE_DOWN,
+        "volume": Client.Movers.SortOrder.VOLUME,
+        "trades": Client.Movers.SortOrder.TRADES,
+    }
+    mapped_sort_order = (
+        sort_order_map.get(sort_order.lower()) if sort_order is not None else None
+    )
+
+    frequency_map = {
+        0: Client.Movers.Frequency.ZERO,
+        1: Client.Movers.Frequency.ONE,
+        5: Client.Movers.Frequency.FIVE,
+        10: Client.Movers.Frequency.TEN,
+        30: Client.Movers.Frequency.THIRTY,
+        60: Client.Movers.Frequency.SIXTY,
+    }
+    mapped_frequency = frequency_map.get(frequency) if frequency is not None else None
+
+    try:
+
+        def _get_movers() -> Any:
+            response = broker.client.get_movers(
+                mapped_index,
+                sort_order=mapped_sort_order,
+                frequency=mapped_frequency,
+            )
+            return response.json()
+
+        movers_data = await execute_broker_request(_get_movers, retry_safe=True)
+
+        return create_success_response(
+            {
+                "index": index,
+                "movers": movers_data.get("screeners", movers_data),
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab movers for {index}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def get_schwab_movers_sp500(
+    sort_order: str | None = None,
+    frequency: int | None = None,
+) -> dict[str, Any]:
+    """Get market movers for the S&P 500 index ($SPX).
+
+    Args:
+        sort_order: Optional sort order ('PERCENT_CHANGE_UP', 'PERCENT_CHANGE_DOWN',
+                    'VOLUME', 'TRADES')
+        frequency: Optional frequency in minutes (0, 1, 5, 10, 30, 60)
+
+    Returns:
+        Dict with S&P 500 movers data.
+    """
+    return await get_schwab_movers("$SPX", sort_order=sort_order, frequency=frequency)
+
+
+@handle_schwab_errors
+async def get_schwab_instrument_by_cusip(cusip: str) -> dict[str, Any]:
+    """Get instrument details by CUSIP identifier.
+
+    Args:
+        cusip: CUSIP identifier (leading zeros are preserved, e.g. '037833100')
+
+    Returns:
+        Dict with instrument data.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get instrument by CUSIP {cusip}"
+    )
+    if error:
+        return error
+
+    cusip_clean = cusip.strip()
+    if not cusip_clean:
+        return create_error_response(ValueError("CUSIP cannot be empty"))
+
+    try:
+
+        def _get_instrument() -> Any:
+            response = broker.client.get_instrument_by_cusip(cusip_clean)
+            return response.json()
+
+        instrument_data = await execute_broker_request(_get_instrument, retry_safe=True)
+
+        return create_success_response(
+            {
+                "cusip": cusip_clean,
+                "symbol": instrument_data.get("symbol"),
+                "description": instrument_data.get("description"),
+                "exchange": instrument_data.get("exchange"),
+                "asset_type": instrument_data.get("assetType"),
+                "data": instrument_data,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab instrument by CUSIP {cusip}: {e}")
+        return create_error_response(e)

--- a/src/open_stocks_mcp/tools/schwab_market_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_market_tools.py
@@ -425,9 +425,15 @@ async def get_schwab_movers(
         "volume": Client.Movers.SortOrder.VOLUME,
         "trades": Client.Movers.SortOrder.TRADES,
     }
-    mapped_sort_order = (
-        sort_order_map.get(sort_order.lower()) if sort_order is not None else None
-    )
+    mapped_sort_order = None
+    if sort_order is not None:
+        mapped_sort_order = sort_order_map.get(sort_order.lower())
+        if mapped_sort_order is None:
+            return create_error_response(
+                ValueError(
+                    f"Invalid sort_order '{sort_order}'. Valid values: {list(sort_order_map.keys())}"
+                )
+            )
 
     frequency_map = {
         0: Client.Movers.Frequency.ZERO,
@@ -437,7 +443,15 @@ async def get_schwab_movers(
         30: Client.Movers.Frequency.THIRTY,
         60: Client.Movers.Frequency.SIXTY,
     }
-    mapped_frequency = frequency_map.get(frequency) if frequency is not None else None
+    mapped_frequency = None
+    if frequency is not None:
+        mapped_frequency = frequency_map.get(frequency)
+        if mapped_frequency is None:
+            return create_error_response(
+                ValueError(
+                    f"Invalid frequency {frequency}. Valid values: {list(frequency_map.keys())}"
+                )
+            )
 
     try:
 

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -181,6 +181,22 @@ class TestToolRegistration:
             assert tool_name in tool_names, f"Tool {tool_name} not registered"
 
     @pytest.mark.asyncio
+    async def test_schwab_market_data_expansion_tools_are_registered(self) -> None:
+        """Test that the four new Schwab market data expansion tools are registered."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+
+        expected_tools = [
+            "schwab_get_market_hours",
+            "schwab_get_movers",
+            "schwab_get_movers_sp500",
+            "schwab_get_instrument_by_cusip",
+        ]
+
+        for tool_name in expected_tools:
+            assert tool_name in tool_names, f"Tool {tool_name} not registered"
+
+    @pytest.mark.asyncio
     async def test_account_info_tool_callable(self) -> None:
         """Test that account_info tool is callable."""
         tools_list = await mcp.list_tools()

--- a/tests/unit/test_schwab_market_tools.py
+++ b/tests/unit/test_schwab_market_tools.py
@@ -434,6 +434,47 @@ class TestSchwabMovers:
 
         assert "result" in result
         assert "error" in result["result"]
+        assert "Invalid index" in result["result"]["error"]
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_movers_invalid_sort_order(
+        self,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test movers with invalid sort order."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await get_schwab_movers("$DJI", sort_order="INVALID_SORT")
+
+        assert "result" in result
+        assert "error" in result["result"]
+        assert "Invalid sort_order" in result["result"]["error"]
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_movers_invalid_frequency(
+        self,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test movers with invalid frequency."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await get_schwab_movers("$DJI", frequency=999)
+
+        assert "result" in result
+        assert "error" in result["result"]
+        assert "Invalid frequency" in result["result"]["error"]
 
     @pytest.mark.journey_market_data
     @pytest.mark.unit

--- a/tests/unit/test_schwab_market_tools.py
+++ b/tests/unit/test_schwab_market_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for Schwab market data tools."""
 
+import datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -7,6 +8,10 @@ import pytest
 
 from open_stocks_mcp.tools.schwab_market_tools import (
     get_schwab_instrument,
+    get_schwab_instrument_by_cusip,
+    get_schwab_market_hours,
+    get_schwab_movers,
+    get_schwab_movers_sp500,
     get_schwab_price_history,
     get_schwab_quote,
     get_schwab_quotes,
@@ -259,3 +264,310 @@ class TestSchwabMarketTools:
         # Search has a custom error message, so we just check status
         if function.__name__ != "search_schwab_instruments":
             assert "API Error" in result["result"]["error"]
+
+
+class TestSchwabMarketHours:
+    """Tests for get_schwab_market_hours."""
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.Client")
+    async def test_get_market_hours_success(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test successful market hours retrieval."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.MarketHours.Market.EQUITY = "equity"
+        mock_execute.return_value = {"equity": {"isOpen": True, "sessionHours": {}}}
+
+        result = await get_schwab_market_hours("equity", "2026-05-20")
+
+        assert "result" in result
+        assert result["result"]["market"] == "equity"
+        assert "hours" in result["result"]
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.Client")
+    async def test_get_market_hours_passes_date_object(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test that a date string is parsed into datetime.date before the call."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.MarketHours.Market.EQUITY = "equity"
+        mock_execute.return_value = {}
+
+        await get_schwab_market_hours("equity", "2026-05-20")
+
+        # Grab the callable passed to execute_broker_request and call it
+        call_args = mock_execute.call_args
+        inner_fn = call_args[0][0]
+        inner_fn()  # Triggers broker.client.get_market_hours(...)
+        _, kwargs = mock_broker.client.get_market_hours.call_args
+        assert kwargs["date"] == datetime.date(2026, 5, 20)
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_market_hours_invalid_market(
+        self,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test market hours with invalid market string."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await get_schwab_market_hours("invalid_market")
+
+        assert "result" in result
+        assert "error" in result["result"]
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_market_hours_auth_error(
+        self,
+        mock_get_broker: AsyncMock,
+        broker_auth_error_payload: dict[str, Any],
+    ) -> None:
+        """Test market hours when auth fails."""
+        mock_get_broker.return_value = (None, broker_auth_error_payload)
+
+        result = await get_schwab_market_hours("equity")
+
+        assert result == broker_auth_error_payload
+
+
+class TestSchwabMovers:
+    """Tests for get_schwab_movers and get_schwab_movers_sp500."""
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.Client")
+    async def test_get_movers_dji_success(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test movers retrieval for $DJI."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Movers.Index.DJI = "$DJI"
+        mock_execute.return_value = {"screeners": [{"symbol": "AAPL", "volume": 1000}]}
+
+        result = await get_schwab_movers("$DJI")
+
+        assert "result" in result
+        assert result["result"]["index"] == "$DJI"
+        assert "movers" in result["result"]
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.Client")
+    async def test_get_movers_nasdaq_success(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test movers retrieval for NASDAQ."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Movers.Index.NASDAQ = "NASDAQ"
+        mock_execute.return_value = {"screeners": []}
+
+        result = await get_schwab_movers("NASDAQ")
+
+        assert "result" in result
+        assert result["result"]["index"] == "NASDAQ"
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_movers_invalid_index(
+        self,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test movers with invalid index."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await get_schwab_movers("INVALID_INDEX")
+
+        assert "result" in result
+        assert "error" in result["result"]
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_market_tools.Client")
+    async def test_get_movers_sp500_uses_spx(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test that sp500 shortcut passes $SPX to the client."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Movers.Index.SPX = "$SPX"
+        mock_execute.return_value = {"screeners": []}
+
+        result = await get_schwab_movers_sp500()
+
+        assert "result" in result
+        assert result["result"]["index"] == "$SPX"
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_movers_auth_error(
+        self,
+        mock_get_broker: AsyncMock,
+        broker_auth_error_payload: dict[str, Any],
+    ) -> None:
+        """Test movers when auth fails."""
+        mock_get_broker.return_value = (None, broker_auth_error_payload)
+
+        result = await get_schwab_movers("$DJI")
+
+        assert result == broker_auth_error_payload
+
+
+class TestSchwabInstrumentByCusip:
+    """Tests for get_schwab_instrument_by_cusip."""
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
+    async def test_get_instrument_by_cusip_success(
+        self,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test successful CUSIP instrument lookup preserving leading zeros."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_execute.return_value = {
+            "cusip": "037833100",
+            "symbol": "AAPL",
+            "description": "Apple Inc",
+            "exchange": "Q",
+            "assetType": "EQUITY",
+        }
+
+        result = await get_schwab_instrument_by_cusip("037833100")
+
+        assert "result" in result
+        assert result["result"]["cusip"] == "037833100"
+        assert result["result"]["symbol"] == "AAPL"
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_market_tools.execute_broker_request")
+    async def test_get_instrument_by_cusip_passes_exact_string(
+        self,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test CUSIP with whitespace is trimmed but leading zeros preserved."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_execute.return_value = {}
+
+        await get_schwab_instrument_by_cusip("  037833100  ")
+
+        call_args = mock_execute.call_args
+        inner_fn = call_args[0][0]
+        inner_fn()
+        mock_broker.client.get_instrument_by_cusip.assert_called_once_with("037833100")
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_instrument_by_cusip_empty_string(
+        self,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test CUSIP lookup with empty/blank CUSIP returns error."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await get_schwab_instrument_by_cusip("   ")
+
+        assert "result" in result
+        assert "error" in result["result"]
+
+    @pytest.mark.journey_market_data
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_instrument_by_cusip_auth_error(
+        self,
+        mock_get_broker: AsyncMock,
+        broker_auth_error_payload: dict[str, Any],
+    ) -> None:
+        """Test CUSIP lookup when auth fails."""
+        mock_get_broker.return_value = (None, broker_auth_error_payload)
+
+        result = await get_schwab_instrument_by_cusip("037833100")
+
+        assert result == broker_auth_error_payload


### PR DESCRIPTION
Closes #194

## Changes
- Add `get_schwab_market_hours(market, date)` wrapping `client.get_market_hours()` with enum-mapped market types and ISO date parsing
- Add `get_schwab_movers(index, sort_order, frequency)` wrapping `client.get_movers()` with enum-mapped index, sort order, and frequency
- Add `get_schwab_movers_sp500(sort_order, frequency)` as a thin `$SPX` shortcut
- Add `get_schwab_instrument_by_cusip(cusip)` wrapping `client.get_instrument_by_cusip()` with whitespace trimming and leading-zero preservation
- Register all four as MCP tools in `app.py` with names matching the acceptance criteria exactly
- Add 13 new unit tests with `journey_market_data` markers covering success, auth error, invalid input, and invariant (date object, exact CUSIP string) cases
- Add registration assertion `test_schwab_market_data_expansion_tools_are_registered` in `test_server_app.py`

## Test plan
- `uv run pytest -m journey_market_data tests/unit/test_schwab_market_tools.py -v` → 26 passed
- `uv run pytest tests/server/test_server_app.py::TestToolRegistration -v` → all passed
- `uv run mypy src/open_stocks_mcp/tools/schwab_market_tools.py src/open_stocks_mcp/server/app.py` → no issues
- `uv run ruff check` → all checks passed