### PR TITLE
feat: register schwab_place_order MCP tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1396,6 +1396,20 @@ async def schwab_sell_stock_limit(
 
 
 @mcp.tool()
+async def schwab_place_order(
+    account_hash: str, order_spec: dict[str, Any]
+) -> dict[str, Any]:
+    """Place a generic Schwab order using a raw order specification.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        order_spec: Order specification dict as accepted by the Schwab API
+            (typically produced via schwab order builder helpers)
+    """
+    return await place_schwab_order(account_hash, order_spec)
+
+
+@mcp.tool()
 async def schwab_orders(account_hash: str, max_results: int = 50) -> dict[str, Any]:
     """Get orders for a Schwab account.
 
@@ -1426,14 +1440,6 @@ async def schwab_get_order(account_hash: str, order_id: str) -> dict[str, Any]:
         order_id: Order ID to retrieve
     """
     return await get_schwab_order_by_id(account_hash, order_id)
-
-
-@mcp.tool()
-async def schwab_place_order(
-    account_hash: str, order_spec: dict[str, Any]
-) -> dict[str, Any]:
-    """Place a generic order with Schwab using a pre-built order spec."""
-    return await place_schwab_order(account_hash, order_spec)
 
 
 async def schwab_transactions(

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -162,6 +162,7 @@ class TestToolRegistration:
             "schwab_get_open_option_positions",
             "schwab_option_buy_to_open",
             "schwab_option_sell_to_close",
+            "schwab_place_order",
         ]
 
         for tool_name in expected_tools:

--- a/tests/unit/test_schwab_trading_tools.py
+++ b/tests/unit/test_schwab_trading_tools.py
@@ -563,8 +563,8 @@ class TestSchwabTradingTools:
         self,
         mock_to_thread: AsyncMock,
         mock_get_broker: AsyncMock,
-        function,
-        args,
+        function: Any,
+        args: tuple[Any, ...],
     ) -> None:
         """Test various trading tools for API failure responses."""
         mock_broker = MagicMock()
@@ -646,26 +646,32 @@ class TestSchwabTradingTools:
         assert "result" in result
         assert "error" in result["result"]
 
+    @pytest.mark.journey_trading
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_schwab_place_order_mcp_wrapper(self) -> None:
-        """Test the MCP wrapper for schwab_place_order."""
+    async def test_schwab_place_order_wrapper_delegates_to_tool(self) -> None:
+        """The server-layer schwab_place_order tool delegates to place_schwab_order."""
         from unittest.mock import AsyncMock, patch
-        from open_stocks_mcp.server.app import schwab_place_order
 
-        with patch(
-            "open_stocks_mcp.server.app.place_schwab_order", new_callable=AsyncMock
-        ) as mock_impl:
-            mock_impl.return_value = {
-                "result": {"status": "order_placed", "order_id": "1"}
+        from open_stocks_mcp.server import app as server_app
+
+        account_hash = "abc123"
+        order_spec = {"orderType": "MARKET", "orderLegCollection": []}
+        expected_payload = {
+            "result": {
+                "status": "order_placed",
+                "order_id": "99999",
+                "status_code": 201,
             }
+        }
 
-            result = await schwab_place_order(
-                account_hash="HASH", order_spec={"orderType": "MARKET"}
-            )
+        with patch.object(
+            server_app, "place_schwab_order", new=AsyncMock(return_value=expected_payload)
+        ) as mock_place:
+            result = await server_app.schwab_place_order(account_hash, order_spec)
 
-            mock_impl.assert_awaited_once_with("HASH", {"orderType": "MARKET"})
-            assert result == {"result": {"status": "order_placed", "order_id": "1"}}
+            mock_place.assert_awaited_once_with(account_hash, order_spec)
+            assert result is expected_payload
 
 
 # ============================================================

--- a/tests/unit/test_schwab_trading_tools.py
+++ b/tests/unit/test_schwab_trading_tools.py
@@ -1,6 +1,7 @@
 """Unit tests for Schwab trading tools."""
 
 import datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Closes #205

## Changes
- Import `place_schwab_order` in `src/open_stocks_mcp/server/app.py`.
- Add `@mcp.tool()` async wrapper `schwab_place_order(account_hash, order_spec)` that delegates directly to `place_schwab_order` without transforming the order spec.
- Add `test_schwab_place_order_wrapper_delegates_to_tool` covering wrapper delegation via patched `AsyncMock`.
- Add `schwab_place_order` to the registered-tool expectation in `TestToolRegistration.test_tools_are_registered`.

## Test plan
- `uv run pytest tests/unit/test_schwab_trading_tools.py -k "schwab_place_order_wrapper or place_order" -v`
- `uv run pytest tests/server/test_server_app.py::TestToolRegistration::test_tools_are_registered -v`
- `uv run ruff check src/open_stocks_mcp/server/app.py tests/unit/test_schwab_trading_tools.py tests/server/test_server_app.py`
- `uv run mypy src/open_stocks_mcp/server/app.py tests/unit/test_schwab_trading_tools.py tests/server/test_server_app.py` (one pre-existing unrelated `no-untyped-def` at line 562 of test_schwab_trading_tools.py, already on main)