### PR TITLE
feat: align broker capability surface with #200 (#245)

### DIFF
--- a/src/open_stocks_mcp/brokers/base.py
+++ b/src/open_stocks_mcp/brokers/base.py
@@ -39,6 +39,7 @@ class BrokerCapabilities:
     streaming_quotes: bool = False
     options: bool = False
     crypto: bool = False
+    extended_hours: bool = False
 
 
 class BaseBroker(ABC):

--- a/tests/unit/test_capabilities_and_streaming.py
+++ b/tests/unit/test_capabilities_and_streaming.py
@@ -1,19 +1,45 @@
-import pytest
-from datetime import datetime
 from unittest.mock import MagicMock, patch
-from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus, BrokerCapabilities
+
+import pytest
+
+from open_stocks_mcp.brokers.base import (
+    BaseBroker,
+    BrokerAuthStatus,
+    BrokerCapabilities,
+)
+
 
 class MockBroker(BaseBroker):
-    async def authenticate(self) -> bool: return True
-    async def is_authenticated(self) -> bool: return True
-    async def logout(self) -> None: pass
-    async def get_account_info(self): return {}
-    async def get_portfolio(self): return {}
-    async def get_positions(self): return {}
-    async def get_stock_quote(self, symbol): return {}
-    async def get_stock_price(self, symbol): return {}
-    async def order_buy_market(self, symbol, quantity): return {}
-    async def order_sell_market(self, symbol, quantity): return {}
+    async def authenticate(self) -> bool:
+        return True
+
+    async def is_authenticated(self) -> bool:
+        return True
+
+    async def logout(self) -> None:
+        pass
+
+    async def get_account_info(self):
+        return {}
+
+    async def get_portfolio(self):
+        return {}
+
+    async def get_positions(self):
+        return {}
+
+    async def get_stock_quote(self, symbol):
+        return {}
+
+    async def get_stock_price(self, symbol):
+        return {}
+
+    async def order_buy_market(self, symbol, quantity):
+        return {}
+
+    async def order_sell_market(self, symbol, quantity):
+        return {}
+
 
 def test_broker_capabilities_defaults():
     capabilities = BrokerCapabilities()
@@ -21,11 +47,12 @@ def test_broker_capabilities_defaults():
     assert not capabilities.options
     assert not capabilities.crypto
 
+
 def test_base_broker_health_status():
     broker = MockBroker("test_broker")
     broker._auth_info.status = BrokerAuthStatus.AUTHENTICATED
     broker._capabilities.streaming_quotes = True
-    
+
     status = broker.get_health_status()
     assert status["broker"] == "test_broker"
     assert status["is_available"] is True
@@ -33,46 +60,46 @@ def test_base_broker_health_status():
     assert status["capabilities"]["streaming_quotes"] is True
     assert status["streaming_ready"] is True
 
+
 @pytest.mark.asyncio
 async def test_schwab_stream_manager_handling():
     from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
-    
+
     mock_broker = MagicMock()
     manager = SchwabStreamManager(mock_broker)
-    
+
     # Test message handling
     message = {
         "service": "LEVELONE_EQUITIES",
-        "content": [
-            {"key": "AAPL", "1": 150.0, "2": 151.0}
-        ]
+        "content": [{"key": "AAPL", "1": 150.0, "2": 151.0}],
     }
-    
+
     manager._handle_message(message)
     quote = manager.get_latest_quote("AAPL")
     assert quote["1"] == 150.0
     assert quote["2"] == 151.0
 
+
 @patch("schwab.streaming.StreamClient")
 @pytest.mark.asyncio
 async def test_schwab_stream_manager_start(mock_stream_client_class):
     from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
-    
+
     mock_broker = MagicMock()
     mock_broker.is_available.return_value = True
     mock_broker.client = MagicMock()
-    
+
     manager = SchwabStreamManager(mock_broker)
-    
+
     # Mock login to avoid actual connection
     mock_stream_client = mock_stream_client_class.return_value
-    
+
     async def async_none():
         return None
-    
+
     mock_stream_client.login = MagicMock(return_value=async_none())
-    
-    # We don't want to actually start the background loop in tests usually, 
+
+    # We don't want to actually start the background loop in tests usually,
     # but we can mock it
     with patch("asyncio.create_task"):
         success = await manager.start()


### PR DESCRIPTION
Closes #245

## Changes
- Add `extended_hours: bool = False` to `BrokerCapabilities` so the capability shipped by #237 covers the EXTENDED_HOURS slot that #200 tracked. The risk #200 raised (silent `broker_unavailable` fallback when callers ask about a missing capability key) is now closed: every default broker reports `extended_hours=False` explicitly, no enum/dict gap remains, and the simple dataclass surface is the only contract.
- Clean up `tests/unit/test_capabilities_and_streaming.py` (drop unused `datetime` import, sort imports, apply ruff format) so the canonical orphan regression test from #244 satisfies project lint/format without changing any assertion semantics.

## Why this is minimal
The base capability dataclass, `_capabilities` initialization, `BaseBroker.get_health_status()`, and `SchwabBroker._wire_stream_manager()` were already shipped in the working tree on `main` (carried forward from the partially merged #113/#186 work). The only acceptance-criteria gap left in #245 was the #200 reconciliation, which this PR closes by adding the missing dataclass field rather than re-introducing a `BrokerCapability` enum.

## Test plan
- `uv run pytest tests/unit/test_capabilities_and_streaming.py -v` — 4 passed
- `uv run pytest tests/unit/test_broker_base.py tests/unit/test_schwab_broker.py -v` — 43 passed
- `uv run pytest tests/unit/ --collect-only` — 712 selected, no errors
- `uv run pytest tests/unit/ -m "not slow and not exception_test" -q` — passed (exit 0)
- `uv run mypy src/open_stocks_mcp/brokers/base.py src/open_stocks_mcp/brokers/schwab.py` — 0 errors
- `uv run ruff check src/open_stocks_mcp/brokers/base.py src/open_stocks_mcp/brokers/schwab.py tests/unit/test_capabilities_and_streaming.py` — clean
- `uv run ruff format --check src/open_stocks_mcp/brokers/base.py tests/unit/test_capabilities_and_streaming.py` — clean

## Issue #200 follow-up
With this change, #200 is resolvable: there is no `BrokerCapability` enum or per-broker capability map; `EXTENDED_HOURS` is now represented as the `extended_hours: bool = False` dataclass field and surfaces through `BaseBroker.get_health_status()["capabilities"]["extended_hours"]` for all brokers.