### PR TITLE
feat: add 10 Schwab trading tools for stop, options, spreads, and replace

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -185,6 +185,36 @@ from open_stocks_mcp.tools.schwab_trading_tools import (
     schwab_sell_limit,
     schwab_sell_market,
 )
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_cancel_all_option_orders as _schwab_cancel_all_option_orders,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_cancel_all_stock_orders as _schwab_cancel_all_stock_orders,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_cancel_option_order as _schwab_cancel_option_order,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_get_open_stock_orders as _schwab_get_open_stock_orders,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_order_buy_option_limit as _schwab_order_buy_option_limit,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_order_option_credit_spread as _schwab_order_option_credit_spread,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_order_option_debit_spread as _schwab_order_option_debit_spread,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_order_sell_option_limit as _schwab_order_sell_option_limit,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_order_sell_stop as _schwab_order_sell_stop,
+)
+from open_stocks_mcp.tools.schwab_trading_tools import (
+    schwab_replace_order as _schwab_replace_order,
+)
 from open_stocks_mcp.tools.session_manager import get_session_manager
 from open_stocks_mcp.tools.unified_watchlist_tools import (
     add_symbols_to_unified_watchlist,
@@ -1444,6 +1474,173 @@ async def schwab_get_transaction(
         transaction_id: Transaction ID to retrieve
     """
     return await get_schwab_transaction(account_hash, transaction_id)
+
+
+@mcp.tool()
+async def schwab_order_sell_stop(
+    account_hash: str, symbol: str, quantity: int, stop_price: str
+) -> dict[str, Any]:
+    """Place a stop sell order for stock.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Stock ticker symbol
+        quantity: Number of shares to sell
+        stop_price: Stop trigger price as a string (e.g. "148.00")
+    """
+    return await _schwab_order_sell_stop(account_hash, symbol, quantity, stop_price)
+
+
+@mcp.tool()
+async def schwab_get_open_stock_orders(
+    account_hash: str, max_results: int = 200
+) -> dict[str, Any]:
+    """Get open (cancellable) equity orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        max_results: Maximum orders to fetch from API before filtering
+    """
+    return await _schwab_get_open_stock_orders(account_hash, max_results)
+
+
+@mcp.tool()
+async def schwab_cancel_all_stock_orders(
+    account_hash: str, max_results: int = 200
+) -> dict[str, Any]:
+    """Cancel all open equity orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        max_results: Maximum orders to fetch before filtering
+    """
+    return await _schwab_cancel_all_stock_orders(account_hash, max_results)
+
+
+@mcp.tool()
+async def schwab_order_buy_option_limit(
+    account_hash: str, option_symbol: str, quantity: int, price: str
+) -> dict[str, Any]:
+    """Place a limit buy-to-open order for an option contract.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        option_symbol: OCC option symbol (e.g. "AAPL  251219C00150000")
+        quantity: Number of contracts to buy
+        price: Limit price as a string (e.g. "5.50")
+    """
+    return await _schwab_order_buy_option_limit(
+        account_hash, option_symbol, quantity, price
+    )
+
+
+@mcp.tool()
+async def schwab_order_sell_option_limit(
+    account_hash: str, option_symbol: str, quantity: int, price: str
+) -> dict[str, Any]:
+    """Place a limit sell-to-close order for an option contract.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        option_symbol: OCC option symbol (e.g. "AAPL  251219C00150000")
+        quantity: Number of contracts to sell
+        price: Limit price as a string (e.g. "4.00")
+    """
+    return await _schwab_order_sell_option_limit(
+        account_hash, option_symbol, quantity, price
+    )
+
+
+@mcp.tool()
+async def schwab_cancel_option_order(
+    account_hash: str, order_id: str
+) -> dict[str, Any]:
+    """Cancel a specific option order.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        order_id: Option order ID to cancel
+    """
+    return await _schwab_cancel_option_order(account_hash, order_id)
+
+
+@mcp.tool()
+async def schwab_cancel_all_option_orders(
+    account_hash: str, max_results: int = 200
+) -> dict[str, Any]:
+    """Cancel all open option orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        max_results: Maximum orders to fetch before filtering
+    """
+    return await _schwab_cancel_all_option_orders(account_hash, max_results)
+
+
+@mcp.tool()
+async def schwab_order_option_credit_spread(
+    account_hash: str,
+    option_type: str,
+    short_symbol: str,
+    long_symbol: str,
+    quantity: int,
+    net_credit: str,
+) -> dict[str, Any]:
+    """Place a vertical credit spread option order.
+
+    For CALL: bear call spread. For PUT: bull put spread.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        option_type: "CALL" or "PUT"
+        short_symbol: OCC symbol for the leg you sell (collects premium)
+        long_symbol: OCC symbol for the hedge/protective leg
+        quantity: Number of spread contracts
+        net_credit: Net credit received as a string (e.g. "2.00")
+    """
+    return await _schwab_order_option_credit_spread(
+        account_hash, option_type, short_symbol, long_symbol, quantity, net_credit
+    )
+
+
+@mcp.tool()
+async def schwab_order_option_debit_spread(
+    account_hash: str,
+    option_type: str,
+    long_symbol: str,
+    short_symbol: str,
+    quantity: int,
+    net_debit: str,
+) -> dict[str, Any]:
+    """Place a vertical debit spread option order.
+
+    For CALL: bull call spread. For PUT: bear put spread.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        option_type: "CALL" or "PUT"
+        long_symbol: OCC symbol for the leg you buy (main directional position)
+        short_symbol: OCC symbol for the hedge/short leg
+        quantity: Number of spread contracts
+        net_debit: Net debit paid as a string (e.g. "3.00")
+    """
+    return await _schwab_order_option_debit_spread(
+        account_hash, option_type, long_symbol, short_symbol, quantity, net_debit
+    )
+
+
+@mcp.tool()
+async def schwab_replace_order(
+    account_hash: str, order_id: str, order_spec: dict[str, Any]
+) -> dict[str, Any]:
+    """Replace (modify) an existing Schwab order.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        order_id: ID of the order to replace
+        order_spec: New order specification dict (use order builder helpers)
+    """
+    return await _schwab_replace_order(account_hash, order_id, order_spec)
 
 
 # Schwab Options Tools

--- a/src/open_stocks_mcp/tools/schwab_trading_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_trading_tools.py
@@ -4,11 +4,27 @@ import asyncio
 import datetime
 from typing import Any
 
+from schwab.orders.common import (
+    Duration,
+    EquityInstruction,
+    OrderStrategyType,
+    OrderType,
+    Session,
+)
 from schwab.orders.equities import (
     equity_buy_limit,
     equity_buy_market,
     equity_sell_limit,
     equity_sell_market,
+)
+from schwab.orders.options import (
+    OrderBuilder,
+    bear_call_vertical_open,
+    bear_put_vertical_open,
+    bull_call_vertical_open,
+    bull_put_vertical_open,
+    option_buy_to_open_limit,
+    option_sell_to_close_limit,
 )
 
 from open_stocks_mcp.logging_config import logger
@@ -487,7 +503,9 @@ async def schwab_get_transactions_by_date(
 
 
 @handle_schwab_errors
-async def get_schwab_transaction(account_hash: str, transaction_id: str) -> dict[str, Any]:
+async def get_schwab_transaction(
+    account_hash: str, transaction_id: str
+) -> dict[str, Any]:
     """Get details for a specific transaction.
 
     Args:
@@ -515,4 +533,642 @@ async def get_schwab_transaction(account_hash: str, transaction_id: str) -> dict
 
     except Exception as e:
         logger.error(f"Error getting Schwab transaction {transaction_id}: {e}")
+        return create_error_response(e)
+
+
+# Open/cancellable order statuses for equity orders
+_OPEN_EQUITY_STATUSES = frozenset(
+    {
+        "WORKING",
+        "NEW",
+        "QUEUED",
+        "ACCEPTED",
+        "AWAITING_CONDITION",
+        "AWAITING_PARENT_ORDER",
+        "AWAITING_RELEASE_TIME",
+        "AWAITING_STOP_CONDITION",
+        "PENDING_ACTIVATION",
+    }
+)
+
+
+def _is_open_equity_order(order: dict[str, Any]) -> bool:
+    """Return True when order is open and all legs are equity instruments."""
+    if order.get("status") not in _OPEN_EQUITY_STATUSES:
+        return False
+    legs = order.get("orderLegCollection", [])
+    return bool(legs) and all(
+        leg.get("instrument", {}).get("assetType") == "EQUITY" for leg in legs
+    )
+
+
+def _is_open_option_order(order: dict[str, Any]) -> bool:
+    """Return True when order is open and all legs are option instruments."""
+    if order.get("status") not in _OPEN_EQUITY_STATUSES:
+        return False
+    legs = order.get("orderLegCollection", [])
+    return bool(legs) and all(
+        leg.get("instrument", {}).get("assetType") == "OPTION" for leg in legs
+    )
+
+
+@handle_schwab_errors
+async def schwab_order_sell_stop(
+    account_hash: str, symbol: str, quantity: int, stop_price: str
+) -> dict[str, Any]:
+    """Place a stop sell order for stock.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        symbol: Stock ticker symbol
+        quantity: Number of shares to sell
+        stop_price: Stop trigger price as a string (e.g. "148.00")
+
+    Returns:
+        Dict with order placement result
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"sell stop {quantity} shares of {symbol} at {stop_price}"
+    )
+    if error:
+        return error
+
+    try:
+        order_spec = (
+            OrderBuilder()
+            .set_order_type(OrderType.STOP)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .set_duration(Duration.DAY)
+            .set_session(Session.NORMAL)
+            .set_stop_price(stop_price)
+            .add_equity_leg(EquityInstruction.SELL, symbol.upper(), quantity)
+            .build()
+        )
+
+        def _place() -> Any:
+            return broker.client.place_order(account_hash, order_spec)
+
+        response = await execute_broker_request(_place, retry_safe=False)
+
+        if response.status_code in (200, 201):
+            location = response.headers.get("Location", "")
+            order_id = location.split("/")[-1] if location else None
+            return create_success_response(
+                {
+                    "status": "order_placed",
+                    "action": "sell",
+                    "symbol": symbol.upper(),
+                    "quantity": quantity,
+                    "order_type": "stop",
+                    "stop_price": stop_price,
+                    "order_id": order_id,
+                }
+            )
+        else:
+            return create_error_response(
+                ValueError(
+                    f"Stop sell order failed with status {response.status_code}: {response.text}"
+                )
+            )
+
+    except Exception as e:
+        logger.error(f"Error placing Schwab stop sell order for {symbol}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_open_stock_orders(
+    account_hash: str, max_results: int = 200
+) -> dict[str, Any]:
+    """Get open (cancellable) equity orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum number of orders to fetch from API before filtering
+
+    Returns:
+        Dict with list of open equity orders
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get open stock orders for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_orders() -> Any:
+            response = broker.client.get_orders_for_account(
+                account_hash, max_results=max_results
+            )
+            return response.json()
+
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
+        all_orders = orders_data if isinstance(orders_data, list) else []
+        open_orders = [o for o in all_orders if _is_open_equity_order(o)]
+
+        return create_success_response(
+            {"orders": open_orders, "count": len(open_orders)}
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting open Schwab stock orders: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_cancel_all_stock_orders(
+    account_hash: str, max_results: int = 200
+) -> dict[str, Any]:
+    """Cancel all open equity orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum number of orders to fetch before filtering
+
+    Returns:
+        Dict with counts of cancelled and failed orders
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"cancel all stock orders for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_orders() -> Any:
+            response = broker.client.get_orders_for_account(
+                account_hash, max_results=max_results
+            )
+            return response.json()
+
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
+        all_orders = orders_data if isinstance(orders_data, list) else []
+        open_orders = [o for o in all_orders if _is_open_equity_order(o)]
+
+        cancelled_count = 0
+        failed_count = 0
+        failed_orders: list[dict[str, Any]] = []
+
+        for order in open_orders:
+            order_id = str(order.get("orderId", ""))
+            try:
+
+                def _cancel(oid: str = order_id) -> Any:
+                    return broker.client.cancel_order(oid, account_hash)
+
+                response = await execute_broker_request(_cancel, retry_safe=False)
+                if response.status_code in (200, 204):
+                    cancelled_count += 1
+                else:
+                    failed_count += 1
+                    failed_orders.append(
+                        {"order_id": order_id, "status_code": response.status_code}
+                    )
+            except Exception as cancel_exc:
+                failed_count += 1
+                failed_orders.append({"order_id": order_id, "error": str(cancel_exc)})
+
+        return create_success_response(
+            {
+                "cancelled_count": cancelled_count,
+                "failed_count": failed_count,
+                "failed_orders": failed_orders,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error cancelling all Schwab stock orders: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_order_buy_option_limit(
+    account_hash: str, option_symbol: str, quantity: int, price: str
+) -> dict[str, Any]:
+    """Place a limit buy-to-open order for an option contract.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        option_symbol: OCC option symbol (e.g. "AAPL  251219C00150000")
+        quantity: Number of contracts to buy
+        price: Limit price as a string (e.g. "5.50")
+
+    Returns:
+        Dict with order placement result
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"buy {quantity} {option_symbol} option contracts at {price}"
+    )
+    if error:
+        return error
+
+    try:
+        order_spec = option_buy_to_open_limit(option_symbol, quantity, price).build()
+
+        def _place() -> Any:
+            return broker.client.place_order(account_hash, order_spec)
+
+        response = await execute_broker_request(_place, retry_safe=False)
+
+        if response.status_code in (200, 201):
+            location = response.headers.get("Location", "")
+            order_id = location.split("/")[-1] if location else None
+            return create_success_response(
+                {
+                    "status": "order_placed",
+                    "action": "buy_to_open",
+                    "option_symbol": option_symbol,
+                    "quantity": quantity,
+                    "order_type": "limit",
+                    "limit_price": price,
+                    "order_id": order_id,
+                }
+            )
+        else:
+            return create_error_response(
+                ValueError(
+                    f"Option buy limit order failed with status {response.status_code}: {response.text}"
+                )
+            )
+
+    except Exception as e:
+        logger.error(f"Error placing Schwab option buy limit for {option_symbol}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_order_sell_option_limit(
+    account_hash: str, option_symbol: str, quantity: int, price: str
+) -> dict[str, Any]:
+    """Place a limit sell-to-close order for an option contract.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        option_symbol: OCC option symbol (e.g. "AAPL  251219C00150000")
+        quantity: Number of contracts to sell
+        price: Limit price as a string (e.g. "4.00")
+
+    Returns:
+        Dict with order placement result
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"sell {quantity} {option_symbol} option contracts at {price}"
+    )
+    if error:
+        return error
+
+    try:
+        order_spec = option_sell_to_close_limit(option_symbol, quantity, price).build()
+
+        def _place() -> Any:
+            return broker.client.place_order(account_hash, order_spec)
+
+        response = await execute_broker_request(_place, retry_safe=False)
+
+        if response.status_code in (200, 201):
+            location = response.headers.get("Location", "")
+            order_id = location.split("/")[-1] if location else None
+            return create_success_response(
+                {
+                    "status": "order_placed",
+                    "action": "sell_to_close",
+                    "option_symbol": option_symbol,
+                    "quantity": quantity,
+                    "order_type": "limit",
+                    "limit_price": price,
+                    "order_id": order_id,
+                }
+            )
+        else:
+            return create_error_response(
+                ValueError(
+                    f"Option sell limit order failed with status {response.status_code}: {response.text}"
+                )
+            )
+
+    except Exception as e:
+        logger.error(f"Error placing Schwab option sell limit for {option_symbol}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_cancel_option_order(
+    account_hash: str, order_id: str
+) -> dict[str, Any]:
+    """Cancel a specific option order.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        order_id: Option order ID to cancel
+
+    Returns:
+        Dict with cancellation result
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"cancel option order {order_id}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _cancel() -> Any:
+            return broker.client.cancel_order(order_id, account_hash)
+
+        response = await execute_broker_request(_cancel, retry_safe=False)
+
+        if response.status_code in (200, 204):
+            return create_success_response(
+                {"status": "order_cancelled", "order_id": order_id}
+            )
+        else:
+            return create_error_response(
+                ValueError(
+                    f"Option order cancellation failed with status {response.status_code}: {response.text}"
+                )
+            )
+
+    except Exception as e:
+        logger.error(f"Error cancelling Schwab option order {order_id}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_cancel_all_option_orders(
+    account_hash: str, max_results: int = 200
+) -> dict[str, Any]:
+    """Cancel all open option orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum number of orders to fetch before filtering
+
+    Returns:
+        Dict with counts of cancelled and failed orders
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"cancel all option orders for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_orders() -> Any:
+            response = broker.client.get_orders_for_account(
+                account_hash, max_results=max_results
+            )
+            return response.json()
+
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
+        all_orders = orders_data if isinstance(orders_data, list) else []
+        open_option_orders = [o for o in all_orders if _is_open_option_order(o)]
+
+        cancelled_count = 0
+        failed_count = 0
+        failed_orders: list[dict[str, Any]] = []
+
+        for order in open_option_orders:
+            order_id = str(order.get("orderId", ""))
+            try:
+
+                def _cancel(oid: str = order_id) -> Any:
+                    return broker.client.cancel_order(oid, account_hash)
+
+                response = await execute_broker_request(_cancel, retry_safe=False)
+                if response.status_code in (200, 204):
+                    cancelled_count += 1
+                else:
+                    failed_count += 1
+                    failed_orders.append(
+                        {"order_id": order_id, "status_code": response.status_code}
+                    )
+            except Exception as cancel_exc:
+                failed_count += 1
+                failed_orders.append({"order_id": order_id, "error": str(cancel_exc)})
+
+        return create_success_response(
+            {
+                "cancelled_count": cancelled_count,
+                "failed_count": failed_count,
+                "failed_orders": failed_orders,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error cancelling all Schwab option orders: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_order_option_credit_spread(
+    account_hash: str,
+    option_type: str,
+    short_symbol: str,
+    long_symbol: str,
+    quantity: int,
+    net_credit: str,
+) -> dict[str, Any]:
+    """Place a vertical credit spread order.
+
+    For CALL: bear call spread — sell the lower strike, buy the higher strike.
+    For PUT:  bull put spread — sell the higher strike, buy the lower strike.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        option_type: "CALL" or "PUT"
+        short_symbol: OCC symbol for the leg you sell (collects premium)
+        long_symbol: OCC symbol for the hedge/protective leg
+        quantity: Number of spread contracts
+        net_credit: Net credit received as a string (e.g. "2.00")
+
+    Returns:
+        Dict with order placement result
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"credit spread {option_type} {short_symbol}/{long_symbol}"
+    )
+    if error:
+        return error
+
+    opt = option_type.upper()
+    if opt not in ("CALL", "PUT"):
+        return create_error_response(
+            ValueError(f"option_type must be 'CALL' or 'PUT', got '{option_type}'")
+        )
+
+    try:
+        if opt == "CALL":
+            order_builder = bear_call_vertical_open(
+                short_symbol, long_symbol, quantity, net_credit
+            )
+        else:
+            order_builder = bull_put_vertical_open(
+                long_symbol, short_symbol, quantity, net_credit
+            )
+
+        order_spec = order_builder.build()
+
+        def _place() -> Any:
+            return broker.client.place_order(account_hash, order_spec)
+
+        response = await execute_broker_request(_place, retry_safe=False)
+
+        if response.status_code in (200, 201):
+            location = response.headers.get("Location", "")
+            order_id = location.split("/")[-1] if location else None
+            return create_success_response(
+                {
+                    "status": "order_placed",
+                    "spread_type": "credit",
+                    "option_type": opt,
+                    "short_symbol": short_symbol,
+                    "long_symbol": long_symbol,
+                    "quantity": quantity,
+                    "net_credit": net_credit,
+                    "order_id": order_id,
+                }
+            )
+        else:
+            return create_error_response(
+                ValueError(
+                    f"Credit spread order failed with status {response.status_code}: {response.text}"
+                )
+            )
+
+    except Exception as e:
+        logger.error(f"Error placing Schwab credit spread: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_order_option_debit_spread(
+    account_hash: str,
+    option_type: str,
+    long_symbol: str,
+    short_symbol: str,
+    quantity: int,
+    net_debit: str,
+) -> dict[str, Any]:
+    """Place a vertical debit spread order.
+
+    For CALL: bull call spread — buy the lower strike, sell the higher strike.
+    For PUT:  bear put spread — buy the higher strike, sell the lower strike.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        option_type: "CALL" or "PUT"
+        long_symbol: OCC symbol for the leg you buy (main directional position)
+        short_symbol: OCC symbol for the hedge/short leg
+        quantity: Number of spread contracts
+        net_debit: Net debit paid as a string (e.g. "3.00")
+
+    Returns:
+        Dict with order placement result
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"debit spread {option_type} {long_symbol}/{short_symbol}"
+    )
+    if error:
+        return error
+
+    opt = option_type.upper()
+    if opt not in ("CALL", "PUT"):
+        return create_error_response(
+            ValueError(f"option_type must be 'CALL' or 'PUT', got '{option_type}'")
+        )
+
+    try:
+        if opt == "CALL":
+            order_builder = bull_call_vertical_open(
+                long_symbol, short_symbol, quantity, net_debit
+            )
+        else:
+            order_builder = bear_put_vertical_open(
+                short_symbol, long_symbol, quantity, net_debit
+            )
+
+        order_spec = order_builder.build()
+
+        def _place() -> Any:
+            return broker.client.place_order(account_hash, order_spec)
+
+        response = await execute_broker_request(_place, retry_safe=False)
+
+        if response.status_code in (200, 201):
+            location = response.headers.get("Location", "")
+            order_id = location.split("/")[-1] if location else None
+            return create_success_response(
+                {
+                    "status": "order_placed",
+                    "spread_type": "debit",
+                    "option_type": opt,
+                    "long_symbol": long_symbol,
+                    "short_symbol": short_symbol,
+                    "quantity": quantity,
+                    "net_debit": net_debit,
+                    "order_id": order_id,
+                }
+            )
+        else:
+            return create_error_response(
+                ValueError(
+                    f"Debit spread order failed with status {response.status_code}: {response.text}"
+                )
+            )
+
+    except Exception as e:
+        logger.error(f"Error placing Schwab debit spread: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_replace_order(
+    account_hash: str, order_id: str, order_spec: dict[str, Any]
+) -> dict[str, Any]:
+    """Replace (modify) an existing Schwab order.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        order_id: ID of the order to replace
+        order_spec: New order specification dict (use order builder helpers)
+
+    Returns:
+        Dict with replacement result including the new order ID
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"replace order {order_id}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _replace() -> Any:
+            return broker.client.replace_order(account_hash, order_id, order_spec)
+
+        response = await execute_broker_request(_replace, retry_safe=False)
+
+        if response.status_code in (200, 201):
+            location = response.headers.get("Location", "")
+            new_order_id = location.split("/")[-1] if location else None
+            return create_success_response(
+                {
+                    "status": "order_replaced",
+                    "replaced_order_id": order_id,
+                    "new_order_id": new_order_id,
+                    "status_code": response.status_code,
+                }
+            )
+        else:
+            return create_error_response(
+                ValueError(
+                    f"Order replacement failed with status {response.status_code}: {response.text}"
+                )
+            )
+
+    except Exception as e:
+        logger.error(f"Error replacing Schwab order {order_id}: {e}")
         return create_error_response(e)

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -197,6 +197,28 @@ class TestToolRegistration:
             assert tool_name in tool_names, f"Tool {tool_name} not registered"
 
     @pytest.mark.asyncio
+    async def test_schwab_trading_expansion_tools_are_registered(self) -> None:
+        """Test that all 10 new Schwab trading expansion tools are registered."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+
+        expected_tools = [
+            "schwab_order_sell_stop",
+            "schwab_get_open_stock_orders",
+            "schwab_cancel_all_stock_orders",
+            "schwab_order_buy_option_limit",
+            "schwab_order_sell_option_limit",
+            "schwab_cancel_option_order",
+            "schwab_cancel_all_option_orders",
+            "schwab_order_option_credit_spread",
+            "schwab_order_option_debit_spread",
+            "schwab_replace_order",
+        ]
+
+        for tool_name in expected_tools:
+            assert tool_name in tool_names, f"Tool {tool_name} not registered"
+
+    @pytest.mark.asyncio
     async def test_account_info_tool_callable(self) -> None:
         """Test that account_info tool is callable."""
         tools_list = await mcp.list_tools()

--- a/tests/unit/test_schwab_trading_tools.py
+++ b/tests/unit/test_schwab_trading_tools.py
@@ -666,3 +666,917 @@ class TestSchwabTradingTools:
 
             mock_impl.assert_awaited_once_with("HASH", {"orderType": "MARKET"})
             assert result == {"result": {"status": "order_placed", "order_id": "1"}}
+
+
+# ============================================================
+# New tools from Issue #196
+# ============================================================
+
+
+class TestSchwabOrderSellStop:
+    """Tests for schwab_order_sell_stop."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_sell_stop_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test successful stop-sell order placement."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.headers = {"Location": "/orders/99001"}
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import schwab_order_sell_stop
+
+        result = await schwab_order_sell_stop("acct1", "AAPL", 5, "148.00")
+
+        assert result["result"]["status"] == "order_placed"
+        assert result["result"]["action"] == "sell"
+        assert result["result"]["order_type"] == "stop"
+        assert result["result"]["symbol"] == "AAPL"
+        assert result["result"]["quantity"] == 5
+        assert result["result"]["order_id"] == "99001"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_sell_stop_auth_error(self, mock_get_broker: AsyncMock) -> None:
+        """Test stop-sell order when authentication fails."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import schwab_order_sell_stop
+
+        result = await schwab_order_sell_stop("acct1", "AAPL", 5, "148.00")
+        assert result == error_response
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_sell_stop_api_error_response(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test stop-sell detects API error status codes."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Invalid stop price"
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import schwab_order_sell_stop
+
+        result = await schwab_order_sell_stop("acct1", "AAPL", 5, "148.00")
+        assert "error" in result["result"]
+
+
+class TestSchwabGetOpenStockOrders:
+    """Tests for schwab_get_open_stock_orders."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_get_open_stock_orders_filters_correctly(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test that only open equity orders are returned."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        orders = [
+            # Open equity order — should be included
+            {
+                "orderId": "1",
+                "status": "WORKING",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "EQUITY", "symbol": "AAPL"}}
+                ],
+            },
+            # Filled equity order — excluded
+            {
+                "orderId": "2",
+                "status": "FILLED",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "EQUITY", "symbol": "MSFT"}}
+                ],
+            },
+            # Open option order — excluded (not equity)
+            {
+                "orderId": "3",
+                "status": "WORKING",
+                "orderLegCollection": [
+                    {
+                        "instrument": {
+                            "assetType": "OPTION",
+                            "symbol": "AAPL  251219C00150000",
+                        }
+                    }
+                ],
+            },
+        ]
+        mock_execute.return_value = orders
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_get_open_stock_orders,
+        )
+
+        result = await schwab_get_open_stock_orders("acct1")
+        assert result["result"]["count"] == 1
+        assert result["result"]["orders"][0]["orderId"] == "1"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_open_stock_orders_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test get_open_stock_orders auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_get_open_stock_orders,
+        )
+
+        result = await schwab_get_open_stock_orders("acct1")
+        assert result == error_response
+
+
+class TestSchwabCancelAllStockOrders:
+    """Tests for schwab_cancel_all_stock_orders."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_cancel_all_stock_orders_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test cancelling all open stock orders successfully."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        open_orders_response = [
+            {
+                "orderId": "10",
+                "status": "WORKING",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "EQUITY", "symbol": "AAPL"}}
+                ],
+            },
+            {
+                "orderId": "11",
+                "status": "NEW",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "EQUITY", "symbol": "TSLA"}}
+                ],
+            },
+        ]
+
+        cancel_response = MagicMock()
+        cancel_response.status_code = 200
+
+        mock_execute.side_effect = [
+            open_orders_response,  # get open orders
+            cancel_response,  # cancel order 10
+            cancel_response,  # cancel order 11
+        ]
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_cancel_all_stock_orders,
+        )
+
+        result = await schwab_cancel_all_stock_orders("acct1")
+        assert result["result"]["cancelled_count"] == 2
+        assert result["result"]["failed_count"] == 0
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_cancel_all_stock_orders_partial_failure(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test cancel_all_stock_orders when some cancellations fail."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        open_orders_response = [
+            {
+                "orderId": "20",
+                "status": "WORKING",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "EQUITY", "symbol": "AAPL"}}
+                ],
+            },
+            {
+                "orderId": "21",
+                "status": "WORKING",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "EQUITY", "symbol": "TSLA"}}
+                ],
+            },
+        ]
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+
+        fail_response = MagicMock()
+        fail_response.status_code = 422
+        fail_response.text = "Already cancelled"
+
+        mock_execute.side_effect = [
+            open_orders_response,
+            ok_response,
+            fail_response,
+        ]
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_cancel_all_stock_orders,
+        )
+
+        result = await schwab_cancel_all_stock_orders("acct1")
+        assert result["result"]["cancelled_count"] == 1
+        assert result["result"]["failed_count"] == 1
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_cancel_all_stock_orders_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test cancel_all_stock_orders auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_cancel_all_stock_orders,
+        )
+
+        result = await schwab_cancel_all_stock_orders("acct1")
+        assert result == error_response
+
+
+class TestSchwabOrderBuyOptionLimit:
+    """Tests for schwab_order_buy_option_limit."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_buy_option_limit_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test successful option limit buy order."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.headers = {"Location": "/orders/30001"}
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_buy_option_limit,
+        )
+
+        result = await schwab_order_buy_option_limit(
+            "acct1", "AAPL  251219C00150000", 2, "5.50"
+        )
+        assert result["result"]["status"] == "order_placed"
+        assert result["result"]["action"] == "buy_to_open"
+        assert result["result"]["order_type"] == "limit"
+        assert result["result"]["quantity"] == 2
+        assert result["result"]["order_id"] == "30001"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_buy_option_limit_api_failure(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test option buy limit detects API error."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Invalid option symbol"
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_buy_option_limit,
+        )
+
+        result = await schwab_order_buy_option_limit("acct1", "BAD_SYMBOL", 1, "3.00")
+        assert "error" in result["result"]
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_buy_option_limit_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test buy_option_limit auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_buy_option_limit,
+        )
+
+        result = await schwab_order_buy_option_limit(
+            "acct1", "AAPL  251219C00150000", 1, "5.00"
+        )
+        assert result == error_response
+
+
+class TestSchwabOrderSellOptionLimit:
+    """Tests for schwab_order_sell_option_limit."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_sell_option_limit_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test successful option limit sell order."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.headers = {"Location": "/orders/40001"}
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_sell_option_limit,
+        )
+
+        result = await schwab_order_sell_option_limit(
+            "acct1", "AAPL  251219C00150000", 2, "4.00"
+        )
+        assert result["result"]["status"] == "order_placed"
+        assert result["result"]["action"] == "sell_to_close"
+        assert result["result"]["order_type"] == "limit"
+        assert result["result"]["order_id"] == "40001"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_sell_option_limit_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test sell_option_limit auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_sell_option_limit,
+        )
+
+        result = await schwab_order_sell_option_limit(
+            "acct1", "AAPL  251219C00150000", 1, "4.00"
+        )
+        assert result == error_response
+
+
+class TestSchwabCancelOptionOrder:
+    """Tests for schwab_cancel_option_order."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_cancel_option_order_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test cancelling a specific option order."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_cancel_option_order,
+        )
+
+        result = await schwab_cancel_option_order("acct1", "opt_order_55")
+        assert result["result"]["status"] == "order_cancelled"
+        assert result["result"]["order_id"] == "opt_order_55"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_cancel_option_order_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test cancel_option_order auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_cancel_option_order,
+        )
+
+        result = await schwab_cancel_option_order("acct1", "opt_order_55")
+        assert result == error_response
+
+
+class TestSchwabCancelAllOptionOrders:
+    """Tests for schwab_cancel_all_option_orders."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_cancel_all_option_orders_ignores_equity(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test cancel_all_option_orders ignores equity orders."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        all_orders = [
+            # Open option order — should be cancelled
+            {
+                "orderId": "opt1",
+                "status": "WORKING",
+                "orderLegCollection": [
+                    {
+                        "instrument": {
+                            "assetType": "OPTION",
+                            "symbol": "AAPL  251219C00150000",
+                        }
+                    }
+                ],
+            },
+            # Open equity order — should be skipped
+            {
+                "orderId": "eq1",
+                "status": "WORKING",
+                "orderLegCollection": [
+                    {"instrument": {"assetType": "EQUITY", "symbol": "AAPL"}}
+                ],
+            },
+            # Filled option — excluded
+            {
+                "orderId": "opt2",
+                "status": "FILLED",
+                "orderLegCollection": [
+                    {
+                        "instrument": {
+                            "assetType": "OPTION",
+                            "symbol": "AAPL  251219P00140000",
+                        }
+                    }
+                ],
+            },
+        ]
+
+        cancel_response = MagicMock()
+        cancel_response.status_code = 200
+
+        mock_execute.side_effect = [
+            all_orders,
+            cancel_response,
+        ]
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_cancel_all_option_orders,
+        )
+
+        result = await schwab_cancel_all_option_orders("acct1")
+        assert result["result"]["cancelled_count"] == 1
+        assert result["result"]["failed_count"] == 0
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_cancel_all_option_orders_auth_error(
+        self, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test cancel_all_option_orders auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_cancel_all_option_orders,
+        )
+
+        result = await schwab_cancel_all_option_orders("acct1")
+        assert result == error_response
+
+
+class TestSchwabOrderOptionCreditSpread:
+    """Tests for schwab_order_option_credit_spread."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_call_credit_spread_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test bear call credit spread order placement."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.headers = {"Location": "/orders/50001"}
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_credit_spread,
+        )
+
+        result = await schwab_order_option_credit_spread(
+            "acct1",
+            "CALL",
+            "AAPL  251219C00150000",  # short (sell)
+            "AAPL  251219C00155000",  # long (buy/hedge)
+            1,
+            "2.00",
+        )
+        assert result["result"]["status"] == "order_placed"
+        assert result["result"]["spread_type"] == "credit"
+        assert result["result"]["option_type"] == "CALL"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_put_credit_spread_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test bull put credit spread order placement."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.headers = {"Location": "/orders/50002"}
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_credit_spread,
+        )
+
+        result = await schwab_order_option_credit_spread(
+            "acct1",
+            "PUT",
+            "AAPL  251219P00150000",  # short (sell)
+            "AAPL  251219P00145000",  # long (buy/hedge)
+            1,
+            "1.50",
+        )
+        assert result["result"]["status"] == "order_placed"
+        assert result["result"]["spread_type"] == "credit"
+        assert result["result"]["option_type"] == "PUT"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_credit_spread_invalid_option_type(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test credit spread with invalid option type returns error."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_credit_spread,
+        )
+
+        result = await schwab_order_option_credit_spread(
+            "acct1",
+            "INVALID",
+            "AAPL  251219C00150000",
+            "AAPL  251219C00155000",
+            1,
+            "2.00",
+        )
+        assert "error" in result["result"]
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_credit_spread_api_error(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test credit spread detects API error."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Order rejected"
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_credit_spread,
+        )
+
+        result = await schwab_order_option_credit_spread(
+            "acct1",
+            "CALL",
+            "AAPL  251219C00150000",
+            "AAPL  251219C00155000",
+            1,
+            "2.00",
+        )
+        assert "error" in result["result"]
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_credit_spread_auth_error(self, mock_get_broker: AsyncMock) -> None:
+        """Test credit spread auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_credit_spread,
+        )
+
+        result = await schwab_order_option_credit_spread(
+            "acct1", "CALL", "A", "B", 1, "2.00"
+        )
+        assert result == error_response
+
+
+class TestSchwabOrderOptionDebitSpread:
+    """Tests for schwab_order_option_debit_spread."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_call_debit_spread_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test bull call debit spread order placement."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.headers = {"Location": "/orders/60001"}
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_debit_spread,
+        )
+
+        result = await schwab_order_option_debit_spread(
+            "acct1",
+            "CALL",
+            "AAPL  251219C00150000",  # long (buy)
+            "AAPL  251219C00155000",  # short (sell/hedge)
+            1,
+            "3.00",
+        )
+        assert result["result"]["status"] == "order_placed"
+        assert result["result"]["spread_type"] == "debit"
+        assert result["result"]["option_type"] == "CALL"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_put_debit_spread_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test bear put debit spread order placement."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.headers = {"Location": "/orders/60002"}
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_debit_spread,
+        )
+
+        result = await schwab_order_option_debit_spread(
+            "acct1",
+            "PUT",
+            "AAPL  251219P00155000",  # long (buy, higher strike for bear put)
+            "AAPL  251219P00150000",  # short (sell/hedge)
+            1,
+            "2.50",
+        )
+        assert result["result"]["status"] == "order_placed"
+        assert result["result"]["spread_type"] == "debit"
+        assert result["result"]["option_type"] == "PUT"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_debit_spread_invalid_option_type(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test debit spread with invalid option type returns error."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_debit_spread,
+        )
+
+        result = await schwab_order_option_debit_spread(
+            "acct1",
+            "STRADDLE",
+            "AAPL  251219C00150000",
+            "AAPL  251219C00155000",
+            1,
+            "3.00",
+        )
+        assert "error" in result["result"]
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_debit_spread_auth_error(self, mock_get_broker: AsyncMock) -> None:
+        """Test debit spread auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import (
+            schwab_order_option_debit_spread,
+        )
+
+        result = await schwab_order_option_debit_spread(
+            "acct1", "CALL", "A", "B", 1, "3.00"
+        )
+        assert result == error_response
+
+
+class TestSchwabReplaceOrder:
+    """Tests for schwab_replace_order."""
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_replace_order_success(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test successful order replacement."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.headers = {"Location": "/orders/70001"}
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import schwab_replace_order
+
+        order_spec = {"orderType": "LIMIT", "price": "155.00"}
+        result = await schwab_replace_order("acct1", "old_order_99", order_spec)
+        assert result["result"]["status"] == "order_replaced"
+        assert result["result"]["new_order_id"] == "70001"
+        assert result["result"]["replaced_order_id"] == "old_order_99"
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_trading_tools.execute_broker_request")
+    async def test_replace_order_non_2xx(
+        self, mock_execute: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Test replace_order detects non-2xx response."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Order cannot be replaced"
+        mock_execute.return_value = mock_response
+
+        from open_stocks_mcp.tools.schwab_trading_tools import schwab_replace_order
+
+        result = await schwab_replace_order(
+            "acct1", "old_order_99", {"orderType": "LIMIT"}
+        )
+        assert "error" in result["result"]
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_trading_tools.get_authenticated_broker_or_error"
+    )
+    async def test_replace_order_auth_error(self, mock_get_broker: AsyncMock) -> None:
+        """Test replace_order auth failure."""
+        error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+        mock_get_broker.return_value = (None, error_response)
+
+        from open_stocks_mcp.tools.schwab_trading_tools import schwab_replace_order
+
+        result = await schwab_replace_order("acct1", "order99", {"orderType": "LIMIT"})
+        assert result == error_response


### PR DESCRIPTION
Closes #196

## Changes
- **`schwab_order_sell_stop`**: Stop sell equity orders using `OrderBuilder` with `OrderType.STOP`
- **`schwab_get_open_stock_orders`**: Filters `get_orders_for_account` to open (WORKING/NEW/QUEUED/etc) equity legs only
- **`schwab_cancel_all_stock_orders`**: Iterates open equity orders and cancels each; reports cancelled/failed counts
- **`schwab_order_buy_option_limit`**: Uses `option_buy_to_open_limit` helper from schwab-py
- **`schwab_order_sell_option_limit`**: Uses `option_sell_to_close_limit` helper from schwab-py
- **`schwab_cancel_option_order`**: Cancels a single option order by ID
- **`schwab_cancel_all_option_orders`**: Iterates open option legs only, skips equity orders
- **`schwab_order_option_credit_spread`**: `CALL` → `bear_call_vertical_open`; `PUT` → `bull_put_vertical_open`
- **`schwab_order_option_debit_spread`**: `CALL` → `bull_call_vertical_open`; `PUT` → `bear_put_vertical_open`
- **`schwab_replace_order`**: Calls `broker.client.replace_order(account_hash, order_id, order_spec)`
- All 10 tools registered as MCP tools in `app.py` using `_`-prefixed import aliases to avoid name shadowing
- 29 new unit tests with `@pytest.mark.journey_trading` + `@pytest.mark.unit`
- 1 new registration test asserting all 10 tool names appear in `mcp.list_tools()`

## Test plan
- `uv run pytest tests/unit/test_schwab_trading_tools.py -m "unit and journey_trading" -q` → 54 passed
- `uv run pytest tests/server/test_server_app.py::TestToolRegistration -q` → 6 passed
- `uv run mypy src/open_stocks_mcp/tools/schwab_trading_tools.py src/open_stocks_mcp/server/app.py` → Success: no issues found
- `uv run ruff check ...` → All checks passed