### PR TITLE
test: use Mock type for patch-injected params in http_transport tests

### DIFF
--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterator
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -106,7 +106,7 @@ class TestHttpTransportUnit:
 
     @patch("open_stocks_mcp.server.http_transport.get_session_manager", return_value=None)
     def test_health_returns_503_when_session_manager_unavailable(
-        self, _mock_get_session_manager: Any, client: TestClient
+        self, _mock_get_session_manager: Mock, client: TestClient
     ) -> None:
         response = client.get("/health")
         assert response.status_code == 503
@@ -116,7 +116,7 @@ class TestHttpTransportUnit:
         "open_stocks_mcp.server.http_transport.get_metrics_collector", return_value=None
     )
     def test_health_returns_503_when_metrics_collector_unavailable(
-        self, _mock_get_metrics_collector: Any, client: TestClient
+        self, _mock_get_metrics_collector: Mock, client: TestClient
     ) -> None:
         response = client.get("/health")
         assert response.status_code == 503
@@ -124,7 +124,7 @@ class TestHttpTransportUnit:
 
     @patch("open_stocks_mcp.server.http_transport.get_metrics_collector", return_value=None)
     def test_status_returns_503_when_metrics_collector_unavailable(
-        self, _mock_get_metrics_collector: Any, client: TestClient
+        self, _mock_get_metrics_collector: Mock, client: TestClient
     ) -> None:
         response = client.get("/status")
         assert response.status_code == 503
@@ -132,7 +132,7 @@ class TestHttpTransportUnit:
 
     @patch("open_stocks_mcp.server.http_transport.get_session_manager", return_value=None)
     def test_status_returns_503_when_session_manager_unavailable(
-        self, _mock_get_session_manager: Any, client: TestClient
+        self, _mock_get_session_manager: Mock, client: TestClient
     ) -> None:
         response = client.get("/status")
         assert response.status_code == 503
@@ -140,7 +140,7 @@ class TestHttpTransportUnit:
 
     @patch("open_stocks_mcp.server.http_transport.get_session_manager", return_value=None)
     def test_session_refresh_returns_503_when_session_manager_unavailable(
-        self, _mock_get_session_manager: Any, client: TestClient
+        self, _mock_get_session_manager: Mock, client: TestClient
     ) -> None:
         response = client.post("/session/refresh")
         assert response.status_code == 503
@@ -151,7 +151,7 @@ class TestHttpTransportUnit:
         side_effect=RuntimeError("boom"),
     )
     def test_tools_endpoint_returns_500_when_list_available_tools_raises(
-        self, _mock_list_available_tools: Any, client: TestClient
+        self, _mock_list_available_tools: Mock, client: TestClient
     ) -> None:
         response = client.get("/tools")
         assert response.status_code == 500


### PR DESCRIPTION
Closes #252

## Changes
- Add `Mock` to `from unittest.mock import Mock, patch` import in `tests/unit/test_http_transport.py` to satisfy issue acceptance criteria
- Replace `Any` type annotations on all `@patch`-injected mock arguments with `Mock` for improved type precision

The test file was scaffolded in commit `96c8b0f` (PR #23) which added all three required test cases (`test_root_endpoint_returns_server_info`, `test_mcp_malformed_json_returns_parse_error_minus_32700`, `test_mcp_oversized_body_returns_413_with_parse_error_minus_32700`). This PR completes the acceptance criteria by adding the `Mock` import and using it for proper type annotations.

## Test plan
- `uv run pytest tests/unit/test_http_transport.py -v` — 12 tests passed
- `uv run ruff check tests/unit/test_http_transport.py` — clean
- `uv run mypy tests/unit/test_http_transport.py` — no issues found