### PR TITLE
test: add network and auth failure exception scenarios

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,6 +257,30 @@ def broker_auth_error_payload() -> dict[str, Any]:
     return broker_payloads.broker_auth_error_payload()
 
 
+@pytest.fixture
+def network_timeout_error() -> TimeoutError:
+    """Deterministic timeout error used by exception tests."""
+    return TimeoutError("request timeout")
+
+
+@pytest.fixture
+def connection_refused_error() -> ConnectionError:
+    """Deterministic connection-refused error used by exception tests."""
+    return ConnectionError("connection refused")
+
+
+@pytest.fixture
+def expired_token_error() -> Exception:
+    """Deterministic expired-token error used by auth exception tests."""
+    return Exception("token expired")
+
+
+@pytest.fixture
+def invalid_credentials_error() -> Exception:
+    """Deterministic invalid-credentials error used by auth exception tests."""
+    return Exception("invalid credentials")
+
+
 # Journey-specific fixtures
 
 

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -696,10 +696,20 @@ def test_classify_timeout_error_as_network_error() -> None:
     assert isinstance(error, NetworkError)
 
 
+test_classify_timeout_error_as_network_error = pytest.mark.exception_test(
+    test_classify_timeout_error_as_network_error
+)
+
+
 def test_classify_connection_refused_as_network_error() -> None:
     """ConnectionError 'connection refused' should classify as NetworkError."""
     error = classify_error(ConnectionError("connection refused"))
     assert isinstance(error, NetworkError)
+
+
+test_classify_connection_refused_as_network_error = pytest.mark.exception_test(
+    test_classify_connection_refused_as_network_error
+)
 
 
 @pytest.mark.asyncio
@@ -724,6 +734,13 @@ async def test_execute_with_retry_succeeds_after_transient_network_failure(
     assert call_count == 2
 
 
+test_execute_with_retry_succeeds_after_transient_network_failure = (
+    pytest.mark.exception_test(
+        test_execute_with_retry_succeeds_after_transient_network_failure
+    )
+)
+
+
 @pytest.mark.asyncio
 async def test_execute_with_retry_raises_network_error_on_repeated_timeout(
     monkeypatch: pytest.MonkeyPatch,
@@ -736,3 +753,10 @@ async def test_execute_with_retry_raises_network_error_on_repeated_timeout(
 
     with pytest.raises(NetworkError):
         await execute_with_retry(always_timeout, max_retries=1, delay=0)
+
+
+test_execute_with_retry_raises_network_error_on_repeated_timeout = (
+    pytest.mark.exception_test(
+        test_execute_with_retry_raises_network_error_on_repeated_timeout
+    )
+)

--- a/tests/unit/test_network_failures.py
+++ b/tests/unit/test_network_failures.py
@@ -1,0 +1,51 @@
+"""Tool-level network failure scenario tests."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+from open_stocks_mcp.tools.schwab_market_tools import get_schwab_quote
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.journey_system,
+    pytest.mark.exception_test,
+]
+
+
+@pytest.mark.asyncio
+async def test_robinhood_stock_price_timeout_returns_structured_error() -> None:
+    with patch(
+        "open_stocks_mcp.tools.robinhood_stock_tools.execute_with_retry",
+        new=AsyncMock(side_effect=TimeoutError("request timeout")),
+    ):
+        result = await get_stock_price("AAPL")
+
+    assert result["result"]["status"] == "error"
+    assert result["result"]["error_type"] == "network"
+    assert result["result"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_schwab_quote_connection_refused_returns_structured_error() -> None:
+    fake_client = SimpleNamespace(
+        get_quote=lambda _symbol: SimpleNamespace(json=lambda: {"AAPL": {"quote": {}}})
+    )
+    fake_broker = SimpleNamespace(client=fake_client)
+    with (
+        patch(
+            "open_stocks_mcp.tools.schwab_market_tools.get_authenticated_broker_or_error",
+            new=AsyncMock(return_value=(fake_broker, None)),
+        ),
+        patch(
+            "open_stocks_mcp.tools.schwab_market_tools.execute_broker_request",
+            new=AsyncMock(side_effect=ConnectionError("connection refused")),
+        ),
+    ):
+        result = await get_schwab_quote("AAPL")
+
+    assert result["result"]["status"] == "error"
+    assert result["result"]["error_type"] == "network"
+    assert result["result"]["error"]

--- a/tests/unit/test_schwab_broker.py
+++ b/tests/unit/test_schwab_broker.py
@@ -110,8 +110,10 @@ class TestSchwabBroker:
         with (
             patch("schwab.auth.easy_client") as mock_easy_client,
             patch("os.isatty", return_value=True),
-            patch.dict("os.environ", {"OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS": "2.5"}),
-            patch("open_stocks_mcp.config._global_config", None), # Reset config
+            patch.dict(
+                "os.environ", {"OPEN_STOCKS_MCP_SCHWAB_REQUEST_TIMEOUT_SECONDS": "2.5"}
+            ),
+            patch("open_stocks_mcp.config._global_config", None),  # Reset config
         ):
             mock_client = MagicMock()
             mock_easy_client.return_value = mock_client
@@ -248,6 +250,71 @@ class TestSchwabBroker:
                 "Interactive authentication required"
                 in schwab_broker._auth_info.error_message
             )
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.exception_test
+    async def test_authenticate_expired_token_then_bad_oauth_credentials(
+        self, schwab_broker: SchwabBroker
+    ) -> None:
+        token_dir = Path.home() / ".tokens"
+        token_dir.mkdir(parents=True, exist_ok=True)
+        token_file = token_dir / "schwab_token_expired_test.json"
+        token_file.write_text('{"access_token":"expired"}')
+        schwab_broker.token_path = str(token_file)
+
+        try:
+            with (
+                patch(
+                    "schwab.auth.client_from_token_file",
+                    side_effect=Exception("token expired"),
+                ),
+                patch(
+                    "schwab.auth.easy_client", side_effect=Exception("bad credentials")
+                ),
+                patch("os.isatty", return_value=True),
+            ):
+                result = await schwab_broker.authenticate()
+        finally:
+            if token_file.exists():
+                token_file.unlink()
+
+        assert result is False
+        assert schwab_broker.client is None
+        assert schwab_broker._auth_info.status == BrokerAuthStatus.AUTH_FAILED
+        assert schwab_broker._auth_info.error_message is not None
+        assert "bad credentials" in schwab_broker._auth_info.error_message
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.exception_test
+    async def test_authenticate_bad_credentials_non_interactive_no_browser(
+        self, schwab_broker: SchwabBroker
+    ) -> None:
+        token_dir = Path.home() / ".tokens"
+        token_dir.mkdir(parents=True, exist_ok=True)
+        token_file = token_dir / "schwab_token_noexist_test.json"
+        if token_file.exists():
+            token_file.unlink()
+        schwab_broker.token_path = str(token_file)
+
+        with (
+            patch("os.isatty", return_value=False),
+            patch("schwab.auth.easy_client") as mock_easy_client,
+        ):
+            result = await schwab_broker.authenticate()
+
+        assert result is False
+        assert schwab_broker._auth_info.status == BrokerAuthStatus.AUTH_FAILED
+        assert schwab_broker.client is None
+        assert schwab_broker._auth_info.error_message is not None
+        assert (
+            "Interactive authentication required"
+            in schwab_broker._auth_info.error_message
+        )
+        mock_easy_client.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_authenticate_import_error(self, schwab_broker: SchwabBroker) -> None:

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -160,3 +160,67 @@ def test_interactive_mfa_prompt_uses_original_stderr_when_stderr_is_redirected()
     assert "ROBINHOOD MFA REQUIRED" in original_stderr.getvalue()
     assert "Enter verification code:" in original_stderr.getvalue()
     assert "ROBINHOOD MFA REQUIRED" not in redirected_stderr.getvalue()
+
+
+@pytest.mark.unit
+@pytest.mark.journey_account
+@pytest.mark.exception_test
+def test_ensure_authenticated_handles_expired_session_without_unhandled_exception() -> (
+    None
+):
+    manager = SessionManager(session_timeout_hours=0)
+    manager.set_credentials("user", "pass")
+    manager._is_authenticated = True
+    manager.login_time = datetime.now()
+
+    with patch.object(manager, "_authenticate", return_value=False):
+        result = asyncio.run(manager.ensure_authenticated())
+
+    assert result is False
+
+
+@pytest.mark.unit
+@pytest.mark.journey_account
+@pytest.mark.exception_test
+def test_ensure_authenticated_handles_invalid_credentials_login_failure() -> None:
+    manager = SessionManager()
+    manager.set_credentials("user", "pass")
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.session_manager.rh.login",
+            side_effect=Exception("invalid credentials"),
+        ),
+        patch("open_stocks_mcp.tools.session_manager.rh.load_user_profile"),
+    ):
+        result = asyncio.run(manager.ensure_authenticated())
+
+    assert result is False
+    assert manager._is_authenticated is False
+    assert manager._failed_login_attempts == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.journey_account
+@pytest.mark.exception_test
+async def test_ensure_authenticated_session_returns_error_tuple_on_exception() -> None:
+    from open_stocks_mcp.tools import session_manager as session_manager_module
+
+    fake_manager = SessionManager()
+    with (
+        patch.object(
+            fake_manager,
+            "ensure_authenticated",
+            side_effect=Exception("invalid credentials"),
+        ),
+        patch.object(
+            session_manager_module,
+            "get_session_manager",
+            return_value=fake_manager,
+        ),
+    ):
+        success, error = await session_manager_module.ensure_authenticated_session()
+
+    assert success is False
+    assert error == "invalid credentials"


### PR DESCRIPTION
Closes #173

## Changes
- add reusable exception fixtures in `tests/conftest.py` for timeout, connection-refused, expired-token, and invalid-credentials scenarios
- mark targeted failure-mode tests in `tests/unit/test_error_handling.py` as `exception_test`
- add `tests/unit/test_network_failures.py` for tool-level Robinhood/Schwab network failure structured error responses
- add exception-test auth degradation coverage to `tests/unit/test_session_manager.py` and `tests/unit/test_schwab_broker.py`
- follow the issue implementation plan with a path correction: Robinhood session tests were applied to `src/open_stocks_mcp/tools/session_manager.py` (current location)

## Test plan
- `uv run pytest tests/unit/test_error_handling.py tests/unit/test_network_failures.py -m exception_test -v`
- `uv run pytest tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py -m exception_test -v`
- `uv run pytest tests/unit/test_error_handling.py tests/unit/test_network_failures.py tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py -m exception_test -q`
- `uv run pytest tests/unit/test_error_handling.py tests/unit/test_network_failures.py -m "not slow and not exception_test" --collect-only -q`
- `uv run ruff check tests/conftest.py tests/unit/test_error_handling.py tests/unit/test_network_failures.py tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py --fix`
- `uv run ruff format tests/conftest.py tests/unit/test_error_handling.py tests/unit/test_network_failures.py tests/unit/test_session_manager.py tests/unit/test_schwab_broker.py`