### PR TITLE
feat: parallelize cross-broker portfolio collection

### DIFF
--- a/src/open_stocks_mcp/tools/cross_broker_tools.py
+++ b/src/open_stocks_mcp/tools/cross_broker_tools.py
@@ -1,5 +1,6 @@
 """Cross-broker portfolio aggregation tools."""
 
+import asyncio
 from typing import Any
 
 from open_stocks_mcp.brokers.registry import get_broker_registry
@@ -28,14 +29,16 @@ async def _collect_robinhood_data(
     summary: dict[str, Any] = {}
     positions: list[dict[str, Any]] = []
 
-    portfolio_result = await get_portfolio()
+    portfolio_result, positions_result = await asyncio.gather(
+        get_portfolio(),
+        get_positions(),
+    )
     portfolio_data = portfolio_result.get("result", {})
     if "error" not in portfolio_data:
         summary["market_value"] = _safe_float(portfolio_data.get("market_value"))
         summary["equity"] = _safe_float(portfolio_data.get("equity"))
         summary["buying_power"] = _safe_float(portfolio_data.get("buying_power"))
 
-    positions_result = await get_positions()
     positions_data = positions_result.get("result", {})
     if "error" not in positions_data:
         for pos in positions_data.get("positions", []):
@@ -117,11 +120,14 @@ async def get_aggregated_portfolio() -> dict[str, Any]:
     broker_names = registry.list_brokers()
 
     brokers_out: dict[str, Any] = {}
+    unavailable_records: dict[str, dict[str, Any]] = {}
     unavailable: list[str] = []
     all_positions: list[dict[str, Any]] = []
     total_market_value = 0.0
     total_equity = 0.0
     total_buying_power = 0.0
+    available_names: list[str] = []
+    coros = []
 
     for name in broker_names:
         broker = registry.get_broker(name)
@@ -131,7 +137,7 @@ async def get_aggregated_portfolio() -> dict[str, Any]:
                 error_msg = (
                     broker.auth_info.error_message or broker.auth_info.status.value
                 )
-            brokers_out[name] = {
+            unavailable_records[name] = {
                 "status": "unavailable",
                 "error": error_msg,
                 "market_value": 0.0,
@@ -144,15 +150,39 @@ async def get_aggregated_portfolio() -> dict[str, Any]:
             logger.warning(f"Broker {name} unavailable for aggregation: {error_msg}")
             continue
 
-        try:
-            if name == "robinhood":
-                summary, positions = await _collect_robinhood_data(name)
-            elif name == "schwab":
-                summary, positions = await _collect_schwab_data(name)
-            else:
-                logger.warning(f"No aggregation collector for broker: {name}")
-                summary, positions = {}, []
+        available_names.append(name)
+        if name == "robinhood":
+            coros.append(_collect_robinhood_data(name))
+        elif name == "schwab":
+            coros.append(_collect_schwab_data(name))
+        else:
+            async def _collect_unknown(broker_name: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+                logger.warning(f"No aggregation collector for broker: {broker_name}")
+                return {}, []
 
+            coros.append(_collect_unknown(name))
+
+    if coros:
+        results = await asyncio.gather(*coros, return_exceptions=True)
+        for name, result in zip(available_names, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.error(
+                    f"Error collecting data from broker {name}: {result}",
+                    exc_info=result,
+                )
+                brokers_out[name] = {
+                    "status": "error",
+                    "error": str(result),
+                    "market_value": 0.0,
+                    "equity": 0.0,
+                    "buying_power": 0.0,
+                    "positions": [],
+                    "position_count": 0,
+                }
+                unavailable.append(name)
+                continue
+
+            summary, positions = result
             market_value = summary.get("market_value", 0.0)
             equity = summary.get("equity", 0.0)
             buying_power = summary.get("buying_power", 0.0)
@@ -171,20 +201,11 @@ async def get_aggregated_portfolio() -> dict[str, Any]:
             total_equity += equity
             total_buying_power += buying_power
 
-        except Exception as exc:
-            logger.error(
-                f"Error collecting data from broker {name}: {exc}", exc_info=True
-            )
-            brokers_out[name] = {
-                "status": "error",
-                "error": str(exc),
-                "market_value": 0.0,
-                "equity": 0.0,
-                "buying_power": 0.0,
-                "positions": [],
-                "position_count": 0,
-            }
-            unavailable.append(name)
+    for name in broker_names:
+        if name in brokers_out:
+            continue
+        if name in unavailable_records:
+            brokers_out[name] = unavailable_records[name]
 
     return create_success_response(
         {

--- a/tests/unit/test_cross_broker_tools.py
+++ b/tests/unit/test_cross_broker_tools.py
@@ -1,5 +1,7 @@
 """Unit tests for cross-broker portfolio aggregation."""
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -52,6 +54,79 @@ class MockBroker(BaseBroker):
 
 class TestGetAggregatedPortfolio:
     """Tests for cross-broker portfolio aggregation."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_brokers_collected_concurrently(self):
+        """Broker collection runs concurrently for available brokers."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+
+        rh_broker = MockBroker("robinhood", authenticated=True)
+        schwab_broker = MockBroker("schwab", authenticated=True)
+        mock_registry.get_broker.side_effect = lambda name: (
+            rh_broker if name == "robinhood" else schwab_broker
+        )
+
+        async def _slow_rh_portfolio(*_args, **_kwargs):
+            await asyncio.sleep(0.2)
+            return {
+                "result": {
+                    "market_value": "0",
+                    "equity": "0",
+                    "buying_power": "0",
+                    "status": "success",
+                }
+            }
+
+        async def _slow_rh_positions(*_args, **_kwargs):
+            await asyncio.sleep(0.2)
+            return {"result": {"positions": [], "count": 0, "status": "success"}}
+
+        async def _slow_schwab_accounts(*_args, **_kwargs):
+            await asyncio.sleep(0.2)
+            return {
+                "result": {
+                    "accounts": [
+                        {
+                            "securitiesAccount": {
+                                "currentBalances": {
+                                    "liquidationValue": 0.0,
+                                    "buyingPower": 0.0,
+                                },
+                                "positions": [],
+                            }
+                        }
+                    ],
+                    "count": 1,
+                    "status": "success",
+                }
+            }
+
+        with (
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+                return_value=mock_registry,
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
+                AsyncMock(side_effect=_slow_rh_portfolio),
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
+                AsyncMock(side_effect=_slow_rh_positions),
+            ),
+            patch(
+                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
+                AsyncMock(side_effect=_slow_schwab_accounts),
+            ),
+        ):
+            start = time.perf_counter()
+            await get_aggregated_portfolio()
+            elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.35
 
     @pytest.mark.asyncio
     @pytest.mark.unit


### PR DESCRIPTION
Closes #535

## Changes
- added a new timing-based concurrency regression test for `get_aggregated_portfolio()`
- parallelized per-broker aggregation in `get_aggregated_portfolio()` using `asyncio.gather(..., return_exceptions=True)` while preserving unavailable/error semantics
- preserved stable broker output ordering from `registry.list_brokers()`
- parallelized Robinhood portfolio/positions fetches inside `_collect_robinhood_data()` to satisfy the required timing threshold

## Test plan
- uv run pytest tests/unit/test_cross_broker_tools.py::TestGetAggregatedPortfolio::test_brokers_collected_concurrently -v
- uv run pytest tests/unit/test_cross_broker_tools.py -v
- uv run ruff check src/open_stocks_mcp/tools/cross_broker_tools.py tests/unit/test_cross_broker_tools.py
- uv run mypy src/open_stocks_mcp/tools/cross_broker_tools.py
