### PR TITLE
docs: add Schwab trading ADK eval and update agent documentation

### DIFF
--- a/examples/google_adk_agent/README.md
+++ b/examples/google_adk_agent/README.md
@@ -1,6 +1,6 @@
 # Stock Trading Agent (Google ADK + MCP)
 
-A comprehensive stock trading agent that uses Google ADK to connect with our open-stocks-mcp server for Robin Stocks and Schwab API operations. This agent provides access to 60+ MCP tools for complete stock market analysis and portfolio management across multiple brokers.
+A comprehensive stock trading agent that uses Google ADK to connect with our open-stocks-mcp server for Robinhood and Schwab API operations. This agent provides access to 60+ MCP tools for complete stock market analysis and portfolio management across multiple brokers.
 
 > **📁 Note**: Evaluation tests and documentation have been moved to `tests/evals/` for better organization alongside the main test suite. See `tests/evals/ADK-testing-evals.md` for comprehensive testing documentation.
 
@@ -92,7 +92,7 @@ The agent has access to 60+ MCP tools organized into these categories:
 - **`options_orders`**: Options order history
 
 ### **Schwab Order Management (3 tools)**
-- **`schwab_orders`**: Account order history and status
+- **`schwab_orders`**: Account order history and status (read-only)
 - **`schwab_get_order`**: Specific order details
 - **`schwab_cancel_order`**: Cancel an existing order
 
@@ -140,6 +140,19 @@ The agent has access to 60+ MCP tools organized into these categories:
 - **`rate_limit_status`**: Rate limiting information
 - **`metrics_summary`**: Performance metrics
 - **`health_check`**: System health
+
+## Testing & Evaluation
+
+You can evaluate the agent's performance using ADK's evaluation tools. 
+
+### **Schwab Orders Evaluation**
+To test the agent's ability to retrieve Schwab order history (read-only), run:
+
+```bash
+MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
+```
+
+> **Note**: This evaluation requires live Schwab OAuth credentials and a valid account hash returned by `schwab_account_numbers`.
 
 ## Agent Capabilities
 

--- a/examples/google_adk_agent/agent.py
+++ b/examples/google_adk_agent/agent.py
@@ -1,7 +1,7 @@
 """Stock Trading Agent Configuration.
 
 This module configures Stock_Trader, a specialized agent for handling
-stock market operations and interactions with Robin Stocks through our MCP server.
+stock market operations and interactions with Robinhood and Schwab through our MCP server.
 
 It uses the specified Google model and connects to our open-stocks-mcp server
 to provide real-time stock market data and trading capabilities.
@@ -51,7 +51,7 @@ def create_agent() -> Agent:
         model=os.environ.get("GOOGLE_MODEL") or "gemini-2.0-flash",
         name="Stock_Trader",
         instruction=agent_instruction,
-        description="Specialized stock trading agent that can perform Robin Stocks and Schwab operations through MCP tools.",
+        description="Specialized stock trading agent that can perform Robinhood and Schwab operations through MCP tools.",
         tools=agent_tools,
     )
 

--- a/examples/google_adk_agent/prompts.py
+++ b/examples/google_adk_agent/prompts.py
@@ -1,7 +1,7 @@
 agent_instruction = """
 # Stock_Trader Agent
 
-You are Stock_Trader, a comprehensive stock market analysis and portfolio management agent powered by Robin Stocks and Schwab through MCP tools.
+You are Stock_Trader, a comprehensive stock market analysis and portfolio management agent powered by Robinhood and Schwab through MCP tools.
 You are connected to a pre-authenticated server with access to 60+ specialized financial tools across multiple brokers.
 
 ## Core Functions

--- a/tests/evals/5_ord_schwab_orders_test.json
+++ b/tests/evals/5_ord_schwab_orders_test.json
@@ -11,7 +11,7 @@
           "user_content": {
             "parts": [
               {
-                "text": "Show me my recent orders on Schwab for account REPLACE_WITH_SCHWAB_ACCOUNT_HASH."
+                "text": "Show me my recent orders on Schwab for account REPLACE_WITH_SCHWAB_ACCOUNT_HASH. (Note: The placeholder account hash must be replaced with a real hash from schwab_account_numbers before live execution.)"
               }
             ],
             "role": "user"
@@ -19,7 +19,7 @@
           "final_response": {
             "parts": [
               {
-                "text": "I have retrieved your recent orders for Schwab account REPLACE_WITH_SCHWAB_ACCOUNT_HASH. You have 0 open orders."
+                "text": "I have retrieved your recent orders for Schwab account REPLACE_WITH_SCHWAB_ACCOUNT_HASH. You have 0 open orders. (Note: For live execution, ensure REPLACE_WITH_SCHWAB_ACCOUNT_HASH is replaced with a real account hash returned by the schwab_account_numbers tool.)"
               }
             ],
             "role": "model"


### PR DESCRIPTION
Closes #125

## Changes
- Updated `tests/evals/5_ord_schwab_orders_test.json` with explicit placeholder instructions for Schwab account hashes.
- Updated `examples/google_adk_agent/agent.py` module docstring and agent description to mention Robinhood and Schwab support.
- Updated `examples/google_adk_agent/README.md` with Schwab tool categories, credential requirements, and the exact Schwab orders eval command.
- Updated `examples/google_adk_agent/prompts.py` for consistent terminology (using Robinhood instead of Robin Stocks).
- Verified that `schwab_orders` is read-only and uses the correct arguments.

## Test plan
- Validated JSON syntax: `python3 -m json.tool tests/evals/5_ord_schwab_orders_test.json`
- Validated Python linting: `ruff check examples/google_adk_agent/agent.py`
- Verified documentation presence with `rg`.