### PR TITLE
feat: add _classify_transaction and schwab_get_dividends (#527)

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -165,6 +165,9 @@ from open_stocks_mcp.tools.schwab_options_tools import (
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_option_sell_to_close as _schwab_option_sell_to_close_impl,
 )
+from open_stocks_mcp.tools.schwab_payment_tools import (
+    schwab_get_dividends as _schwab_get_dividends_impl,
+)
 from open_stocks_mcp.tools.schwab_portfolio_tools import (
     get_schwab_aggregate_positions,
     get_schwab_all_option_positions,
@@ -1480,6 +1483,22 @@ async def schwab_get_transaction(
         transaction_id: Transaction ID to retrieve
     """
     return await get_schwab_transaction(account_hash, transaction_id)
+
+
+@mcp.tool()
+async def schwab_get_dividends(
+    account_hash: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> dict[str, Any]:
+    """Get dividend payments for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        start_date: Optional start date (YYYY-MM-DD)
+        end_date: Optional end date (YYYY-MM-DD)
+    """
+    return await _schwab_get_dividends_impl(account_hash, start_date, end_date)
 
 
 @mcp.tool()

--- a/src/open_stocks_mcp/tools/schwab_payment_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_payment_tools.py
@@ -1,0 +1,110 @@
+"""Schwab payment and dividend extraction MCP tools."""
+
+import asyncio
+import datetime
+from decimal import Decimal
+from typing import Any
+
+from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.broker_utils import (
+    get_authenticated_broker_or_error,
+)
+from open_stocks_mcp.tools.error_handling import (
+    create_error_response,
+    create_success_response,
+    handle_schwab_errors,
+)
+
+
+def _classify_transaction(tx: dict[str, Any]) -> str:
+    """Classify a Schwab transaction into payment categories.
+
+    Args:
+        tx: Transaction dictionary from Schwab API
+
+    Returns:
+        One of: "dividend", "interest", "stock_loan", "other"
+    """
+    tx_type = tx.get("type", "")
+    description = tx.get("description", "").upper()
+
+    if tx_type == "DIVIDEND_OR_INTEREST":
+        if "INTEREST" in description:
+            return "interest"
+        return "dividend"
+
+    if tx_type == "JOURNAL" and (
+        "SECURITIES LENDING REVENUE" in description or "STOCK LOAN" in description
+    ):
+        return "stock_loan"
+
+    return "other"
+
+
+@handle_schwab_errors
+async def schwab_get_dividends(
+    account_hash: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> dict[str, Any]:
+    """Get dividend payments for a Schwab account.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        start_date: Optional start date (YYYY-MM-DD)
+        end_date: Optional end_date (YYYY-MM-DD)
+
+    Returns:
+        Dict with list of dividends and total amount
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get dividends for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+        parsed_start_date = (
+            datetime.date.fromisoformat(start_date) if start_date is not None else None
+        )
+        parsed_end_date = (
+            datetime.date.fromisoformat(end_date) if end_date is not None else None
+        )
+
+        # We hard-code transaction_types to DIVIDEND_OR_INTEREST for this tool
+        # but _classify_transaction will filter out interest.
+        response = await asyncio.to_thread(
+            broker.client.get_transactions,
+            account_hash,
+            start_date=parsed_start_date,
+            end_date=parsed_end_date,
+            transaction_types=["DIVIDEND_OR_INTEREST"],
+            symbol=None,
+        )
+
+        transactions = response.json() if hasattr(response, "json") else response
+
+        if not isinstance(transactions, list):
+            transactions = []
+
+        # Filter for dividends and calculate total
+        dividends = []
+        total_amount = Decimal("0.00")
+
+        for tx in transactions:
+            if _classify_transaction(tx) == "dividend":
+                dividends.append(tx)
+                net_amount = tx.get("netAmount", 0)
+                total_amount += Decimal(str(net_amount))
+
+        return create_success_response(
+            {
+                "dividends": dividends,
+                "total_amount": str(total_amount.quantize(Decimal("0.01"))),
+                "count": len(dividends),
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab dividends for {account_hash}: {e}")
+        return create_error_response(e)

--- a/tests/unit/test_schwab_payment_tools.py
+++ b/tests/unit/test_schwab_payment_tools.py
@@ -1,0 +1,119 @@
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.schwab_payment_tools import (
+    _classify_transaction,
+    schwab_get_dividends,
+)
+
+
+def test_classify_transaction_dividend_returns_dividend():
+    tx = {"type": "DIVIDEND_OR_INTEREST", "description": "QUALIFIED DIVIDEND"}
+    assert _classify_transaction(tx) == "dividend"
+
+
+def test_classify_transaction_interest_returns_interest():
+    tx = {"type": "DIVIDEND_OR_INTEREST", "description": "FREE BALANCE INTEREST ADJUSTMENT"}
+    assert _classify_transaction(tx) == "interest"
+
+
+def test_classify_transaction_journal_stock_loan_returns_stock_loan():
+    tx = {"type": "JOURNAL", "description": "SECURITIES LENDING REVENUE"}
+    assert _classify_transaction(tx) == "stock_loan"
+
+
+def test_classify_transaction_other_returns_other():
+    tx = {"type": "TRADE", "description": "Bought AAPL"}
+    assert _classify_transaction(tx) == "other"
+
+
+def test_classify_transaction_missing_fields_returns_other():
+    assert _classify_transaction({}) == "other"
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_success(mock_to_thread, mock_get_broker):
+    # Mock broker
+    broker = MagicMock()
+    mock_get_broker.return_value = (broker, None)
+
+    # Mock transactions
+    mock_to_thread.return_value = [
+        {"type": "DIVIDEND_OR_INTEREST", "description": "QUALIFIED DIVIDEND", "netAmount": 1.50},
+        {"type": "DIVIDEND_OR_INTEREST", "description": "DIVIDEND", "netAmount": 2.50},
+        {"type": "DIVIDEND_OR_INTEREST", "description": "FREE BALANCE INTEREST ADJUSTMENT", "netAmount": 0.05},
+        {"type": "TRADE", "description": "Bought AAPL", "netAmount": 100.0},
+    ]
+
+    result = await schwab_get_dividends("hash123")
+
+    assert result["result"]["status"] == "success"
+    assert len(result["result"]["dividends"]) == 2
+    assert result["result"]["total_amount"] == "4.00"
+    assert result["result"]["count"] == 2
+    assert result["result"]["dividends"][0]["netAmount"] == 1.50
+    assert result["result"]["dividends"][1]["netAmount"] == 2.50
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_passes_dividend_or_interest_type_filter(mock_to_thread, mock_get_broker):
+    broker = MagicMock()
+    mock_get_broker.return_value = (broker, None)
+    mock_to_thread.return_value = []
+
+    await schwab_get_dividends("hash123")
+
+    mock_to_thread.assert_called_once()
+    _, kwargs = mock_to_thread.call_args
+    assert kwargs["transaction_types"] == ["DIVIDEND_OR_INTEREST"]
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_passes_date_filters(mock_to_thread, mock_get_broker):
+    broker = MagicMock()
+    mock_get_broker.return_value = (broker, None)
+    mock_to_thread.return_value = []
+
+    await schwab_get_dividends("hash123", start_date="2026-04-01", end_date="2026-04-30")
+
+    mock_to_thread.assert_called_once()
+    _, kwargs = mock_to_thread.call_args
+    assert kwargs["start_date"] == datetime.date(2026, 4, 1)
+    assert kwargs["end_date"] == datetime.date(2026, 4, 30)
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_empty_list(mock_to_thread, mock_get_broker):
+    broker = MagicMock()
+    mock_get_broker.return_value = (broker, None)
+    mock_to_thread.return_value = []
+
+    result = await schwab_get_dividends("hash123")
+
+    assert result["result"]["status"] == "success"
+    assert result["result"]["dividends"] == []
+    assert result["result"]["total_amount"] == "0.00"
+    assert result["result"]["count"] == 0
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_auth_error(mock_to_thread, mock_get_broker):
+    mock_get_broker.return_value = (None, {"result": {"status": "error", "error": "Auth failed"}})
+
+    result = await schwab_get_dividends("hash123")
+
+    assert result["result"]["status"] == "error"
+    assert result["result"]["error"] == "Auth failed"
+    mock_to_thread.assert_not_called()

--- a/tests/unit/test_schwab_tool_layering.py
+++ b/tests/unit/test_schwab_tool_layering.py
@@ -7,6 +7,7 @@ SCHWAB_TOOL_FILES = [
     "schwab_account_tools.py",
     "schwab_market_tools.py",
     "schwab_options_tools.py",
+    "schwab_payment_tools.py",
     "schwab_trading_tools.py",
 ]
 


### PR DESCRIPTION
Closes #527

## Changes
- Introduced _classify_transaction helper in schwab_payment_tools.py to categorize Schwab transactions.
- Implemented schwab_get_dividends tool to extract and sum dividend payments.
- Registered schwab_get_dividends as an MCP tool in server/app.py.
- Added schwab_payment_tools.py to architectural layering tests.
- Added comprehensive unit tests in tests/unit/test_schwab_payment_tools.py.

## Test plan
- Run pytest for new tools and layering.
- Verify mypy and ruff are clean.