### PR TITLE
test: add APIError create_error_response coverage

### DIFF
--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -139,6 +139,14 @@ def test_create_error_response_with_context() -> None:
     assert response["result"]["error_type"] == "rate_limit"
 
 
+def test_create_error_response_error_type_matches_api_error_fallback() -> None:
+    exc = RuntimeError("kaboom")
+    response = create_error_response(exc)
+    assert response["result"]["error_type"] == classify_error(exc).error_type
+    assert response["result"]["error_type"] == "api"
+    assert response["result"]["status"] == "error"
+
+
 def test_create_success_response_default_and_custom_status() -> None:
     payload = {"symbol": "AAPL"}
     response = create_success_response(payload)


### PR DESCRIPTION
Closes #240

## Changes
- Adds `test_create_error_response_error_type_matches_api_error_fallback` to `tests/unit/test_error_handling.py`
- This covers the missing acceptance criterion: `error_type` matches `classify_error(exc).error_type` for `APIError` inputs (the fallback case where an arbitrary `RuntimeError("kaboom")` classifies as `APIError`)
- The existing tests already covered `AuthenticationError` and `RateLimitError` inputs for `create_error_response`; this completes the required trio

## Context
`tests/unit/test_error_handling.py` was created by PR #326 (parent issue #21). This issue (#240) audited that file against its own acceptance criteria and found all assertions present except the explicit `APIError` case for `create_error_response`.

## Test plan
- `pytest tests/unit/test_error_handling.py -m "unit"` → 91 passed
- `ruff check tests/unit/test_error_handling.py` → clean
- `ruff format --check tests/unit/test_error_handling.py` → clean