### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/src/open_stocks_mcp/brokers/registry.py
+++ b/src/open_stocks_mcp/brokers/registry.py
@@ -10,6 +10,7 @@ from open_stocks_mcp.logging_config import logger
 
 class RegistryNotInitializedError(LookupError):
     """Raised when broker registry is accessed before initialization."""
+
     pass
 
 
@@ -294,13 +295,18 @@ class BrokerRegistry:
                     "operation": operation_name,
                     "status": "error",
                     "duration_ms": 0,
-                    "error": {"type": "invalid_operation", "message": "Operation must be callable"},
+                    "error": {
+                        "type": "invalid_operation",
+                        "message": "Operation must be callable",
+                    },
                 }
 
             start = time.perf_counter()
             try:
                 async with semaphore:
-                    result = await asyncio.wait_for(operation(), timeout=timeout_seconds)
+                    result = await asyncio.wait_for(
+                        operation(), timeout=timeout_seconds
+                    )
                 return {
                     "broker": broker,
                     "account_id": account_id,
@@ -332,7 +338,9 @@ class BrokerRegistry:
                     "error": {"type": type(exc).__name__, "message": str(exc)},
                 }
 
-        return await asyncio.gather(*[_run(op) for op in operations], return_exceptions=False)
+        return await asyncio.gather(
+            *[_run(op) for op in operations], return_exceptions=False
+        )
 
     async def coordinated_refresh(
         self,

--- a/src/open_stocks_mcp/brokers/request_policy.py
+++ b/src/open_stocks_mcp/brokers/request_policy.py
@@ -1,15 +1,19 @@
 import asyncio
 import functools
 import time
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from open_stocks_mcp.logging_config import logger
 
 T = TypeVar("T")
 
-def install_robinhood_request_timeout(timeout_seconds: float, session: Any | None = None) -> None:
+
+def install_robinhood_request_timeout(
+    timeout_seconds: float, session: Any | None = None
+) -> None:
     """Idempotently install a timeout policy on a requests-like session.
-    
+
     This wraps the session's request method to ensure every call uses the
     centrally configured timeout, overriding any call-site defaults provided
     by the SDK.
@@ -17,9 +21,12 @@ def install_robinhood_request_timeout(timeout_seconds: float, session: Any | Non
     if session is None:
         try:
             from robin_stocks.robinhood import helper
+
             session = helper.SESSION
         except ImportError:
-            logger.warning("robin_stocks not installed; skipping Robinhood timeout policy installation")
+            logger.warning(
+                "robin_stocks not installed; skipping Robinhood timeout policy installation"
+            )
             return
 
     # Check if already installed
@@ -35,7 +42,7 @@ def install_robinhood_request_timeout(timeout_seconds: float, session: Any | Non
         kwargs["timeout"] = getattr(session, "_robinhood_timeout", 16.0)
         return original_request(*args, **kwargs)
 
-    setattr(timeout_wrapper, "_is_timeout_wrapper", True)
+    timeout_wrapper._is_timeout_wrapper = True  # type: ignore[attr-defined]
     session.request = timeout_wrapper
     logger.debug(f"Installed Robinhood request timeout policy: {timeout_seconds}s")
 
@@ -81,9 +88,7 @@ async def execute_broker_request(
             if elapsed >= deadline:
                 if last_exception:
                     raise last_exception
-                raise asyncio.TimeoutError(
-                    f"Broker request exceeded deadline of {deadline}s"
-                )
+                raise TimeoutError(f"Broker request exceeded deadline of {deadline}s")
 
         try:
             # Run sync function in thread pool to avoid blocking the event loop

--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -35,7 +35,9 @@ class RobinhoodBroker(BaseBroker):
 
         # Install request timeout policy
         config = get_config()
-        install_robinhood_request_timeout(config.broker_requests.robinhood_timeout_seconds)
+        install_robinhood_request_timeout(
+            config.broker_requests.robinhood_timeout_seconds
+        )
 
         # Use provided session manager or create new one
         self.session_manager = session_manager or SessionManager()

--- a/src/open_stocks_mcp/brokers/schwab.py
+++ b/src/open_stocks_mcp/brokers/schwab.py
@@ -143,7 +143,9 @@ class SchwabBroker(BaseBroker):
                     )
                     # Apply configured timeout
                     assert self.client is not None
-                    self.client.set_timeout(get_config().broker_requests.schwab_timeout_seconds)
+                    self.client.set_timeout(
+                        get_config().broker_requests.schwab_timeout_seconds
+                    )
                     logger.info("✓ Schwab authentication successful (existing token)")
                     self._auth_info.status = BrokerAuthStatus.AUTHENTICATED
                     self._auth_info.last_successful_auth = datetime.now()
@@ -349,7 +351,9 @@ class SchwabBroker(BaseBroker):
             }
         }
 
-    async def get_transaction(self, account_hash: str, transaction_id: str) -> dict[str, Any]:
+    async def get_transaction(
+        self, account_hash: str, transaction_id: str
+    ) -> dict[str, Any]:
         """Get details for a specific transaction.
 
         Args:
@@ -362,6 +366,7 @@ class SchwabBroker(BaseBroker):
             return self.create_unavailable_response(f"get transaction {transaction_id}")
 
         try:
+
             def _get() -> Any:
                 return self.client.get_transaction(account_hash, transaction_id).json()
 

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 
 class ConfigError(ValueError):
@@ -460,9 +460,7 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
             ),
         ),
         alerts=AlertConfig(
-            enabled=_parse_bool(
-                os.getenv("ALERTS_ENABLED", "false"), "ALERTS_ENABLED"
-            ),
+            enabled=_parse_bool(os.getenv("ALERTS_ENABLED", "false"), "ALERTS_ENABLED"),
             webhook_url=os.getenv("ALERT_WEBHOOK_URL") or None,
             error_rate_degraded_threshold=_parse_float(
                 os.getenv("ALERT_ERROR_RATE_DEGRADED_THRESHOLD", "10.0"),

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 
 class ConfigError(ValueError):

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -35,9 +35,7 @@ class _LogAlertSink:
     """Default no-op sink that logs events. No external delivery."""
 
     async def send(self, event: AlertEvent) -> None:
-        logger.warning(
-            f"ALERT [{event.severity}] {event.signal}: {event.message}"
-        )
+        logger.warning(f"ALERT [{event.severity}] {event.signal}: {event.message}")
 
 
 class MetricsCollector:
@@ -166,9 +164,7 @@ class MetricsCollector:
             now = datetime.now()
             self._clean_old_entries(now)
             duration_ms_val = (
-                duration_ms
-                if duration_ms is not None
-                else ((duration or 0.0) * 1000.0)
+                duration_ms if duration_ms is not None else ((duration or 0.0) * 1000.0)
             )
             self.broker_operations.append(
                 {
@@ -219,7 +215,9 @@ class MetricsCollector:
             while tool_durations and tool_durations[0][0] < cutoff:
                 tool_durations.popleft()
 
-        while self.broker_operations and self.broker_operations[0]["timestamp"] < cutoff:
+        while (
+            self.broker_operations and self.broker_operations[0]["timestamp"] < cutoff
+        ):
             self.broker_operations.popleft()
 
     @staticmethod

--- a/src/open_stocks_mcp/tools/broker_comparison_tools.py
+++ b/src/open_stocks_mcp/tools/broker_comparison_tools.py
@@ -63,7 +63,9 @@ async def _collect_robinhood_comparison(
     portfolio_data = portfolio_result.get("result", {})
     if "error" not in portfolio_data:
         data["summary"]["equity"] = _safe_float(portfolio_data.get("equity"))
-        data["summary"]["buying_power"] = _safe_float(portfolio_data.get("buying_power"))
+        data["summary"]["buying_power"] = _safe_float(
+            portfolio_data.get("buying_power")
+        )
 
     positions_result = await get_positions()
     positions_data = positions_result.get("result", {})
@@ -85,14 +87,16 @@ async def _collect_robinhood_comparison(
             for o in rh_orders[:max_orders]:
                 symbol = o.get("symbol")
                 if not symbols or symbol in symbols:
-                    data["orders"].append({
-                        "symbol": symbol,
-                        "side": o.get("side"),
-                        "quantity": _safe_float(o.get("quantity")),
-                        "price": _safe_float(o.get("average_price")),
-                        "state": o.get("state"),
-                        "created_at": o.get("created_at"),
-                    })
+                    data["orders"].append(
+                        {
+                            "symbol": symbol,
+                            "side": o.get("side"),
+                            "quantity": _safe_float(o.get("quantity")),
+                            "price": _safe_float(o.get("average_price")),
+                            "state": o.get("state"),
+                            "created_at": o.get("created_at"),
+                        }
+                    )
 
     return data
 
@@ -161,7 +165,9 @@ async def _collect_schwab_comparison(
 
     # 3. Orders
     if include_orders:
-        orders_result = await get_schwab_orders(account_hash, max_results=max_orders * 2)
+        orders_result = await get_schwab_orders(
+            account_hash, max_results=max_orders * 2
+        )
         orders_data = orders_result.get("result", {})
         if "error" not in orders_data:
             schwab_orders = orders_data.get("orders", [])
@@ -178,14 +184,16 @@ async def _collect_schwab_comparison(
                 symbol = instr.get("symbol")
 
                 if not symbols or symbol in symbols:
-                    data["orders"].append({
-                        "symbol": symbol,
-                        "side": leg.get("instruction"),
-                        "quantity": _safe_float(o.get("quantity")),
-                        "price": _safe_float(o.get("price")),
-                        "state": o.get("status"),
-                        "created_at": o.get("enteredTime"),
-                    })
+                    data["orders"].append(
+                        {
+                            "symbol": symbol,
+                            "side": leg.get("instruction"),
+                            "quantity": _safe_float(o.get("quantity")),
+                            "price": _safe_float(o.get("price")),
+                            "state": o.get("status"),
+                            "created_at": o.get("enteredTime"),
+                        }
+                    )
 
     return data
 
@@ -226,9 +234,13 @@ async def get_broker_comparison(
 
         try:
             if name == "robinhood":
-                broker_data = await _collect_robinhood_comparison(symbols, include_orders, max_orders)
+                broker_data = await _collect_robinhood_comparison(
+                    symbols, include_orders, max_orders
+                )
             elif name == "schwab":
-                broker_data = await _collect_schwab_comparison(symbols, include_orders, max_orders)
+                broker_data = await _collect_schwab_comparison(
+                    symbols, include_orders, max_orders
+                )
             else:
                 logger.warning(f"No comparison collector for broker: {name}")
                 continue
@@ -240,7 +252,9 @@ async def get_broker_comparison(
             brokers_out[name] = broker_data
 
         except Exception as exc:
-            logger.error(f"Error collecting comparison data from {name}: {exc}", exc_info=True)
+            logger.error(
+                f"Error collecting comparison data from {name}: {exc}", exc_info=True
+            )
             brokers_out[name] = {
                 "broker": name,
                 "available": False,
@@ -252,7 +266,7 @@ async def get_broker_comparison(
     # Build comparison summary
     comparison: dict[str, Any] = {
         "symbols": symbols if symbols else [],
-        "metrics": ["pricing", "holdings", "orders"]
+        "metrics": ["pricing", "holdings", "orders"],
     }
 
     status = "success"
@@ -261,9 +275,11 @@ async def get_broker_comparison(
     if not any(b.get("available") for b in brokers_out.values()):
         status = "error"
 
-    return create_success_response({
-        "brokers": brokers_out,
-        "comparison": comparison,
-        "availability_notes": availability_notes,
-        "status": status,
-    })
+    return create_success_response(
+        {
+            "brokers": brokers_out,
+            "comparison": comparison,
+            "availability_notes": availability_notes,
+            "status": status,
+        }
+    )

--- a/src/open_stocks_mcp/tools/broker_utils.py
+++ b/src/open_stocks_mcp/tools/broker_utils.py
@@ -5,7 +5,7 @@ from typing import Any
 from open_stocks_mcp.brokers.registry import get_broker_registry
 from open_stocks_mcp.brokers.request_policy import execute_broker_request
 
-__all__ = ["get_authenticated_broker_or_error", "execute_broker_request"]
+__all__ = ["execute_broker_request", "get_authenticated_broker_or_error"]
 
 
 async def get_authenticated_broker_or_error(

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -124,7 +124,9 @@ async def execute_with_retry(
                     auth_retry_count += 1
 
                     try:
-                        success = await (await get_broker_registry()).coordinated_refresh(
+                        success = await (
+                            await get_broker_registry()
+                        ).coordinated_refresh(
                             broker_name=broker_name,
                             account_id=account_id,
                             refresh_coro=session_manager.refresh_session,

--- a/src/open_stocks_mcp/tools/robinhood_stock_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_stock_tools.py
@@ -50,11 +50,14 @@ async def get_stock_price(symbol: str) -> dict[str, Any]:
     # Get latest price and quote data with retry logic; coalesce_key deduplicates
     # concurrent calls for the same symbol while cache is cold.
     price_data = await execute_with_retry(
-        rh.get_latest_price, symbol, "ask_price",
+        rh.get_latest_price,
+        symbol,
+        "ask_price",
         coalesce_key=f"get_latest_price:{symbol}",
     )
     quote_data = await execute_with_retry(
-        rh.get_quotes, symbol,
+        rh.get_quotes,
+        symbol,
         coalesce_key=f"get_quotes:{symbol}",
     )
 

--- a/src/open_stocks_mcp/tools/robinhood_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_watchlist_tools.py
@@ -497,7 +497,11 @@ async def get_watchlist_performance(watchlist_name: str) -> dict[str, Any]:
                 or quote.get("ask_price")
                 or quote.get("bid_price")
             )
-            if price_str in (None, "") and prices_are_aligned and not quotes_have_symbols:
+            if (
+                price_str in (None, "")
+                and prices_are_aligned
+                and not quotes_have_symbols
+            ):
                 price_str = price_results[i]
 
             if price_str is not None:

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -163,7 +163,9 @@ async def get_schwab_option_expirations(symbol: str) -> dict[str, Any]:
             response = broker.client.get_option_expiration_chain(symbol.upper())
             return response.json()
 
-        expiration_data = await execute_broker_request(_get_option_chain, retry_safe=True)
+        expiration_data = await execute_broker_request(
+            _get_option_chain, retry_safe=True
+        )
 
         # Extract expiration dates
         expirations = expiration_data.get("expirationList", [])

--- a/src/open_stocks_mcp/tools/schwab_portfolio_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_portfolio_tools.py
@@ -84,8 +84,11 @@ async def get_schwab_build_holdings() -> dict[str, Any]:
         return error
 
     try:
+
         def _get_accounts() -> Any:
-            response = broker.client.get_accounts(fields=Client.Account.Fields.POSITIONS)
+            response = broker.client.get_accounts(
+                fields=Client.Account.Fields.POSITIONS
+            )
             return response.json()
 
         accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)
@@ -105,6 +108,7 @@ async def get_schwab_build_holdings() -> dict[str, Any]:
 
         quotes: dict[str, Any] = {}
         if symbols:
+
             def _get_quotes() -> Any:
                 response = broker.client.get_quotes(sorted(symbols))
                 return response.json()
@@ -128,8 +132,7 @@ async def get_schwab_build_holdings() -> dict[str, Any]:
                 "market_value": row["market_value"],
                 "price": quote_price,
                 "day_change": _to_float(
-                    quote.get("quote", {}).get("netChange")
-                    or quote.get("netChange")
+                    quote.get("quote", {}).get("netChange") or quote.get("netChange")
                 ),
                 "day_change_percent": _to_float(
                     quote.get("quote", {}).get("netPercentChangeInDouble")
@@ -160,6 +163,7 @@ async def get_schwab_day_trades() -> dict[str, Any]:
         return error
 
     try:
+
         def _get_account_numbers() -> Any:
             response = broker.client.get_account_numbers()
             return response.json()
@@ -181,6 +185,7 @@ async def get_schwab_day_trades() -> dict[str, Any]:
         trades: list[dict[str, Any]] = []
 
         for account_hash in account_hashes:
+
             def _get_transactions(current_account_hash: str = account_hash) -> Any:
                 response = broker.client.get_transactions(
                     current_account_hash,
@@ -202,7 +207,13 @@ async def get_schwab_day_trades() -> dict[str, Any]:
                 if not txn_date:
                     continue
                 instruction = str(txn.get("instruction") or "").upper()
-                side = "BUY" if "BUY" in instruction else "SELL" if "SELL" in instruction else ""
+                side = (
+                    "BUY"
+                    if "BUY" in instruction
+                    else "SELL"
+                    if "SELL" in instruction
+                    else ""
+                )
                 if not side:
                     continue
                 bucket[(txn_date, symbol)].add(side)
@@ -244,8 +255,11 @@ async def get_schwab_aggregate_positions() -> dict[str, Any]:
         return error
 
     try:
+
         def _get_accounts() -> Any:
-            response = broker.client.get_accounts(fields=Client.Account.Fields.POSITIONS)
+            response = broker.client.get_accounts(
+                fields=Client.Account.Fields.POSITIONS
+            )
             return response.json()
 
         accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)
@@ -317,7 +331,9 @@ async def get_schwab_all_option_positions() -> dict[str, Any]:
             return error
 
         def _get_accounts() -> Any:
-            response = broker.client.get_accounts(fields=Client.Account.Fields.POSITIONS)
+            response = broker.client.get_accounts(
+                fields=Client.Account.Fields.POSITIONS
+            )
             return response.json()
 
         accounts_data = await execute_broker_request(_get_accounts, retry_safe=True)

--- a/src/open_stocks_mcp/tools/unified_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/unified_watchlist_tools.py
@@ -30,23 +30,24 @@ def _normalize_symbols(symbols: list[str]) -> list[str]:
                 seen.add(clean)
     return normalized
 
+
 async def get_unified_watchlists(brokers: list[str] | None = None) -> dict[str, Any]:
     """Get all watchlists across supported brokers."""
     registry = await get_broker_registry()
     all_broker_names = registry.list_brokers()
     broker_names = brokers if brokers is not None else all_broker_names
-    
+
     brokers_out = {}
     unified_watchlists = []
     warnings = []
     partial_failure = False
-    
+
     for name in broker_names:
         if name not in all_broker_names:
             brokers_out[name] = {"status": "error", "message": "Broker not registered"}
             partial_failure = True
             continue
-            
+
         broker = registry.get_broker(name)
         if name == "robinhood":
             if broker and broker.is_available():
@@ -55,17 +56,22 @@ async def get_unified_watchlists(brokers: list[str] | None = None) -> dict[str, 
                 if rh_data.get("status") == "success":
                     brokers_out[name] = {
                         "status": "success",
-                        "watchlist_count": rh_data.get("total_watchlists", 0)
+                        "watchlist_count": rh_data.get("total_watchlists", 0),
                     }
                     for wl in rh_data.get("watchlists", []):
-                        unified_watchlists.append({
-                            "name": wl.get("name"),
-                            "symbols": wl.get("symbols", []),
-                            "symbol_count": wl.get("symbol_count", 0),
-                            "brokers": ["robinhood"]
-                        })
+                        unified_watchlists.append(
+                            {
+                                "name": wl.get("name"),
+                                "symbols": wl.get("symbols", []),
+                                "symbol_count": wl.get("symbol_count", 0),
+                                "brokers": ["robinhood"],
+                            }
+                        )
                 else:
-                    brokers_out[name] = {"status": "error", "message": rh_data.get("message", "Error fetching watchlists")}
+                    brokers_out[name] = {
+                        "status": "error",
+                        "message": rh_data.get("message", "Error fetching watchlists"),
+                    }
                     partial_failure = True
             else:
                 brokers_out[name] = {"status": "unavailable"}
@@ -73,35 +79,45 @@ async def get_unified_watchlists(brokers: list[str] | None = None) -> dict[str, 
         elif name == "schwab":
             brokers_out[name] = {
                 "status": "unsupported",
-                "message": "Schwab does not currently expose a watchlist API."
+                "message": "Schwab does not currently expose a watchlist API.",
             }
-            warnings.append({"broker": "schwab", "message": "Watchlists are not supported on Schwab."})
+            warnings.append(
+                {
+                    "broker": "schwab",
+                    "message": "Watchlists are not supported on Schwab.",
+                }
+            )
         else:
             brokers_out[name] = {"status": "unsupported"}
-            
+
     status = "success"
     if partial_failure:
         status = "partial_success"
-        
-    return create_success_response({
-        "watchlists": unified_watchlists,
-        "total_watchlists": len(unified_watchlists),
-        "brokers": brokers_out,
-        "warnings": warnings,
-        "status": status
-    })
 
-async def get_unified_watchlist_by_name(watchlist_name: str, brokers: list[str] | None = None) -> dict[str, Any]:
+    return create_success_response(
+        {
+            "watchlists": unified_watchlists,
+            "total_watchlists": len(unified_watchlists),
+            "brokers": brokers_out,
+            "warnings": warnings,
+            "status": status,
+        }
+    )
+
+
+async def get_unified_watchlist_by_name(
+    watchlist_name: str, brokers: list[str] | None = None
+) -> dict[str, Any]:
     """Get a specific watchlist by name across supported brokers."""
     registry = await get_broker_registry()
     all_broker_names = registry.list_brokers()
     broker_names = brokers if brokers is not None else all_broker_names
-    
+
     per_broker = {}
     combined_symbols = set()
     warnings = []
     found_any = False
-    
+
     for name in broker_names:
         if name not in all_broker_names:
             per_broker[name] = {"status": "error", "message": "Broker not registered"}
@@ -115,44 +131,61 @@ async def get_unified_watchlist_by_name(watchlist_name: str, brokers: list[str] 
                 if rh_data.get("status") == "success":
                     per_broker[name] = {
                         "status": "success",
-                        "symbols": rh_data.get("symbols", [])
+                        "symbols": rh_data.get("symbols", []),
                     }
                     combined_symbols.update(rh_data.get("symbols", []))
                     found_any = True
                 elif rh_data.get("status") == "not_found":
                     per_broker[name] = {"status": "not_found"}
                 else:
-                    per_broker[name] = {"status": "error", "message": rh_data.get("message", "Error")}
+                    per_broker[name] = {
+                        "status": "error",
+                        "message": rh_data.get("message", "Error"),
+                    }
             else:
                 per_broker[name] = {"status": "unavailable"}
         elif name == "schwab":
             per_broker[name] = {"status": "unsupported"}
-            warnings.append({"broker": "schwab", "message": "Watchlists are not supported on Schwab."})
-            
-    symbols = sorted(combined_symbols)
-    return create_success_response({
-        "watchlist_name": watchlist_name,
-        "symbols": symbols,
-        "symbol_count": len(symbols),
-        "brokers": list(per_broker.keys()),
-        "per_broker": per_broker,
-        "warnings": warnings,
-        "status": "success" if found_any else "not_found"
-    })
+            warnings.append(
+                {
+                    "broker": "schwab",
+                    "message": "Watchlists are not supported on Schwab.",
+                }
+            )
 
-async def add_symbols_to_unified_watchlist(watchlist_name: str, symbols: list[str], brokers: list[str] | None = None) -> dict[str, Any]:
+    symbols = sorted(combined_symbols)
+    return create_success_response(
+        {
+            "watchlist_name": watchlist_name,
+            "symbols": symbols,
+            "symbol_count": len(symbols),
+            "brokers": list(per_broker.keys()),
+            "per_broker": per_broker,
+            "warnings": warnings,
+            "status": "success" if found_any else "not_found",
+        }
+    )
+
+
+async def add_symbols_to_unified_watchlist(
+    watchlist_name: str, symbols: list[str], brokers: list[str] | None = None
+) -> dict[str, Any]:
     """Add symbols to a watchlist across supported brokers."""
     registry = await get_broker_registry()
     all_broker_names = registry.list_brokers()
     broker_names = brokers if brokers is not None else all_broker_names
-    
+
     normalized = _normalize_symbols(symbols)
     per_broker = {}
     warnings = []
-    
+
     for name in broker_names:
         if name not in all_broker_names:
-            per_broker[name] = {"status": "error", "success": False, "message": "Broker not registered"}
+            per_broker[name] = {
+                "status": "error",
+                "success": False,
+                "message": "Broker not registered",
+            }
             continue
 
         broker = registry.get_broker(name)
@@ -167,10 +200,12 @@ async def add_symbols_to_unified_watchlist(watchlist_name: str, symbols: list[st
             per_broker[name] = {
                 "status": "unsupported",
                 "success": False,
-                "message": "Schwab does not support watchlist mutations via API."
+                "message": "Schwab does not support watchlist mutations via API.",
             }
-            warnings.append({"broker": "schwab", "message": "Add operation ignored for Schwab."})
-            
+            warnings.append(
+                {"broker": "schwab", "message": "Add operation ignored for Schwab."}
+            )
+
     # Determine overall status
     success_count = sum(1 for b in per_broker.values() if b.get("status") == "success")
     if success_count == len(per_broker) and len(per_broker) > 0:
@@ -179,28 +214,37 @@ async def add_symbols_to_unified_watchlist(watchlist_name: str, symbols: list[st
         status = "partial_success"
     else:
         status = "error"
-        
-    return create_success_response({
-        "watchlist_name": watchlist_name,
-        "symbols_added": normalized,
-        "per_broker": per_broker,
-        "warnings": warnings,
-        "status": status
-    })
 
-async def remove_symbols_from_unified_watchlist(watchlist_name: str, symbols: list[str], brokers: list[str] | None = None) -> dict[str, Any]:
+    return create_success_response(
+        {
+            "watchlist_name": watchlist_name,
+            "symbols_added": normalized,
+            "per_broker": per_broker,
+            "warnings": warnings,
+            "status": status,
+        }
+    )
+
+
+async def remove_symbols_from_unified_watchlist(
+    watchlist_name: str, symbols: list[str], brokers: list[str] | None = None
+) -> dict[str, Any]:
     """Remove symbols from a watchlist across supported brokers."""
     registry = await get_broker_registry()
     all_broker_names = registry.list_brokers()
     broker_names = brokers if brokers is not None else all_broker_names
-    
+
     normalized = _normalize_symbols(symbols)
     per_broker = {}
     warnings = []
-    
+
     for name in broker_names:
         if name not in all_broker_names:
-            per_broker[name] = {"status": "error", "success": False, "message": "Broker not registered"}
+            per_broker[name] = {
+                "status": "error",
+                "success": False,
+                "message": "Broker not registered",
+            }
             continue
 
         broker = registry.get_broker(name)
@@ -215,10 +259,12 @@ async def remove_symbols_from_unified_watchlist(watchlist_name: str, symbols: li
             per_broker[name] = {
                 "status": "unsupported",
                 "success": False,
-                "message": "Schwab does not support watchlist mutations via API."
+                "message": "Schwab does not support watchlist mutations via API.",
             }
-            warnings.append({"broker": "schwab", "message": "Remove operation ignored for Schwab."})
-            
+            warnings.append(
+                {"broker": "schwab", "message": "Remove operation ignored for Schwab."}
+            )
+
     success_count = sum(1 for b in per_broker.values() if b.get("status") == "success")
     if success_count == len(per_broker) and len(per_broker) > 0:
         status = "success"
@@ -226,11 +272,13 @@ async def remove_symbols_from_unified_watchlist(watchlist_name: str, symbols: li
         status = "partial_success"
     else:
         status = "error"
-        
-    return create_success_response({
-        "watchlist_name": watchlist_name,
-        "symbols_removed": normalized,
-        "per_broker": per_broker,
-        "warnings": warnings,
-        "status": status
-    })
+
+    return create_success_response(
+        {
+            "watchlist_name": watchlist_name,
+            "symbols_removed": normalized,
+            "per_broker": per_broker,
+            "warnings": warnings,
+            "status": status,
+        }
+    )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,2 +1,1 @@
 """Reusable test fixture payloads."""
-

--- a/tests/fixtures/broker_payloads.py
+++ b/tests/fixtures/broker_payloads.py
@@ -143,6 +143,7 @@ def robinhood_positions_payload() -> list[dict[str, Any]]:
 
 def robinhood_phoenix_account_payload() -> dict[str, Any]:
     """Return representative Robinhood phoenix account details."""
+
     def currency(amount: str) -> dict[str, str]:
         return {"amount": amount, "currency_code": "USD", "currency_id": "usd"}
 

--- a/tests/http_transport/test_http_auth.py
+++ b/tests/http_transport/test_http_auth.py
@@ -293,7 +293,12 @@ class TestHTTPSecurity:
             headers={"content-type": "application/json"},
         )
         # Should handle gracefully, not crash
-        assert response.status_code in [400, 401, 422, 500]  # Various valid error responses
+        assert response.status_code in [
+            400,
+            401,
+            422,
+            500,
+        ]  # Various valid error responses
 
 
 @pytest.mark.integration

--- a/tests/http_transport/test_http_error_handling.py
+++ b/tests/http_transport/test_http_error_handling.py
@@ -82,7 +82,8 @@ class TestHTTPErrorHandling:
             headers={"content-type": "application/json"},
         )
         assert response.status_code in [400, 401, 422]
-  # Bad Request or Unprocessable Entity
+
+    # Bad Request or Unprocessable Entity
 
     async def test_invalid_content_type(self, http_client: httpx.AsyncClient) -> None:
         """Test handling of invalid content types"""
@@ -92,7 +93,12 @@ class TestHTTPErrorHandling:
             headers={"content-type": "text/plain"},
         )
         # Should handle gracefully
-        assert response.status_code in [400, 401, 415, 422]  # Various acceptable error codes
+        assert response.status_code in [
+            400,
+            401,
+            415,
+            422,
+        ]  # Various acceptable error codes
 
     @patch("open_stocks_mcp.server.http_transport.get_health_service")
     async def test_503_service_unavailable(
@@ -118,7 +124,9 @@ class TestHTTPErrorHandling:
         """Test internal server error handling"""
         # Mock session manager failure
         mock_session_manager = Mock()
-        mock_session_manager.ensure_authenticated = AsyncMock(side_effect=Exception("Database connection failed"))
+        mock_session_manager.ensure_authenticated = AsyncMock(
+            side_effect=Exception("Database connection failed")
+        )
         mock_get_session_manager.return_value = mock_session_manager
 
         response = await http_client.post("/session/refresh")
@@ -378,7 +386,10 @@ class TestListToolsErrorHandling:
     ) -> None:
         """Valid list_available_tools responses are returned as-is."""
         mock_list_tools.return_value = {
-            "result": {"tools": [{"name": "get_stock_quote", "description": "Get quote"}], "count": 1}
+            "result": {
+                "tools": [{"name": "get_stock_quote", "description": "Get quote"}],
+                "count": 1,
+            }
         }
         response = await http_client.get("/tools")
         assert response.status_code == 200
@@ -400,7 +411,9 @@ class TestRecoveryMechanisms:
         mock_session_manager = Mock()
 
         # First call fails
-        mock_session_manager.ensure_authenticated = AsyncMock(side_effect=Exception("Temporary failure"))
+        mock_session_manager.ensure_authenticated = AsyncMock(
+            side_effect=Exception("Temporary failure")
+        )
         mock_get_session_manager.return_value = mock_session_manager
 
         response1 = await http_client.post("/session/refresh")

--- a/tests/http_transport/test_http_integration.py
+++ b/tests/http_transport/test_http_integration.py
@@ -180,7 +180,11 @@ class TestHTTPIntegration:
             content="invalid json",
             headers={"content-type": "application/json"},
         )
-        assert response.status_code in [400, 401, 422]  # Bad request or validation error
+        assert response.status_code in [
+            400,
+            401,
+            422,
+        ]  # Bad request or validation error
 
     async def test_security_middleware_integration(
         self, mcp_server_with_tools: FastMCP
@@ -202,7 +206,10 @@ class TestHTTPIntegration:
     @patch("open_stocks_mcp.health.get_session_manager")
     @patch("open_stocks_mcp.server.http_transport.get_session_manager")
     async def test_session_lifecycle_integration(
-        self, mock_get_session_manager_transport: Mock, mock_get_session_manager_health: Mock, mock_http_client: httpx.AsyncClient
+        self,
+        mock_get_session_manager_transport: Mock,
+        mock_get_session_manager_health: Mock,
+        mock_http_client: httpx.AsyncClient,
     ) -> None:
         """Test complete session lifecycle over HTTP"""
         # Mock session manager for lifecycle testing

--- a/tests/integration/test_live_market_harness.py
+++ b/tests/integration/test_live_market_harness.py
@@ -25,7 +25,9 @@ class TestDefaultOptInRejection:
         config.getoption.return_value = False
         with pytest.raises(pytest.skip.Exception) as exc_info:
             require_live_market_preflight(config)
-        assert "run-live-market" in str(exc_info.value).lower() or LIVE_MARKET_SKIP_REASON in str(exc_info.value)
+        assert "run-live-market" in str(
+            exc_info.value
+        ).lower() or LIVE_MARKET_SKIP_REASON in str(exc_info.value)
 
     def test_skips_without_env_var(self, monkeypatch: Any) -> None:
         """Skip when OPEN_STOCKS_RUN_LIVE_MARKET env var is absent."""

--- a/tests/unit/test_broker_comparison_tools.py
+++ b/tests/unit/test_broker_comparison_tools.py
@@ -66,47 +66,123 @@ async def test_get_broker_comparison_success():
     )
 
     # Mock Robinhood responses
-    mock_rh_price = AsyncMock(return_value={"result": {"symbol": "AAPL", "price": 150.0, "status": "success"}})
-    mock_rh_portfolio = AsyncMock(return_value={"result": {"equity": 10000.0, "buying_power": 2000.0, "status": "success"}})
-    mock_rh_positions = AsyncMock(return_value={"result": {"positions": [{"symbol": "AAPL", "quantity": 10}], "status": "success"}})
-    mock_rh_orders = AsyncMock(return_value={"result": {"orders": [{"symbol": "AAPL", "side": "BUY", "quantity": 5, "state": "filled"}], "status": "success"}})
+    mock_rh_price = AsyncMock(
+        return_value={"result": {"symbol": "AAPL", "price": 150.0, "status": "success"}}
+    )
+    mock_rh_portfolio = AsyncMock(
+        return_value={
+            "result": {"equity": 10000.0, "buying_power": 2000.0, "status": "success"}
+        }
+    )
+    mock_rh_positions = AsyncMock(
+        return_value={
+            "result": {
+                "positions": [{"symbol": "AAPL", "quantity": 10}],
+                "status": "success",
+            }
+        }
+    )
+    mock_rh_orders = AsyncMock(
+        return_value={
+            "result": {
+                "orders": [
+                    {"symbol": "AAPL", "side": "BUY", "quantity": 5, "state": "filled"}
+                ],
+                "status": "success",
+            }
+        }
+    )
 
     # Mock Schwab responses
-    mock_schwab_quote = AsyncMock(return_value={"result": {"symbol": "AAPL", "last_price": 150.5, "status": "success"}})
-    mock_schwab_account_numbers = AsyncMock(return_value={"result": {"accounts": [{"hash_value": "hash1"}], "status": "success"}})
-    mock_schwab_balances = AsyncMock(return_value={"result": {"current_balances": {"liquidationValue": 5000.0, "buyingPower": 1000.0}, "status": "success"}})
-    mock_schwab_portfolio = AsyncMock(return_value={"result": {"positions": [{"symbol": "AAPL", "quantity": 5}], "status": "success"}})
-    mock_schwab_orders = AsyncMock(return_value={
-        "result": {
-            "orders": [
-                {
-                    "orderLegCollection": [
-                        {
-                            "instruction": "BUY",
-                            "quantity": 2,
-                            "instrument": {"symbol": "AAPL"}
-                        }
-                    ],
-                    "status": "FILLED",
-                    "enteredTime": "2023-10-27T14:55:00Z",
-                    "price": 150.5
-                }
-            ],
-            "status": "success"
+    mock_schwab_quote = AsyncMock(
+        return_value={
+            "result": {"symbol": "AAPL", "last_price": 150.5, "status": "success"}
         }
-    })
+    )
+    mock_schwab_account_numbers = AsyncMock(
+        return_value={
+            "result": {"accounts": [{"hash_value": "hash1"}], "status": "success"}
+        }
+    )
+    mock_schwab_balances = AsyncMock(
+        return_value={
+            "result": {
+                "current_balances": {"liquidationValue": 5000.0, "buyingPower": 1000.0},
+                "status": "success",
+            }
+        }
+    )
+    mock_schwab_portfolio = AsyncMock(
+        return_value={
+            "result": {
+                "positions": [{"symbol": "AAPL", "quantity": 5}],
+                "status": "success",
+            }
+        }
+    )
+    mock_schwab_orders = AsyncMock(
+        return_value={
+            "result": {
+                "orders": [
+                    {
+                        "orderLegCollection": [
+                            {
+                                "instruction": "BUY",
+                                "quantity": 2,
+                                "instrument": {"symbol": "AAPL"},
+                            }
+                        ],
+                        "status": "FILLED",
+                        "enteredTime": "2023-10-27T14:55:00Z",
+                        "price": 150.5,
+                    }
+                ],
+                "status": "success",
+            }
+        }
+    )
 
     with (
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_broker_registry", return_value=mock_registry),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_stock_price", mock_rh_price),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_portfolio", mock_rh_portfolio),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_positions", mock_rh_positions),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_stock_orders", mock_rh_orders),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_quote", mock_schwab_quote),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_numbers", mock_schwab_account_numbers),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_balances", mock_schwab_balances),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_portfolio", mock_schwab_portfolio),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_schwab_orders", mock_schwab_orders),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_broker_registry",
+            return_value=mock_registry,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_stock_price",
+            mock_rh_price,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_portfolio",
+            mock_rh_portfolio,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_positions",
+            mock_rh_positions,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_stock_orders",
+            mock_rh_orders,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_quote",
+            mock_schwab_quote,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_numbers",
+            mock_schwab_account_numbers,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_account_balances",
+            mock_schwab_balances,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_portfolio",
+            mock_schwab_portfolio,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_schwab_orders",
+            mock_schwab_orders,
+        ),
     ):
         result = await get_broker_comparison(symbols=["AAPL"])
 
@@ -140,23 +216,53 @@ async def test_get_broker_comparison_partial_failure():
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
 
     rh_broker = MockBroker("robinhood", authenticated=True)
-    schwab_broker = MockBroker("schwab", authenticated=False) # Schwab down
+    schwab_broker = MockBroker("schwab", authenticated=False)  # Schwab down
     mock_registry.get_broker.side_effect = lambda name: (
         rh_broker if name == "robinhood" else schwab_broker
     )
 
     # Mock Robinhood responses
-    mock_rh_price = AsyncMock(return_value={"result": {"symbol": "AAPL", "price": 150.0, "status": "success"}})
-    mock_rh_portfolio = AsyncMock(return_value={"result": {"equity": 10000.0, "buying_power": 2000.0, "status": "success"}})
-    mock_rh_positions = AsyncMock(return_value={"result": {"positions": [{"symbol": "AAPL", "quantity": 10}], "status": "success"}})
-    mock_rh_orders = AsyncMock(return_value={"result": {"orders": [], "status": "success"}})
+    mock_rh_price = AsyncMock(
+        return_value={"result": {"symbol": "AAPL", "price": 150.0, "status": "success"}}
+    )
+    mock_rh_portfolio = AsyncMock(
+        return_value={
+            "result": {"equity": 10000.0, "buying_power": 2000.0, "status": "success"}
+        }
+    )
+    mock_rh_positions = AsyncMock(
+        return_value={
+            "result": {
+                "positions": [{"symbol": "AAPL", "quantity": 10}],
+                "status": "success",
+            }
+        }
+    )
+    mock_rh_orders = AsyncMock(
+        return_value={"result": {"orders": [], "status": "success"}}
+    )
 
     with (
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_broker_registry", return_value=mock_registry),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_stock_price", mock_rh_price),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_portfolio", mock_rh_portfolio),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_positions", mock_rh_positions),
-        patch("open_stocks_mcp.tools.broker_comparison_tools.get_stock_orders", mock_rh_orders),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_broker_registry",
+            return_value=mock_registry,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_stock_price",
+            mock_rh_price,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_portfolio",
+            mock_rh_portfolio,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_positions",
+            mock_rh_positions,
+        ),
+        patch(
+            "open_stocks_mcp.tools.broker_comparison_tools.get_stock_orders",
+            mock_rh_orders,
+        ),
     ):
         result = await get_broker_comparison(symbols=["AAPL"])
 

--- a/tests/unit/test_broker_fixture_payloads.py
+++ b/tests/unit/test_broker_fixture_payloads.py
@@ -33,9 +33,7 @@ def test_robinhood_account_payloads_contain_consumed_fields() -> None:
     assert {"portfolio_equity", "total_equity", "account_buying_power"}.issubset(
         phoenix["results"][0]
     )
-    assert {"price", "quantity", "equity", "type", "name"}.issubset(
-        holdings["AAPL"]
-    )
+    assert {"price", "quantity", "equity", "type", "name"}.issubset(holdings["AAPL"])
 
 
 def test_schwab_market_payloads_contain_consumed_fields() -> None:

--- a/tests/unit/test_broker_request_policy.py
+++ b/tests/unit/test_broker_request_policy.py
@@ -10,28 +10,29 @@ class TestBrokerRequestPolicy(unittest.TestCase):
     def test_install_robinhood_request_timeout(self):
         # Create a mock session that behaves like requests.Session
         import requests
+
         session = requests.Session()
         # Mock the request method directly
         mock_request = MagicMock(return_value=MagicMock())
         session.request = mock_request
-        
+
         # Configure timeout
         timeout = 1.0
-        
+
         # Install policy
         install_robinhood_request_timeout(timeout, session=session)
-        
+
         # Call session.request directly
         session.request("GET", "https://example.test")
-        args, kwargs = mock_request.call_args
+        _args, kwargs = mock_request.call_args
         self.assertEqual(kwargs.get("timeout"), timeout)
-        
+
         # Call session.get
         session.get("https://example.test")
         # requests.Session.get calls request(method='GET', ...)
-        args, kwargs = mock_request.call_args
+        _args, kwargs = mock_request.call_args
         self.assertEqual(kwargs.get("timeout"), timeout)
-        
+
         # Call session.post with an explicit timeout (should be overridden)
         session.post("https://example.test", timeout=16)
         _, kwargs = mock_request.call_args
@@ -39,56 +40,62 @@ class TestBrokerRequestPolicy(unittest.TestCase):
 
     def test_install_robinhood_request_timeout_idempotent(self):
         import requests
+
         session = requests.Session()
         original_request = session.request
-        
+
         timeout = 2.0
-        
+
         # Install twice
         install_robinhood_request_timeout(timeout, session=session)
         wrapped_once = session.request
         install_robinhood_request_timeout(timeout, session=session)
         wrapped_twice = session.request
-        
+
         # Should be the same wrapper
         self.assertEqual(wrapped_once, wrapped_twice)
         self.assertNotEqual(original_request, wrapped_once)
         self.assertTrue(hasattr(session.request, "_is_timeout_wrapper"))
 
+
 @pytest.mark.asyncio
 async def test_execute_broker_request_retries():
     from open_stocks_mcp.brokers.request_policy import execute_broker_request
     from open_stocks_mcp.config import BrokerRequestConfig
-    
+
     mock_func = MagicMock()
     # Fail twice, succeed on third
-    mock_func.side_effect = [Exception("Transient error"), Exception("Transient error"), "Success"]
-    
+    mock_func.side_effect = [
+        Exception("Transient error"),
+        Exception("Transient error"),
+        "Success",
+    ]
+
     policy = BrokerRequestConfig(
-        retry_max_retries=3,
-        retry_initial_delay=0.01,
-        retry_backoff_factor=1.0
+        retry_max_retries=3, retry_initial_delay=0.01, retry_backoff_factor=1.0
     )
-    
+
     result = await execute_broker_request(mock_func, policy=policy, retry_safe=True)
-    
+
     assert result == "Success"
     assert mock_func.call_count == 3
+
 
 @pytest.mark.asyncio
 async def test_execute_broker_request_no_retry_unsafe():
     from open_stocks_mcp.brokers.request_policy import execute_broker_request
     from open_stocks_mcp.config import BrokerRequestConfig
-    
+
     mock_func = MagicMock()
     mock_func.side_effect = Exception("Mutation error")
-    
+
     policy = BrokerRequestConfig(retry_max_retries=3)
-    
+
     with pytest.raises(Exception, match="Mutation error"):
         await execute_broker_request(mock_func, policy=policy, retry_safe=False)
-    
+
     assert mock_func.call_count == 1
+
 
 @pytest.mark.asyncio
 async def test_execute_broker_request_deadline():
@@ -96,26 +103,26 @@ async def test_execute_broker_request_deadline():
 
     from open_stocks_mcp.brokers.request_policy import execute_broker_request
     from open_stocks_mcp.config import BrokerRequestConfig
-    
+
     mock_func = MagicMock()
     mock_func.side_effect = Exception("Timeout error")
-    
+
     # Policy with 0.1s deadline
     policy = BrokerRequestConfig(
         retry_max_retries=10,
         retry_initial_delay=0.05,
         retry_backoff_factor=2.0,
-        total_deadline_seconds=0.1
+        total_deadline_seconds=0.1,
     )
-    
+
     start_time = time.time()
     with pytest.raises(Exception, match="Timeout error"):
         await execute_broker_request(mock_func, policy=policy, retry_safe=True)
-    
+
     elapsed = time.time() - start_time
     # Should stop before second retry (0.05 delay + 0.1 next delay > 0.1 budget)
     # Wait, 1st call at 0s. Failed. Delay 0.05s.
     # 2nd call at 0.05s. Failed. Delay 0.1s.
     # Total would be 0.15s which exceeds 0.1s.
-    assert mock_func.call_count <= 3 
+    assert mock_func.call_count <= 3
     assert elapsed < 0.2

--- a/tests/unit/test_example_notebooks.py
+++ b/tests/unit/test_example_notebooks.py
@@ -41,6 +41,7 @@ async def test_example_notebooks_have_required_structure() -> None:
         )
         assert len(code_cells) >= 3
         assert any(
-            any(tool_name in cell for tool_name in live_tool_names) for cell in code_cells
+            any(tool_name in cell for tool_name in live_tool_names)
+            for cell in code_cells
         )
         assert all("your_password" not in cell for cell in markdown_cells + code_cells)

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -104,7 +104,9 @@ class TestHttpTransportUnit:
         assert "invalid params" in body["error"]["message"].lower()
         assert body["id"] == 8
 
-    @patch("open_stocks_mcp.server.http_transport.get_session_manager", return_value=None)
+    @patch(
+        "open_stocks_mcp.server.http_transport.get_session_manager", return_value=None
+    )
     def test_health_returns_503_when_session_manager_unavailable(
         self, _mock_get_session_manager: Any, client: TestClient
     ) -> None:
@@ -122,7 +124,9 @@ class TestHttpTransportUnit:
         assert response.status_code == 503
         assert response.json()["detail"] == "Metrics collector unavailable"
 
-    @patch("open_stocks_mcp.server.http_transport.get_metrics_collector", return_value=None)
+    @patch(
+        "open_stocks_mcp.server.http_transport.get_metrics_collector", return_value=None
+    )
     def test_status_returns_503_when_metrics_collector_unavailable(
         self, _mock_get_metrics_collector: Any, client: TestClient
     ) -> None:
@@ -130,7 +134,9 @@ class TestHttpTransportUnit:
         assert response.status_code == 503
         assert response.json()["detail"] == "Metrics collector unavailable"
 
-    @patch("open_stocks_mcp.server.http_transport.get_session_manager", return_value=None)
+    @patch(
+        "open_stocks_mcp.server.http_transport.get_session_manager", return_value=None
+    )
     def test_status_returns_503_when_session_manager_unavailable(
         self, _mock_get_session_manager: Any, client: TestClient
     ) -> None:
@@ -138,7 +144,9 @@ class TestHttpTransportUnit:
         assert response.status_code == 503
         assert response.json()["detail"] == "Session manager unavailable"
 
-    @patch("open_stocks_mcp.server.http_transport.get_session_manager", return_value=None)
+    @patch(
+        "open_stocks_mcp.server.http_transport.get_session_manager", return_value=None
+    )
     def test_session_refresh_returns_503_when_session_manager_unavailable(
         self, _mock_get_session_manager: Any, client: TestClient
     ) -> None:

--- a/tests/unit/test_kubernetes_examples.py
+++ b/tests/unit/test_kubernetes_examples.py
@@ -59,7 +59,11 @@ def test_secret_example_content():
     assert "ROBINHOOD_USERNAME" in text
     assert "ROBINHOOD_PASSWORD" in text
     # Must not contain real-looking credential values
-    assert "your_email@example.com" not in text or "placeholder" in text.lower() or "example" in text.lower()
+    assert (
+        "your_email@example.com" not in text
+        or "placeholder" in text.lower()
+        or "example" in text.lower()
+    )
     # Should not have real passwords
     for suspicious in ["my_password", "secretpassword123", "hunter2"]:
         assert suspicious not in text
@@ -91,4 +95,6 @@ def test_kubernetes_readme_content():
 @pytest.mark.journey_system
 def test_root_readme_links_to_kubernetes():
     text = ROOT_README.read_text(encoding="utf-8")
-    assert "examples/kubernetes" in text, "Expected root README.md to link to examples/kubernetes"
+    assert "examples/kubernetes" in text, (
+        "Expected root README.md to link to examples/kubernetes"
+    )

--- a/tests/unit/test_schwab_account_tools.py
+++ b/tests/unit/test_schwab_account_tools.py
@@ -268,9 +268,7 @@ class TestSchwabAccountTools:
 
         assert "result" in result
         assert "user_preferences" in result["result"]
-        assert (
-            result["result"]["user_preferences"]["userProps"]["firstName"] == "John"
-        )
+        assert result["result"]["user_preferences"]["userProps"]["firstName"] == "John"
 
     @pytest.mark.journey_account
     @pytest.mark.unit

--- a/tests/unit/test_schwab_portfolio_tools.py
+++ b/tests/unit/test_schwab_portfolio_tools.py
@@ -78,10 +78,26 @@ class TestSchwabPortfolioTools:
 
         accounts_payload = [{"hashValue": "hash-1"}]
         trades_payload = [
-            {"symbol": "AAPL", "transactionDate": "2026-01-01T10:00:00Z", "instruction": "BUY"},
-            {"symbol": "AAPL", "transactionDate": "2026-01-01T11:00:00Z", "instruction": "SELL"},
-            {"symbol": "MSFT", "transactionDate": "2026-01-01T11:00:00Z", "instruction": "BUY"},
-            {"symbol": "AAPL", "transactionDate": "2026-01-02T11:00:00Z", "instruction": "BUY"},
+            {
+                "symbol": "AAPL",
+                "transactionDate": "2026-01-01T10:00:00Z",
+                "instruction": "BUY",
+            },
+            {
+                "symbol": "AAPL",
+                "transactionDate": "2026-01-01T11:00:00Z",
+                "instruction": "SELL",
+            },
+            {
+                "symbol": "MSFT",
+                "transactionDate": "2026-01-01T11:00:00Z",
+                "instruction": "BUY",
+            },
+            {
+                "symbol": "AAPL",
+                "transactionDate": "2026-01-02T11:00:00Z",
+                "instruction": "BUY",
+            },
         ]
         mock_execute_broker_request.side_effect = [accounts_payload, trades_payload]
 

--- a/tests/unit/test_session_security.py
+++ b/tests/unit/test_session_security.py
@@ -20,18 +20,25 @@ def tmp_tokens_dir(tmp_path: Path) -> Path:
 @pytest.fixture()
 def manager(tmp_tokens_dir: Path) -> Generator[SessionManager, None, None]:
     """SessionManager with home directory patched to a temp location."""
-    with patch("open_stocks_mcp.tools.session_manager.Path.home", return_value=tmp_tokens_dir.parent):
+    with patch(
+        "open_stocks_mcp.tools.session_manager.Path.home",
+        return_value=tmp_tokens_dir.parent,
+    ):
         yield SessionManager()
 
 
 class TestTokensDirectoryPermissions:
-    def test_directory_created_with_restricted_permissions(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_directory_created_with_restricted_permissions(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         manager._get_tokens_dir()
         assert tmp_tokens_dir.exists()
         mode = stat.S_IMODE(tmp_tokens_dir.stat().st_mode)
         assert mode == 0o700
 
-    def test_existing_directory_permissions_are_hardened(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_existing_directory_permissions_are_hardened(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         # Create directory with looser permissions first
         tmp_tokens_dir.mkdir(mode=0o755, parents=True, exist_ok=True)
         manager._get_tokens_dir()
@@ -40,19 +47,25 @@ class TestTokensDirectoryPermissions:
 
 
 class TestFernetKeyManagement:
-    def test_key_file_created_on_first_access(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_key_file_created_on_first_access(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         key = manager._get_or_create_fernet_key()
         key_path = tmp_tokens_dir / ".session.key"
         assert key_path.exists()
         assert key == key_path.read_bytes()
 
-    def test_key_file_has_restricted_permissions(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_key_file_has_restricted_permissions(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         manager._get_or_create_fernet_key()
         key_path = tmp_tokens_dir / ".session.key"
         mode = stat.S_IMODE(key_path.stat().st_mode)
         assert mode == 0o600
 
-    def test_same_key_returned_on_subsequent_calls(self, manager: SessionManager) -> None:
+    def test_same_key_returned_on_subsequent_calls(
+        self, manager: SessionManager
+    ) -> None:
         key1 = manager._get_or_create_fernet_key()
         key2 = manager._get_or_create_fernet_key()
         assert key1 == key2
@@ -66,7 +79,9 @@ class TestFernetKeyManagement:
 
 
 class TestPickleEncryption:
-    def test_encrypt_removes_plaintext(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_encrypt_removes_plaintext(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         pickle_path.write_bytes(b"fake-pickle-data")
@@ -75,7 +90,9 @@ class TestPickleEncryption:
 
         assert not pickle_path.exists()
 
-    def test_encrypt_creates_enc_file(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_encrypt_creates_enc_file(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         pickle_path.write_bytes(b"fake-pickle-data")
@@ -85,7 +102,9 @@ class TestPickleEncryption:
         enc_path = tmp_tokens_dir / "robinhood.pickle.enc"
         assert enc_path.exists()
 
-    def test_enc_file_has_restricted_permissions(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_enc_file_has_restricted_permissions(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         pickle_path.write_bytes(b"fake-pickle-data")
@@ -96,14 +115,18 @@ class TestPickleEncryption:
         mode = stat.S_IMODE(enc_path.stat().st_mode)
         assert mode == 0o600
 
-    def test_encrypt_no_op_when_no_plaintext(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_encrypt_no_op_when_no_plaintext(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         manager._encrypt_pickle_if_exists()  # Should not raise
         enc_path = tmp_tokens_dir / "robinhood.pickle.enc"
         assert not enc_path.exists()
 
 
 class TestPickleDecryption:
-    def test_round_trip_preserves_content(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_round_trip_preserves_content(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         original_data = b"serialized-oauth-token-data"
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -118,11 +141,15 @@ class TestPickleDecryption:
         assert pickle_path.exists()
         assert pickle_path.read_bytes() == original_data
 
-    def test_decrypt_returns_false_when_no_enc_file(self, manager: SessionManager) -> None:
+    def test_decrypt_returns_false_when_no_enc_file(
+        self, manager: SessionManager
+    ) -> None:
         result = manager._decrypt_pickle_if_exists()
         assert result is False
 
-    def test_corrupt_enc_file_is_removed(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_corrupt_enc_file_is_removed(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         enc_path = tmp_tokens_dir / "robinhood.pickle.enc"
         enc_path.write_bytes(b"not-valid-fernet-ciphertext")
@@ -132,7 +159,9 @@ class TestPickleDecryption:
         assert result is False
         assert not enc_path.exists()
 
-    def test_decrypted_file_has_restricted_permissions(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_decrypted_file_has_restricted_permissions(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         pickle_path.write_bytes(b"data")
@@ -177,7 +206,9 @@ class TestLoginPickleReencryption:
 
 
 class TestClearPickleFile:
-    def test_clears_both_plaintext_and_encrypted(self, manager: SessionManager, tmp_tokens_dir: Path) -> None:
+    def test_clears_both_plaintext_and_encrypted(
+        self, manager: SessionManager, tmp_tokens_dir: Path
+    ) -> None:
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         enc_path = tmp_tokens_dir / "robinhood.pickle.enc"

--- a/tests/unit/test_unified_watchlist_tools.py
+++ b/tests/unit/test_unified_watchlist_tools.py
@@ -14,10 +14,13 @@ from open_stocks_mcp.tools.unified_watchlist_tools import (
 
 @pytest.fixture
 def mock_registry():
-    with patch("open_stocks_mcp.tools.unified_watchlist_tools.get_broker_registry") as mock:
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_broker_registry"
+    ) as mock:
         registry = MagicMock()
         mock.return_value = registry
         yield registry
+
 
 @pytest.fixture
 def mock_robinhood():
@@ -26,6 +29,7 @@ def mock_robinhood():
     broker.is_available.return_value = True
     return broker
 
+
 @pytest.fixture
 def mock_schwab():
     broker = MagicMock()
@@ -33,29 +37,37 @@ def mock_schwab():
     broker.is_available.return_value = True
     return broker
 
+
 @pytest.mark.asyncio
-async def test_get_unified_watchlists_success(mock_registry, mock_robinhood, mock_schwab):
+async def test_get_unified_watchlists_success(
+    mock_registry, mock_robinhood, mock_schwab
+):
     """Test normalized response for all watchlists across brokers."""
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
-    mock_registry.get_broker.side_effect = lambda name: mock_robinhood if name == "robinhood" else mock_schwab
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
 
     rh_watchlists = {
         "result": {
             "watchlists": [
                 {"name": "Tech", "symbols": ["AAPL", "MSFT"], "symbol_count": 2}
             ],
-            "status": "success"
+            "status": "success",
         }
     }
 
-    with patch("open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists", return_value=rh_watchlists):
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
+        return_value=rh_watchlists,
+    ):
         result = await get_unified_watchlists()
 
     assert result["result"]["status"] in ["success", "partial_success"]
     assert "robinhood" in result["result"]["brokers"]
     assert "schwab" in result["result"]["brokers"]
     assert result["result"]["brokers"]["schwab"]["status"] == "unsupported"
-    
+
     # Check aggregation
     watchlists = result["result"]["watchlists"]
     assert len(watchlists) >= 1
@@ -63,22 +75,30 @@ async def test_get_unified_watchlists_success(mock_registry, mock_robinhood, moc
     assert "robinhood" in tech["brokers"]
     assert tech["symbols"] == ["AAPL", "MSFT"]
 
+
 @pytest.mark.asyncio
-async def test_get_unified_watchlist_by_name_success(mock_registry, mock_robinhood, mock_schwab):
+async def test_get_unified_watchlist_by_name_success(
+    mock_registry, mock_robinhood, mock_schwab
+):
     """Test normalized response for a single watchlist by name."""
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
-    mock_registry.get_broker.side_effect = lambda name: mock_robinhood if name == "robinhood" else mock_schwab
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
 
     rh_watchlist = {
         "result": {
             "name": "Tech",
             "symbols": ["AAPL", "MSFT"],
             "symbol_count": 2,
-            "status": "success"
+            "status": "success",
         }
     }
 
-    with patch("open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name", return_value=rh_watchlist):
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name",
+        return_value=rh_watchlist,
+    ):
         result = await get_unified_watchlist_by_name("Tech")
 
     assert result["result"]["status"] in ["success", "partial_success"]
@@ -88,46 +108,56 @@ async def test_get_unified_watchlist_by_name_success(mock_registry, mock_robinho
     assert "schwab" in result["result"]["brokers"]
     assert result["result"]["per_broker"]["schwab"]["status"] == "unsupported"
 
+
 @pytest.mark.asyncio
-async def test_add_symbols_to_unified_watchlist_partial_success(mock_registry, mock_robinhood, mock_schwab):
+async def test_add_symbols_to_unified_watchlist_partial_success(
+    mock_registry, mock_robinhood, mock_schwab
+):
     """Test partial success when adding symbols (RH success, Schwab unsupported)."""
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
-    mock_registry.get_broker.side_effect = lambda name: mock_robinhood if name == "robinhood" else mock_schwab
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
 
     rh_result = {
-        "result": {
-            "success": True,
-            "symbols_added": ["AAPL"],
-            "status": "success"
-        }
+        "result": {"success": True, "symbols_added": ["AAPL"], "status": "success"}
     }
 
-    with patch("open_stocks_mcp.tools.unified_watchlist_tools.add_rh_symbols", return_value=rh_result):
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.add_rh_symbols",
+        return_value=rh_result,
+    ):
         result = await add_symbols_to_unified_watchlist("Tech", ["aapl", "AAPL "])
 
     assert result["result"]["status"] == "partial_success"
     assert "AAPL" in result["result"]["symbols_added"]
-    assert len(result["result"]["symbols_added"]) == 1 # De-duplicated and uppercased
+    assert len(result["result"]["symbols_added"]) == 1  # De-duplicated and uppercased
     assert result["result"]["per_broker"]["robinhood"]["status"] == "success"
     assert result["result"]["per_broker"]["schwab"]["status"] == "unsupported"
 
+
 @pytest.mark.asyncio
-async def test_remove_symbols_from_unified_watchlist_success(mock_registry, mock_robinhood, mock_schwab):
+async def test_remove_symbols_from_unified_watchlist_success(
+    mock_registry, mock_robinhood, mock_schwab
+):
     """Test success when removing symbols from Robinhood."""
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
-    mock_registry.get_broker.side_effect = lambda name: mock_robinhood if name == "robinhood" else mock_schwab
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
 
     rh_result = {
-        "result": {
-            "success": True,
-            "symbols_removed": ["AAPL"],
-            "status": "success"
-        }
+        "result": {"success": True, "symbols_removed": ["AAPL"], "status": "success"}
     }
 
-    with patch("open_stocks_mcp.tools.unified_watchlist_tools.remove_rh_symbols", return_value=rh_result):
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.remove_rh_symbols",
+        return_value=rh_result,
+    ):
         result = await remove_symbols_from_unified_watchlist("Tech", ["AAPL"])
 
-    assert result["result"]["status"] == "partial_success" # Because Schwab is unsupported
+    assert (
+        result["result"]["status"] == "partial_success"
+    )  # Because Schwab is unsupported
     assert result["result"]["symbols_removed"] == ["AAPL"]
     assert result["result"]["per_broker"]["robinhood"]["status"] == "success"

--- a/tests/unit/test_watchlist_tools.py
+++ b/tests/unit/test_watchlist_tools.py
@@ -541,7 +541,11 @@ class TestGetWatchlistPerformance:
     ) -> None:
         """When the bulk broker call fails, all symbols get fallback error entries."""
         mock_get_watchlist.return_value = {
-            "result": {"name": "Test", "symbols": ["AAPL", "GOOGL"], "status": "success"}
+            "result": {
+                "name": "Test",
+                "symbols": ["AAPL", "GOOGL"],
+                "status": "success",
+            }
         }
         mock_execute.side_effect = Exception("API Error")
 


### PR DESCRIPTION
Automated cleanup from Foreman play 6934.\n\nTools applied:\n- uv run ruff check --fix .: applied 6 safe lint fixes; one dynamic marker needed a manual type-ignore alignment after Ruff's safe fix.\n- uv run ruff format .: reformatted 30 files.\n\nValidation:\n- uv run ruff check .: pass\n- uv run ruff format --check .: pass\n- uv run mypy src/: pass\n- git diff --check: pass\n- uv run pytest: fails during collection because tests/integration/conftest.py defines pytest_plugins in a non-top-level conftest under pytest 9.\n\nFiles changed: 32 tracked files.