### PR TITLE
feat: add five Schwab options MCP tools

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1508,6 +1508,86 @@ async def schwab_options_positions(account_hash: str) -> dict[str, Any]:
 
 
 @mcp.tool()
+async def schwab_find_tradable_options(
+    symbol: str,
+    expiration_date: str | None = None,
+    option_type: str | None = None,
+    strike: float | None = None,
+) -> dict[str, Any]:
+    """Find tradable option contracts filtered by expiration, type, and strike.
+
+    Args:
+        symbol: Underlying stock ticker symbol
+        expiration_date: Optional expiration date (YYYY-MM-DD) to filter by
+        option_type: Optional contract type ('call' or 'put')
+        strike: Optional strike price to filter by
+    """
+    return await _schwab_find_tradable_options_impl(
+        symbol, expiration_date, option_type, strike
+    )
+
+
+@mcp.tool()
+async def schwab_option_positions_detailed(account_hash: str) -> dict[str, Any]:
+    """Get open option positions enriched with live market quotes.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+    """
+    return await schwab_get_option_positions_detailed(account_hash)
+
+
+@mcp.tool()
+async def schwab_option_quote(
+    symbol: str,
+    expiration_date: str,
+    strike: float,
+    option_type: str,
+) -> dict[str, Any]:
+    """Get a quote for a single option contract.
+
+    Args:
+        symbol: Underlying stock ticker symbol
+        expiration_date: Contract expiration (YYYY-MM-DD)
+        strike: Strike price
+        option_type: 'call' or 'put'
+    """
+    return await schwab_get_option_quote(
+        symbol, expiration_date, strike, option_type
+    )
+
+
+@mcp.tool()
+async def schwab_option_orders(
+    account_hash: str,
+    max_results: int = 50,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """Get orders filtered to option-legged orders.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        max_results: Maximum number of orders to fetch (default: 50)
+        status: Optional order status filter (e.g. 'FILLED', 'WORKING')
+    """
+    return await schwab_get_option_orders(account_hash, max_results, status)
+
+
+@mcp.tool()
+async def schwab_open_option_orders(
+    account_hash: str,
+    max_results: int = 50,
+) -> dict[str, Any]:
+    """Get open (working/pending) option-legged orders.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        max_results: Maximum number of orders to fetch (default: 50)
+    """
+    return await schwab_get_open_option_orders(account_hash, max_results)
+
+
+@mcp.tool()
 async def schwab_option_buy_to_open(
     account_hash: str,
     symbol: str,

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -678,7 +678,6 @@ async def schwab_get_option_positions_detailed(
                 response = broker.client.get_option_chain(
                     symbol.upper(),
                     contract_type=contract_type,
-                    strike_count=1,
                 )
                 return response.json()
 

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -408,6 +408,9 @@ _OPEN_ORDER_STATUSES = {
 }
 
 
+_CALL_PUT_ONLY = ("call", "put")
+
+
 def _resolve_contract_type(option_type: str | None) -> Any:
     """Resolve a string option type to a schwab-py ContractType enum value."""
     if option_type is None:
@@ -417,6 +420,16 @@ def _resolve_contract_type(option_type: str | None) -> Any:
         return None
     enum_name = _CONTRACT_TYPE_MAP[key]
     return getattr(Client.Options.ContractType, enum_name, None)
+
+
+def _resolve_call_put_only(option_type: str | None) -> Any:
+    """Resolve option_type to a ContractType enum, accepting only 'call' or 'put'."""
+    if option_type is None:
+        return None
+    key = option_type.lower()
+    if key not in _CALL_PUT_ONLY:
+        return None
+    return _resolve_contract_type(key)
 
 
 def _flatten_chain_map(chain_map: dict[str, Any], put_call: str) -> list[dict[str, Any]]:
@@ -535,11 +548,11 @@ async def schwab_find_tradable_options(
 
     ct = None
     if option_type is not None:
-        ct = _resolve_contract_type(option_type)
+        ct = _resolve_call_put_only(option_type)
         if ct is None:
             return create_error_response(
                 ValueError(
-                    f"Invalid option_type. Valid options: {list(_CONTRACT_TYPE_MAP.keys())}"
+                    f"Invalid option_type. Valid options: {list(_CALL_PUT_ONLY)}"
                 )
             )
 
@@ -767,11 +780,11 @@ async def schwab_get_option_quote(
     if error:
         return error
 
-    ct = _resolve_contract_type(option_type)
+    ct = _resolve_call_put_only(option_type)
     if ct is None:
         return create_error_response(
             ValueError(
-                f"Invalid option_type. Valid options: {list(_CONTRACT_TYPE_MAP.keys())}"
+                f"Invalid option_type. Valid options: {list(_CALL_PUT_ONLY)}"
             )
         )
 

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -389,3 +389,546 @@ async def schwab_option_sell_to_close(
     except Exception as e:
         logger.error(f"Error placing Schwab option sell order: {e}")
         return create_error_response(e)
+
+
+_CONTRACT_TYPE_MAP = {
+    "call": "CALL",
+    "put": "PUT",
+    "all": "ALL",
+}
+
+_OPEN_ORDER_STATUSES = {
+    "WORKING",
+    "PENDING_ACTIVATION",
+    "QUEUED",
+    "ACCEPTED",
+    "AWAITING_CONDITION",
+    "AWAITING_MANUAL_REVIEW",
+    "AWAITING_PARENT_ORDER",
+}
+
+
+def _resolve_contract_type(option_type: str | None) -> Any:
+    """Resolve a string option type to a schwab-py ContractType enum value."""
+    if option_type is None:
+        return None
+    key = option_type.lower()
+    if key not in _CONTRACT_TYPE_MAP:
+        return None
+    enum_name = _CONTRACT_TYPE_MAP[key]
+    return getattr(Client.Options.ContractType, enum_name, None)
+
+
+def _flatten_chain_map(chain_map: dict[str, Any], put_call: str) -> list[dict[str, Any]]:
+    """Flatten a Schwab callExpDateMap/putExpDateMap into a list of contracts."""
+    contracts: list[dict[str, Any]] = []
+    if not isinstance(chain_map, dict):
+        return contracts
+    for exp_key, strikes in chain_map.items():
+        if not isinstance(strikes, dict):
+            continue
+        # Schwab returns expiration keys as "YYYY-MM-DD:DTE"; strip suffix
+        expiration = exp_key.split(":", 1)[0]
+        for strike_key, entries in strikes.items():
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                contract = dict(entry)
+                contract.setdefault("expiration", expiration)
+                contract.setdefault("strike", _safe_float(strike_key))
+                contract.setdefault("putCall", put_call)
+                contracts.append(contract)
+    return contracts
+
+
+def _safe_float(value: Any) -> float | None:
+    """Convert a value to float, returning None on failure."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _strikes_match(actual: Any, requested: float) -> bool:
+    """Compare a chain-map strike key against a requested float strike."""
+    candidate = _safe_float(actual)
+    if candidate is None:
+        return False
+    return abs(candidate - requested) < 1e-6
+
+
+def _find_contract_for_expiration(
+    chain_map: dict[str, Any],
+    expiration: str,
+    strike: float,
+    put_call: str,
+) -> dict[str, Any] | None:
+    """Find the first contract entry matching an expiration prefix and strike."""
+    if not isinstance(chain_map, dict):
+        return None
+    for exp_key, strikes in chain_map.items():
+        if not exp_key.startswith(expiration):
+            continue
+        if not isinstance(strikes, dict):
+            continue
+        for strike_key, entries in strikes.items():
+            if not _strikes_match(strike_key, strike):
+                continue
+            if not isinstance(entries, list) or not entries:
+                continue
+            first = entries[0]
+            if not isinstance(first, dict):
+                continue
+            contract = dict(first)
+            contract.setdefault("expiration", exp_key.split(":", 1)[0])
+            contract.setdefault("strike", _safe_float(strike_key))
+            contract.setdefault("putCall", put_call)
+            return contract
+    return None
+
+
+def _order_has_option_leg(order: dict[str, Any]) -> bool:
+    """Return True when an order contains at least one OPTION leg.
+
+    Checks both ``orderLegType`` (older shape) and ``instrument.assetType``
+    (current shape) since the Schwab API exposes both.
+    """
+    legs = order.get("orderLegCollection")
+    if not isinstance(legs, list):
+        return False
+    for leg in legs:
+        if not isinstance(leg, dict):
+            continue
+        if leg.get("orderLegType") == "OPTION":
+            return True
+        instrument = leg.get("instrument")
+        if isinstance(instrument, dict) and instrument.get("assetType") == "OPTION":
+            return True
+    return False
+
+
+@handle_schwab_errors
+async def schwab_find_tradable_options(
+    symbol: str,
+    expiration_date: str | None = None,
+    option_type: str | None = None,
+    strike: float | None = None,
+) -> dict[str, Any]:
+    """Find tradable option contracts filtered by expiration, type, and strike.
+
+    Args:
+        symbol: Underlying stock symbol.
+        expiration_date: Optional expiration date (YYYY-MM-DD) to filter by.
+        option_type: Optional contract type ('call' or 'put'); ``None`` returns both.
+        strike: Optional strike price to filter by.
+
+    Returns:
+        Dict with ``options`` (filtered list), ``total_found``, and ``filters``.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"find tradable options for {symbol}"
+    )
+    if error:
+        return error
+
+    ct = None
+    if option_type is not None:
+        ct = _resolve_contract_type(option_type)
+        if ct is None:
+            return create_error_response(
+                ValueError(
+                    f"Invalid option_type. Valid options: {list(_CONTRACT_TYPE_MAP.keys())}"
+                )
+            )
+
+    exp_dt: date | None = None
+    if expiration_date is not None:
+        try:
+            exp_dt = date.fromisoformat(expiration_date)
+        except ValueError as exc:
+            return create_error_response(exc)
+
+    try:
+
+        def _get_option_chain() -> Any:
+            response = broker.client.get_option_chain(
+                symbol.upper(),
+                contract_type=ct,
+                from_date=exp_dt,
+                to_date=exp_dt,
+            )
+            return response.json()
+
+        chain_data = await execute_broker_request(_get_option_chain, retry_safe=True)
+
+        call_map = chain_data.get("callExpDateMap", {}) if isinstance(chain_data, dict) else {}
+        put_map = chain_data.get("putExpDateMap", {}) if isinstance(chain_data, dict) else {}
+
+        type_key = option_type.lower() if option_type else None
+
+        options: list[dict[str, Any]] = []
+        if type_key != "put":
+            options.extend(_flatten_chain_map(call_map, "CALL"))
+        if type_key != "call":
+            options.extend(_flatten_chain_map(put_map, "PUT"))
+
+        if strike is not None:
+            options = [
+                contract
+                for contract in options
+                if _strikes_match(contract.get("strike"), strike)
+            ]
+
+        return create_success_response(
+            {
+                "symbol": symbol.upper(),
+                "options": options,
+                "total_found": len(options),
+                "filters": {
+                    "expiration_date": expiration_date,
+                    "option_type": option_type.upper() if option_type else None,
+                    "strike": strike,
+                },
+            }
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Error finding tradable Schwab options for {symbol}: {e}"
+        )
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_option_positions_detailed(
+    account_hash: str,
+) -> dict[str, Any]:
+    """Get open option positions enriched with live market quotes.
+
+    Each position is enriched with a ``quote`` dict containing bid/ask/last and
+    available greeks looked up via the option chain for the underlying symbol.
+    Option chains are fetched at most once per underlying symbol per call.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers().
+
+    Returns:
+        Dict with ``positions``, ``count``, and ``enrichment_success_rate``.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get detailed option positions for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_account() -> Any:
+            response = broker.client.get_account(
+                account_hash, fields=Client.Account.Fields.POSITIONS
+            )
+            return response.json()
+
+        account_data = await execute_broker_request(_get_account, retry_safe=True)
+
+        securities_account = account_data.get("securitiesAccount", {})
+        all_positions = securities_account.get("positions", [])
+
+        positions: list[dict[str, Any]] = []
+        for position in all_positions:
+            instrument = position.get("instrument", {})
+            if instrument.get("assetType") != "OPTION":
+                continue
+            positions.append(
+                {
+                    "symbol": instrument.get("symbol"),
+                    "underlying_symbol": instrument.get("underlyingSymbol"),
+                    "option_type": instrument.get("putCall"),
+                    "strike_price": instrument.get("strikePrice"),
+                    "expiration_date": instrument.get("expirationDate"),
+                    "quantity": position.get("longQuantity", 0)
+                    + position.get("shortQuantity", 0),
+                    "average_price": position.get("averagePrice"),
+                    "market_value": position.get("marketValue"),
+                    "current_day_pl": position.get("currentDayProfitLoss"),
+                    "quote": {},
+                }
+            )
+
+        if not positions:
+            return create_success_response(
+                {
+                    "positions": [],
+                    "count": 0,
+                    "enrichment_success_rate": "0%",
+                }
+            )
+
+        # Group underlyings so each option chain is fetched once.
+        chain_cache: dict[str, dict[str, Any] | None] = {}
+        for position in positions:
+            underlying = position.get("underlying_symbol")
+            if not underlying or underlying in chain_cache:
+                continue
+            ct = _resolve_contract_type(
+                str(position.get("option_type") or "").lower() or None
+            )
+
+            def _get_chain(symbol: str = underlying, contract_type: Any = ct) -> Any:
+                response = broker.client.get_option_chain(
+                    symbol.upper(),
+                    contract_type=contract_type,
+                    strike_count=1,
+                )
+                return response.json()
+
+            try:
+                chain_cache[underlying] = await execute_broker_request(
+                    _get_chain, retry_safe=True
+                )
+            except Exception as chain_error:
+                logger.warning(
+                    f"Failed to fetch option chain for {underlying}: {chain_error}"
+                )
+                chain_cache[underlying] = None
+
+        enriched = 0
+        for position in positions:
+            underlying = position.get("underlying_symbol")
+            chain_data = chain_cache.get(underlying) if underlying else None
+            if not isinstance(chain_data, dict):
+                continue
+            strike_price = _safe_float(position.get("strike_price"))
+            expiration = position.get("expiration_date")
+            option_type = str(position.get("option_type") or "").upper()
+            if strike_price is None or not expiration:
+                continue
+            map_key = (
+                "callExpDateMap" if option_type == "CALL" else "putExpDateMap"
+            )
+            # Schwab expirationDate from positions can include time; strip to date.
+            exp_prefix = str(expiration).split("T", 1)[0][:10]
+            contract = _find_contract_for_expiration(
+                chain_data.get(map_key, {}),
+                exp_prefix,
+                strike_price,
+                option_type,
+            )
+            if contract is None:
+                continue
+            position["quote"] = {
+                "bid": contract.get("bid"),
+                "ask": contract.get("ask"),
+                "last": contract.get("last"),
+                "mark": contract.get("mark"),
+                "delta": contract.get("delta"),
+                "gamma": contract.get("gamma"),
+                "theta": contract.get("theta"),
+                "vega": contract.get("vega"),
+                "volatility": contract.get("volatility"),
+            }
+            enriched += 1
+
+        rate = round((enriched / len(positions)) * 100)
+
+        return create_success_response(
+            {
+                "positions": positions,
+                "count": len(positions),
+                "enrichment_success_rate": f"{rate}%",
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting detailed Schwab option positions: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_option_quote(
+    symbol: str,
+    expiration_date: str,
+    strike: float,
+    option_type: str,
+) -> dict[str, Any]:
+    """Get a quote for a single option contract.
+
+    Args:
+        symbol: Underlying stock symbol.
+        expiration_date: Contract expiration (YYYY-MM-DD).
+        strike: Strike price.
+        option_type: 'call' or 'put'.
+
+    Returns:
+        Dict with the contract data or an error if the contract is not found.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get option quote for {symbol}"
+    )
+    if error:
+        return error
+
+    ct = _resolve_contract_type(option_type)
+    if ct is None:
+        return create_error_response(
+            ValueError(
+                f"Invalid option_type. Valid options: {list(_CONTRACT_TYPE_MAP.keys())}"
+            )
+        )
+
+    try:
+        exp_dt = date.fromisoformat(expiration_date)
+    except ValueError as exc:
+        return create_error_response(exc)
+
+    try:
+
+        def _get_option_chain() -> Any:
+            response = broker.client.get_option_chain(
+                symbol.upper(),
+                contract_type=ct,
+                from_date=exp_dt,
+                to_date=exp_dt,
+            )
+            return response.json()
+
+        chain_data = await execute_broker_request(_get_option_chain, retry_safe=True)
+
+        put_call = option_type.upper()
+        map_key = "callExpDateMap" if put_call == "CALL" else "putExpDateMap"
+        chain_map = chain_data.get(map_key, {}) if isinstance(chain_data, dict) else {}
+
+        contract = _find_contract_for_expiration(
+            chain_map, expiration_date, strike, put_call
+        )
+        if contract is None:
+            return create_error_response(
+                ValueError(
+                    f"No {put_call} contract found for {symbol.upper()} "
+                    f"{expiration_date} @ {strike}"
+                )
+            )
+
+        return create_success_response(contract)
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab option quote for {symbol}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_option_orders(
+    account_hash: str,
+    max_results: int = 50,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """Get orders filtered to option-legged orders.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers().
+        max_results: Maximum number of orders to fetch from the broker.
+        status: Optional order status filter (e.g. 'FILLED', 'WORKING').
+
+    Returns:
+        Dict with ``orders`` (list) and ``count``.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get option orders for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_orders() -> Any:
+            response = broker.client.get_orders_for_account(
+                account_hash, max_results=max_results
+            )
+            return response.json()
+
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
+
+        if not isinstance(orders_data, list):
+            return create_error_response(
+                ValueError("Unexpected orders payload (not a list)")
+            )
+
+        filtered: list[dict[str, Any]] = []
+        for order in orders_data:
+            if not isinstance(order, dict):
+                continue
+            if not _order_has_option_leg(order):
+                continue
+            if status is not None and order.get("status") != status:
+                continue
+            filtered.append(order)
+
+        return create_success_response(
+            {
+                "orders": filtered,
+                "count": len(filtered),
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab option orders: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_open_option_orders(
+    account_hash: str,
+    max_results: int = 50,
+) -> dict[str, Any]:
+    """Get open (working/pending) option-legged orders.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers().
+        max_results: Maximum number of orders to fetch from the broker.
+
+    Returns:
+        Dict with ``orders`` and ``count``.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get open option orders for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_orders() -> Any:
+            response = broker.client.get_orders_for_account(
+                account_hash, max_results=max_results
+            )
+            return response.json()
+
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
+
+        if not isinstance(orders_data, list):
+            return create_error_response(
+                ValueError("Unexpected orders payload (not a list)")
+            )
+
+        filtered: list[dict[str, Any]] = []
+        for order in orders_data:
+            if not isinstance(order, dict):
+                continue
+            if not _order_has_option_leg(order):
+                continue
+            if order.get("status") not in _OPEN_ORDER_STATUSES:
+                continue
+            filtered.append(order)
+
+        return create_success_response(
+            {
+                "orders": filtered,
+                "count": len(filtered),
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting open Schwab option orders: {e}")
+        return create_error_response(e)

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -672,9 +672,7 @@ async def schwab_get_option_positions_detailed(
             underlying = position.get("underlying_symbol")
             if not underlying or underlying in chain_cache:
                 continue
-            ct = _resolve_contract_type(
-                str(position.get("option_type") or "").lower() or None
-            )
+            ct = _resolve_contract_type("all")
 
             def _get_chain(symbol: str = underlying, contract_type: Any = ct) -> Any:
                 response = broker.client.get_option_chain(

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -679,6 +679,85 @@ class TestSchwabOptionsTools:
     )
     @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_positions_detailed_mixed_call_put_same_underlying(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Mixed CALL/PUT positions on one underlying both enrich from one ALL-chain fetch."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+        mock_client.Options.ContractType.ALL = "ALL"
+
+        account_payload = {
+            "securitiesAccount": {
+                "positions": [
+                    {
+                        "shortQuantity": 0.0,
+                        "averagePrice": 6.50,
+                        "longQuantity": 1.0,
+                        "currentDayProfitLoss": 50.0,
+                        "instrument": {
+                            "assetType": "OPTION",
+                            "symbol": "AAPL_011924C170",
+                            "underlyingSymbol": "AAPL",
+                            "putCall": "CALL",
+                            "strikePrice": 170.0,
+                            "expirationDate": "2024-01-19T00:00:00.000Z",
+                        },
+                        "marketValue": 700.0,
+                    },
+                    {
+                        "shortQuantity": 0.0,
+                        "averagePrice": 3.20,
+                        "longQuantity": 1.0,
+                        "currentDayProfitLoss": 25.0,
+                        "instrument": {
+                            "assetType": "OPTION",
+                            "symbol": "AAPL_011924P170",
+                            "underlyingSymbol": "AAPL",
+                            "putCall": "PUT",
+                            "strikePrice": 170.0,
+                            "expirationDate": "2024-01-19T00:00:00.000Z",
+                        },
+                        "marketValue": 330.0,
+                    },
+                ]
+            }
+        }
+        chain_payload = {
+            "callExpDateMap": {
+                "2024-01-19:30": {
+                    "170.0": [{"putCall": "CALL", "bid": 6.60, "ask": 6.70, "last": 6.65}]
+                }
+            },
+            "putExpDateMap": {
+                "2024-01-19:30": {
+                    "170.0": [{"putCall": "PUT", "bid": 3.10, "ask": 3.20, "last": 3.15}]
+                }
+            },
+        }
+        mock_to_thread.side_effect = [account_payload, chain_payload]
+
+        result = await schwab_get_option_positions_detailed("abc123")
+
+        positions = result["result"]["positions"]
+        assert len(positions) == 2
+        assert positions[0]["quote"]["bid"] == 6.60
+        assert positions[1]["quote"]["bid"] == 3.10
+        assert result["result"]["enrichment_success_rate"] == "100%"
+        _assert_retry_safe(mock_to_thread, True)
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
     async def test_get_option_positions_detailed_no_positions(
         self,
         mock_client: MagicMock,

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -758,6 +758,75 @@ class TestSchwabOptionsTools:
     )
     @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
     @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_positions_detailed_otm_strike_enriched(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Positions with strikes far OTM/ITM from ATM are still enriched when strike_count is not truncated."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+        mock_client.Options.ContractType.ALL = "ALL"
+
+        # Position at 250.0 — a strike well away from a hypothetical ATM of 170.
+        account_payload = {
+            "securitiesAccount": {
+                "positions": [
+                    {
+                        "shortQuantity": 0.0,
+                        "averagePrice": 1.20,
+                        "longQuantity": 2.0,
+                        "currentDayProfitLoss": -40.0,
+                        "instrument": {
+                            "assetType": "OPTION",
+                            "symbol": "AAPL_011924C250",
+                            "underlyingSymbol": "AAPL",
+                            "putCall": "CALL",
+                            "strikePrice": 250.0,
+                            "expirationDate": "2024-01-19T00:00:00.000Z",
+                        },
+                        "marketValue": 240.0,
+                    }
+                ]
+            }
+        }
+        # Chain contains only the far-OTM strike (250.0), simulating a full-chain response.
+        chain_payload = {
+            "callExpDateMap": {
+                "2024-01-19:30": {
+                    "250.0": [
+                        {
+                            "putCall": "CALL",
+                            "bid": 1.10,
+                            "ask": 1.30,
+                            "last": 1.20,
+                            "mark": 1.20,
+                            "delta": 0.05,
+                        }
+                    ]
+                }
+            }
+        }
+        mock_to_thread.side_effect = [account_payload, chain_payload]
+
+        result = await schwab_get_option_positions_detailed("abc123")
+
+        positions = result["result"]["positions"]
+        assert len(positions) == 1
+        assert positions[0]["quote"]["bid"] == 1.10
+        assert positions[0]["quote"]["ask"] == 1.30
+        assert result["result"]["enrichment_success_rate"] == "100%"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
     async def test_get_option_positions_detailed_no_positions(
         self,
         mock_client: MagicMock,

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -9,6 +9,11 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_chain_by_expiration,
     get_schwab_option_expirations,
     get_schwab_options_positions,
+    schwab_find_tradable_options,
+    schwab_get_open_option_orders,
+    schwab_get_option_orders,
+    schwab_get_option_positions_detailed,
+    schwab_get_option_quote,
     schwab_option_buy_to_open,
     schwab_option_sell_to_close,
 )
@@ -400,6 +405,7 @@ class TestSchwabOptionsTools:
     async def test_schwab_option_buy_to_open_mcp_wrapper(self) -> None:
         """Test the MCP wrapper for schwab_option_buy_to_open."""
         from unittest.mock import AsyncMock, patch
+
         from open_stocks_mcp.server.app import schwab_option_buy_to_open
 
         with patch(
@@ -427,6 +433,7 @@ class TestSchwabOptionsTools:
     async def test_schwab_option_sell_to_close_mcp_wrapper(self) -> None:
         """Test the MCP wrapper for schwab_option_sell_to_close."""
         from unittest.mock import AsyncMock, patch
+
         from open_stocks_mcp.server.app import schwab_option_sell_to_close
 
         with patch(
@@ -448,3 +455,514 @@ class TestSchwabOptionsTools:
                 "HASH", "AAPL", 1, "CALL", 150.0, "2026-06-19"
             )
             assert result == {"result": {"status": "order_placed"}}
+
+    # ---- schwab_find_tradable_options ----------------------------------
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_find_tradable_options_filters_by_type_and_expiration(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Filter to calls at a specific expiration only."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_client.Options.ContractType.CALL = "CALL"
+        mock_client.Options.ContractType.PUT = "PUT"
+        mock_client.Options.ContractType.ALL = "ALL"
+
+        mock_to_thread.return_value = {
+            "callExpDateMap": {
+                "2024-01-19:30": {
+                    "170.0": [
+                        {
+                            "putCall": "CALL",
+                            "symbol": "AAPL_011924C170",
+                            "bid": 6.50,
+                            "ask": 6.55,
+                        }
+                    ],
+                    "175.0": [
+                        {
+                            "putCall": "CALL",
+                            "symbol": "AAPL_011924C175",
+                            "bid": 4.10,
+                            "ask": 4.15,
+                        }
+                    ],
+                }
+            },
+            "putExpDateMap": {
+                "2024-01-19:30": {
+                    "170.0": [
+                        {
+                            "putCall": "PUT",
+                            "symbol": "AAPL_011924P170",
+                            "bid": 3.20,
+                            "ask": 3.25,
+                        }
+                    ],
+                }
+            },
+        }
+
+        result = await schwab_find_tradable_options(
+            "AAPL", expiration_date="2024-01-19", option_type="call"
+        )
+
+        assert "result" in result
+        options = result["result"]["options"]
+        assert len(options) == 2
+        assert {opt["putCall"] for opt in options} == {"CALL"}
+        assert result["result"]["total_found"] == 2
+        assert result["result"]["filters"]["option_type"] == "CALL"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_find_tradable_options_strike_filter(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Strike filter narrows the returned contracts."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Options.ContractType.CALL = "CALL"
+        mock_client.Options.ContractType.PUT = "PUT"
+        mock_client.Options.ContractType.ALL = "ALL"
+
+        mock_to_thread.return_value = {
+            "callExpDateMap": {
+                "2024-01-19:30": {
+                    "170.0": [{"putCall": "CALL", "symbol": "C170"}],
+                    "175.0": [{"putCall": "CALL", "symbol": "C175"}],
+                }
+            },
+            "putExpDateMap": {},
+        }
+
+        result = await schwab_find_tradable_options("AAPL", strike=170.0)
+
+        assert result["result"]["total_found"] == 1
+        assert result["result"]["options"][0]["symbol"] == "C170"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    async def test_find_tradable_options_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Auth failures short-circuit and return the error tuple."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        result = await schwab_find_tradable_options("AAPL")
+
+        assert result == error_response
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    async def test_find_tradable_options_invalid_option_type(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Invalid option_type is rejected before any API call."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await schwab_find_tradable_options("AAPL", option_type="bogus")
+
+        assert result["result"]["status"] == "error"
+        assert "Invalid option_type" in result["result"]["error"]
+
+    # ---- schwab_get_option_positions_detailed --------------------------
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_positions_detailed_enriches_with_quote(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Each open option position is enriched with a quote sub-dict."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_client.Account.Fields.POSITIONS = "positions"
+        mock_client.Options.ContractType.CALL = "CALL"
+        mock_client.Options.ContractType.PUT = "PUT"
+
+        account_payload = {
+            "securitiesAccount": {
+                "positions": [
+                    {
+                        "shortQuantity": 0.0,
+                        "averagePrice": 6.50,
+                        "longQuantity": 1.0,
+                        "currentDayProfitLoss": 50.0,
+                        "instrument": {
+                            "assetType": "OPTION",
+                            "symbol": "AAPL_011924C170",
+                            "underlyingSymbol": "AAPL",
+                            "putCall": "CALL",
+                            "strikePrice": 170.0,
+                            "expirationDate": "2024-01-19T00:00:00.000Z",
+                        },
+                        "marketValue": 700.0,
+                    }
+                ]
+            }
+        }
+        chain_payload = {
+            "callExpDateMap": {
+                "2024-01-19:30": {
+                    "170.0": [
+                        {
+                            "putCall": "CALL",
+                            "bid": 6.60,
+                            "ask": 6.70,
+                            "last": 6.65,
+                            "mark": 6.65,
+                            "delta": 0.55,
+                        }
+                    ]
+                }
+            }
+        }
+        mock_to_thread.side_effect = [account_payload, chain_payload]
+
+        result = await schwab_get_option_positions_detailed("abc123")
+
+        assert "result" in result
+        positions = result["result"]["positions"]
+        assert len(positions) == 1
+        quote = positions[0]["quote"]
+        assert quote["bid"] == 6.60
+        assert quote["ask"] == 6.70
+        assert quote["last"] == 6.65
+        assert result["result"]["enrichment_success_rate"] == "100%"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_positions_detailed_no_positions(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Empty positions returns count=0 and 0% enrichment."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+
+        mock_to_thread.return_value = {"securitiesAccount": {"positions": []}}
+
+        result = await schwab_get_option_positions_detailed("abc123")
+
+        assert result["result"]["count"] == 0
+        assert result["result"]["enrichment_success_rate"] == "0%"
+        assert result["result"]["positions"] == []
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_option_positions_detailed_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        result = await schwab_get_option_positions_detailed("abc123")
+
+        assert result == error_response
+
+    # ---- schwab_get_option_quote ---------------------------------------
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_quote_returns_contract(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Single contract lookup returns the requested contract dict."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Options.ContractType.CALL = "CALL"
+
+        mock_to_thread.return_value = {
+            "callExpDateMap": {
+                "2024-01-19:30": {
+                    "170.0": [
+                        {
+                            "putCall": "CALL",
+                            "symbol": "AAPL_011924C170",
+                            "bid": 6.50,
+                            "ask": 6.55,
+                            "last": 6.52,
+                            "delta": 0.55,
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = await schwab_get_option_quote(
+            "AAPL", "2024-01-19", 170.0, "call"
+        )
+
+        assert "result" in result
+        assert result["result"]["putCall"] == "CALL"
+        assert result["result"]["bid"] == 6.50
+        assert result["result"]["ask"] == 6.55
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_quote_not_found(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Empty chain map produces an error response."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Options.ContractType.CALL = "CALL"
+
+        mock_to_thread.return_value = {"callExpDateMap": {}, "putExpDateMap": {}}
+
+        result = await schwab_get_option_quote(
+            "AAPL", "2024-01-19", 170.0, "call"
+        )
+
+        assert result["result"]["status"] == "error"
+        assert "No CALL contract" in result["result"]["error"]
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_option_quote_invalid_type(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await schwab_get_option_quote(
+            "AAPL", "2024-01-19", 170.0, "spread"
+        )
+
+        assert result["result"]["status"] == "error"
+        assert "Invalid option_type" in result["result"]["error"]
+
+    # ---- schwab_get_option_orders --------------------------------------
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    async def test_get_option_orders_filters_option_legs(
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Only option-legged orders are returned."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_to_thread.return_value = [
+            {
+                "orderId": "1",
+                "status": "FILLED",
+                "orderLegCollection": [{"orderLegType": "OPTION"}],
+            },
+            {
+                "orderId": "2",
+                "status": "FILLED",
+                "orderLegCollection": [{"orderLegType": "EQUITY"}],
+            },
+            {
+                "orderId": "3",
+                "status": "WORKING",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "OPTION"}},
+                ],
+            },
+        ]
+
+        result = await schwab_get_option_orders("abc123")
+
+        assert result["result"]["count"] == 2
+        ids = [o["orderId"] for o in result["result"]["orders"]]
+        assert ids == ["1", "3"]
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    async def test_get_option_orders_status_filter(
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """status='FILLED' excludes orders in other states."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_to_thread.return_value = [
+            {
+                "orderId": "1",
+                "status": "FILLED",
+                "orderLegCollection": [{"orderLegType": "OPTION"}],
+            },
+            {
+                "orderId": "2",
+                "status": "WORKING",
+                "orderLegCollection": [{"orderLegType": "OPTION"}],
+            },
+        ]
+
+        result = await schwab_get_option_orders("abc123", status="FILLED")
+
+        assert result["result"]["count"] == 1
+        assert result["result"]["orders"][0]["orderId"] == "1"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_option_orders_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        result = await schwab_get_option_orders("abc123")
+
+        assert result == error_response
+
+    # ---- schwab_get_open_option_orders ---------------------------------
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    async def test_get_open_option_orders_filters_to_working_status(
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Only OPTION-legged + open-status orders are returned."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_to_thread.return_value = [
+            {
+                "orderId": "1",
+                "status": "WORKING",
+                "orderLegCollection": [{"orderLegType": "OPTION"}],
+            },
+            {
+                "orderId": "2",
+                "status": "FILLED",
+                "orderLegCollection": [{"orderLegType": "OPTION"}],
+            },
+            {
+                "orderId": "3",
+                "status": "WORKING",
+                "orderLegCollection": [{"orderLegType": "EQUITY"}],
+            },
+            {
+                "orderId": "4",
+                "status": "PENDING_ACTIVATION",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "OPTION"}},
+                ],
+            },
+        ]
+
+        result = await schwab_get_open_option_orders("abc123")
+
+        assert result["result"]["count"] == 2
+        ids = [o["orderId"] for o in result["result"]["orders"]]
+        assert ids == ["1", "4"]
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_open_option_orders_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        result = await schwab_get_open_option_orders("abc123")
+
+        assert result == error_response

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -597,6 +597,24 @@ class TestSchwabOptionsTools:
         assert result["result"]["status"] == "error"
         assert "Invalid option_type" in result["result"]["error"]
 
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    async def test_find_tradable_options_rejects_all(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """option_type='all' must be rejected — public contract is call/put-only."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await schwab_find_tradable_options("AAPL", option_type="all")
+
+        assert result["result"]["status"] == "error"
+        assert "Invalid option_type" in result["result"]["error"]
+
     # ---- schwab_get_option_positions_detailed --------------------------
 
     @pytest.mark.journey_options
@@ -951,6 +969,26 @@ class TestSchwabOptionsTools:
 
         result = await schwab_get_option_quote(
             "AAPL", "2024-01-19", 170.0, "spread"
+        )
+
+        assert result["result"]["status"] == "error"
+        assert "Invalid option_type" in result["result"]["error"]
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_option_quote_rejects_all(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """option_type='all' must be rejected — single-contract quote is call/put-only."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        result = await schwab_get_option_quote(
+            "AAPL", "2024-01-19", 170.0, "all"
         )
 
         assert result["result"]["status"] == "error"


### PR DESCRIPTION
Closes #195

## Summary
Adds the five remaining Schwab options MCP tools called out in the roadmap and the `FOREMAN_IMPLEMENTATION_PLAN` on issue #195:

- `schwab_find_tradable_options(symbol, expiration_date=None, option_type=None, strike=None)` — filters the option chain into a flat list with `total_found` and the applied `filters`.
- `schwab_option_positions_detailed(account_hash)` — enriches each open option position with a live `quote` sub-dict (bid/ask/last + greeks). Option chains are fetched at most once per underlying symbol per call. Reports `enrichment_success_rate` as a percentage string.
- `schwab_option_quote(symbol, expiration_date, strike, option_type)` — single-contract lookup. Returns the contract dict on hit, or an error response when the contract is not present.
- `schwab_option_orders(account_hash, max_results=50, status=None)` — option-legged orders only, with optional status filter. Checks both `orderLegType == "OPTION"` and `instrument.assetType == "OPTION"` so it works against both Schwab API shapes.
- `schwab_open_option_orders(account_hash, max_results=50)` — option-legged orders in the open-status set (`WORKING`, `PENDING_ACTIVATION`, `QUEUED`, `ACCEPTED`, `AWAITING_*`).

All five tools follow the established `schwab_options_tools.py` style: `@handle_schwab_errors`, auth via `get_authenticated_broker_or_error`, sync broker calls wrapped through `execute_broker_request` (which routes to `asyncio.to_thread`), and `create_success_response` / `create_error_response` returns. They're registered in `src/open_stocks_mcp/server/app.py` immediately after `schwab_options_positions`.

Schwab keys expirations as `"YYYY-MM-DD:DTE"`, so chain lookups are prefix-matched; strike keys are compared as floats to absorb the `"170.0"` string form.

## Test plan
- [x] `uv run pytest tests/unit/test_schwab_options_tools.py -x -q` — 30 passed
- [x] `uv run pytest -m journey_options tests/unit/ -q` — 45 passed, 8 skipped (exception_test), 0 failed
- [x] `uv run mypy src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/server/app.py` — zero errors
- [x] `uv run ruff check src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_schwab_options_tools.py` — clean
- [x] MCP registry check confirms all five new tools appear by name alongside the existing four

🤖 Generated with [Claude Code](https://claude.com/claude-code)