### PR TITLE
feat: add env-scoped config flags and broker gating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,11 @@ uv run ruff check src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/rate_l
 uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/server/app.py
 ```
 
+Config path environment variables:
+- `OPEN_STOCKS_CONFIG`
+- `OPEN_STOCKS_CONFIG_FILE`
+- `OPEN_STOCKS_MCP_CONFIG` (legacy alias)
+
 ### MCP Development
 ```bash
 # Test server locally (HTTP transport)

--- a/README.md
+++ b/README.md
@@ -264,13 +264,28 @@ mypy .                          # Type check
 
 ### YAML Configuration
 Open Stocks MCP can load configuration from `open-stocks-mcp.yaml` or `config.yaml` in the current working directory.
-You can also set an explicit path with `OPEN_STOCKS_MCP_CONFIG=/path/to/config.yaml`.
+You can also set an explicit path with `OPEN_STOCKS_CONFIG=/path/to/config.yaml` or `OPEN_STOCKS_CONFIG_FILE=/path/to/config.yaml` (`OPEN_STOCKS_MCP_CONFIG` remains supported for backward compatibility).
 
 Environment variables always win over YAML values, including:
 - `MCP_SERVER_NAME`, `LOG_LEVEL`
 - `RATE_LIMIT_CALLS_PER_MINUTE`, `RATE_LIMIT_CALLS_PER_HOUR`, `RATE_LIMIT_BURST_SIZE`
 - `CACHE_TTL_MARKET_SECONDS`, `CACHE_TTL_ACCOUNT_SECONDS`, `CACHE_MAX_SIZE`
 - `ENABLE_CACHE`, `ENABLE_CIRCUIT_BREAKER`
+
+Feature flags support safe defaults plus per-environment overrides:
+
+```yaml
+environment: production
+feature_flags:
+  brokers.robinhood:
+    default: true
+  brokers.schwab:
+    default: false
+    environments:
+      production: true
+```
+
+Unknown feature flags resolve to disabled (`false`).
 
 See `config.yaml.example` for the supported schema.
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,9 +1,15 @@
 # Open Stocks MCP configuration
 # Environment variables override every value below.
+environment: development
 
 server:
   name: Open Stocks MCP
   log_level: INFO
+
+brokers:
+  schwab:
+    api_key: ""
+    app_secret: ""
 
 rate_limits:
   calls_per_minute: 30
@@ -18,3 +24,12 @@ cache:
 feature_flags:
   enable_cache: true
   enable_circuit_breaker: false
+  brokers.robinhood:
+    default: true
+    environments:
+      production: true
+      staging: true
+  brokers.schwab:
+    default: false
+    environments:
+      production: false

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -15,7 +15,9 @@ class ConfigError(ValueError):
 
 
 _ALLOWED_TOP_LEVEL_KEYS = {
+    "environment",
     "server",
+    "brokers",
     "rate_limits",
     "cache",
     "feature_flags",
@@ -46,6 +48,8 @@ def _parse_bool(value: Any, field_name: str) -> bool:
         return value
     if isinstance(value, str):
         normalized = value.strip().lower()
+        if normalized == "":
+            return False
         if normalized in {"1", "true", "yes", "on"}:
             return True
         if normalized in {"0", "false", "no", "off"}:
@@ -99,9 +103,10 @@ def _discover_config_path(explicit_path: Path | None) -> Path | None:
     if explicit_path is not None:
         return explicit_path
 
-    env_path = os.getenv("OPEN_STOCKS_MCP_CONFIG")
-    if env_path:
-        return Path(env_path)
+    for env_var in ("OPEN_STOCKS_CONFIG", "OPEN_STOCKS_CONFIG_FILE", "OPEN_STOCKS_MCP_CONFIG"):
+        env_path = os.getenv(env_var)
+        if env_path:
+            return Path(env_path)
 
     for candidate in (Path("open-stocks-mcp.yaml"), Path("config.yaml")):
         if candidate.exists():
@@ -143,6 +148,12 @@ class FeatureFlagConfig:
 
     enable_cache: bool = True
     enable_circuit_breaker: bool = False
+
+
+@dataclass
+class FeatureFlagDefinition:
+    default: bool = False
+    environments: dict[str, bool] = field(default_factory=dict)
 
 
 @dataclass
@@ -221,6 +232,7 @@ class OtelConfig:
 @dataclass
 class ServerConfig:
     name: str = "Open Stocks MCP"
+    environment: str = "default"
     log_level: str = "INFO"
     monitoring_enabled: bool = True
     rate_limits: RateLimitConfig = field(default_factory=RateLimitConfig)
@@ -232,12 +244,31 @@ class ServerConfig:
     broker_requests: BrokerRequestConfig = field(default_factory=BrokerRequestConfig)
     alerts: AlertConfig = field(default_factory=AlertConfig)
     otel: OtelConfig = field(default_factory=OtelConfig)
+    feature_flag_definitions: dict[str, FeatureFlagDefinition] = field(
+        default_factory=dict
+    )
+    schwab_api_key: str | None = None
+    schwab_app_secret: str | None = None
 
     def __post_init__(self) -> None:
         if self.retry is None:
             self.retry = RetryConfig()
         if self.timeout is None:
             self.timeout = TimeoutConfig()
+
+    def is_feature_enabled(self, flag_name: str) -> bool:
+        if flag_name == "enable_cache":
+            return self.feature_flags.enable_cache
+        if flag_name == "enable_circuit_breaker":
+            return self.feature_flags.enable_circuit_breaker
+
+        definition = self.feature_flag_definitions.get(flag_name)
+        if definition is None:
+            return False
+
+        if self.environment in definition.environments:
+            return definition.environments[self.environment]
+        return definition.default
 
 
 def load_config(config_path: Path | str | None = None) -> ServerConfig:
@@ -250,8 +281,11 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
             raw = _load_yaml_mapping(selected)
         elif explicit is not None:
             raw = {}
+        else:
+            raise ConfigError(f"Config file not found: {selected}")
 
     server = raw.get("server", {}) if isinstance(raw.get("server", {}), dict) else {}
+    brokers = raw.get("brokers", {}) if isinstance(raw.get("brokers", {}), dict) else {}
     rate_limits = (
         raw.get("rate_limits", {})
         if isinstance(raw.get("rate_limits", {}), dict)
@@ -263,15 +297,48 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
         if isinstance(raw.get("feature_flags", {}), dict)
         else {}
     )
+    environment = str(raw.get("environment", "default"))
 
     for section_name, section_value in (
         ("server", raw.get("server", {})),
+        ("brokers", raw.get("brokers", {})),
         ("rate_limits", raw.get("rate_limits", {})),
         ("cache", raw.get("cache", {})),
         ("feature_flags", raw.get("feature_flags", {})),
     ):
         if section_value is not None and not isinstance(section_value, dict):
             raise ConfigError(f"{section_name} must be a mapping")
+
+    feature_flag_definitions: dict[str, FeatureFlagDefinition] = {}
+    for flag_name, flag_value in feature_flags.items():
+        if flag_name in {"enable_cache", "enable_circuit_breaker"}:
+            continue
+        if isinstance(flag_value, bool):
+            feature_flag_definitions[flag_name] = FeatureFlagDefinition(
+                default=flag_value
+            )
+            continue
+        if not isinstance(flag_value, dict):
+            raise ConfigError(f"feature_flags.{flag_name} must be a boolean or mapping")
+        default_raw = flag_value.get("default", False)
+        if not isinstance(default_raw, bool):
+            raise ConfigError(f"feature_flags.{flag_name}.default must be a boolean")
+        env_values_raw = flag_value.get("environments", {})
+        if not isinstance(env_values_raw, dict):
+            raise ConfigError(
+                f"feature_flags.{flag_name}.environments must be a mapping"
+            )
+        env_values: dict[str, bool] = {}
+        for env_name, env_enabled in env_values_raw.items():
+            if not isinstance(env_enabled, bool):
+                raise ConfigError(
+                    f"feature_flags.{flag_name}.environments.{env_name} must be a boolean"
+                )
+            env_values[str(env_name)] = env_enabled
+        feature_flag_definitions[flag_name] = FeatureFlagDefinition(
+            default=default_raw,
+            environments=env_values,
+        )
 
     name = os.getenv("MCP_SERVER_NAME", str(server.get("name", "Open Stocks MCP")))
     log_level = _validate_log_level(
@@ -353,6 +420,7 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
 
     cfg = ServerConfig(
         name=name,
+        environment=os.getenv("OPEN_STOCKS_ENVIRONMENT", environment),
         log_level=log_level,
         monitoring_enabled=monitoring_enabled,
         rate_limits=RateLimitConfig(
@@ -487,6 +555,21 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
             enabled=otel_enabled,
             service_name=os.getenv("OTEL_SERVICE_NAME", "open-stocks-mcp"),
             exporter_endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
+        ),
+        feature_flag_definitions=feature_flag_definitions,
+        schwab_api_key=(
+            os.getenv("SCHWAB_API_KEY")
+            or str(
+                (brokers.get("schwab", {}) if isinstance(brokers.get("schwab"), dict) else {}).get("api_key", "")
+            )
+            or None
+        ),
+        schwab_app_secret=(
+            os.getenv("SCHWAB_APP_SECRET")
+            or str(
+                (brokers.get("schwab", {}) if isinstance(brokers.get("schwab"), dict) else {}).get("app_secret", "")
+            )
+            or None
         ),
     )
 

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -9,6 +9,10 @@ import click
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
+from open_stocks_mcp.brokers.auth_coordinator import attempt_broker_logins
+from open_stocks_mcp.brokers.registry import get_broker_registry
+from open_stocks_mcp.brokers.robinhood import RobinhoodBroker
+from open_stocks_mcp.brokers.schwab import SchwabBroker
 from open_stocks_mcp.config import ServerConfig, load_config
 from open_stocks_mcp.logging_config import logger, setup_logging
 from open_stocks_mcp.server.tool_helpers import (
@@ -1805,7 +1809,11 @@ def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:
     return mcp
 
 
-async def setup_brokers(username: str | None, password: str | None) -> None:
+async def setup_brokers(
+    username: str | None,
+    password: str | None,
+    config: ServerConfig | None = None,
+) -> None:
     """
     Setup and register all configured brokers.
 
@@ -1816,17 +1824,19 @@ async def setup_brokers(username: str | None, password: str | None) -> None:
         username: Robinhood username (optional)
         password: Robinhood password (optional)
     """
-    from open_stocks_mcp.brokers.auth_coordinator import attempt_broker_logins
-    from open_stocks_mcp.brokers.registry import get_broker_registry
-    from open_stocks_mcp.brokers.robinhood import RobinhoodBroker
+    if config is None:
+        config = load_config()
 
     logger.info("Setting up broker integrations...")
 
     # Get the global registry
     registry = await get_broker_registry()
 
-    # Setup Robinhood broker if credentials provided
-    if username and password:
+    robinhood_enabled = config.is_feature_enabled("brokers.robinhood")
+    schwab_enabled = config.is_feature_enabled("brokers.schwab")
+
+    # Setup Robinhood broker if enabled and credentials provided
+    if robinhood_enabled and username and password:
         logger.info("Configuring Robinhood broker...")
         session_manager = get_session_manager()
         robinhood_broker = RobinhoodBroker(
@@ -1836,13 +1846,31 @@ async def setup_brokers(username: str | None, password: str | None) -> None:
         )
         registry.register(robinhood_broker)
         logger.info("✓ Robinhood broker registered")
-    else:
+    elif robinhood_enabled:
         logger.warning(
             "⚠️  Robinhood credentials not provided - skipping Robinhood integration"
         )
         logger.info(
             "   Set ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD to enable Robinhood"
         )
+    else:
+        logger.info("Robinhood broker disabled by feature flag brokers.robinhood")
+
+    # Setup Schwab broker if enabled and credentials configured
+    if schwab_enabled and config.schwab_api_key and config.schwab_app_secret:
+        logger.info("Configuring Schwab broker...")
+        schwab_broker = SchwabBroker(
+            api_key=config.schwab_api_key,
+            app_secret=config.schwab_app_secret,
+        )
+        registry.register(schwab_broker)
+        logger.info("✓ Schwab broker registered")
+    elif schwab_enabled:
+        logger.warning(
+            "⚠️  Schwab enabled but SCHWAB_API_KEY/SCHWAB_APP_SECRET not configured"
+        )
+    else:
+        logger.info("Schwab broker disabled by feature flag brokers.schwab")
 
     # Attempt to authenticate all registered brokers
     await attempt_broker_logins(require_at_least_one=False)
@@ -1963,11 +1991,12 @@ def main(
             password = None
 
     # Create MCP server
-    server = create_mcp_server()
+    config = load_config()
+    server = create_mcp_server(config)
 
     # Setup broker authentication (non-blocking)
     logger.info("Initializing broker authentication...")
-    asyncio.run(setup_brokers(username, password))
+    asyncio.run(setup_brokers(username, password, config=config))
 
     # Start server regardless of authentication status
     try:

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -9,6 +9,7 @@ from open_stocks_mcp.server.app import (
     create_mcp_server,
     health_check,
     mcp,
+    setup_brokers,
 )
 
 
@@ -305,3 +306,68 @@ def test_create_mcp_server_applies_rate_limiter_from_config() -> None:
     assert result is mcp
     mock_logging.assert_called_once_with(mock_config)
     mock_rl.assert_called_once_with(77, 1700, 13)
+
+
+@pytest.mark.asyncio
+async def test_setup_brokers_skips_robinhood_when_flag_disabled() -> None:
+    mock_registry = MagicMock()
+    config = MagicMock()
+    config.is_feature_enabled.side_effect = (
+        lambda name: {"brokers.robinhood": False, "brokers.schwab": False}.get(name, False)
+    )
+    config.schwab_api_key = None
+    config.schwab_app_secret = None
+
+    with (
+        patch(
+            "open_stocks_mcp.server.app.get_broker_registry", AsyncMock(return_value=mock_registry)
+        ),
+        patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+    ):
+        await setup_brokers("user", "pass", config=config)
+
+    mock_registry.register.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_brokers_registers_robinhood_when_flag_enabled() -> None:
+    mock_registry = MagicMock()
+    config = MagicMock()
+    config.is_feature_enabled.side_effect = (
+        lambda name: {"brokers.robinhood": True, "brokers.schwab": False}.get(name, False)
+    )
+    config.schwab_api_key = None
+    config.schwab_app_secret = None
+
+    with (
+        patch(
+            "open_stocks_mcp.server.app.get_broker_registry", AsyncMock(return_value=mock_registry)
+        ),
+        patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
+    ):
+        await setup_brokers("user", "pass", config=config)
+
+    mock_registry.register.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_brokers_registers_schwab_when_enabled_and_configured() -> None:
+    mock_registry = MagicMock()
+    config = MagicMock()
+    config.is_feature_enabled.side_effect = (
+        lambda name: {"brokers.robinhood": False, "brokers.schwab": True}.get(name, False)
+    )
+    config.schwab_api_key = "key"
+    config.schwab_app_secret = "secret"
+
+    with (
+        patch(
+            "open_stocks_mcp.server.app.get_broker_registry", AsyncMock(return_value=mock_registry)
+        ),
+        patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        patch("open_stocks_mcp.server.app.SchwabBroker", MagicMock()),
+    ):
+        await setup_brokers(None, None, config=config)
+
+    mock_registry.register.assert_called_once()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -161,3 +161,88 @@ def test_invalid_boolean_env_value_raises(
 
     with pytest.raises(ConfigError, match="ENABLE_CACHE"):
         load_config(config_path=path)
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_load_config_from_open_stocks_config_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        """
+server:
+  name: Env Path Config
+feature_flags:
+  brokers.robinhood:
+    default: false
+""".strip()
+    )
+    monkeypatch.setenv("OPEN_STOCKS_CONFIG", str(path))
+    monkeypatch.delenv("OPEN_STOCKS_CONFIG_FILE", raising=False)
+
+    cfg = load_config()
+    assert cfg.name == "Env Path Config"
+    assert cfg.is_feature_enabled("brokers.robinhood") is False
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_load_config_from_open_stocks_config_file_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "config-file.yaml"
+    path.write_text(
+        """
+server:
+  name: Env Path Config File
+feature_flags:
+  brokers.schwab:
+    default: true
+""".strip()
+    )
+    monkeypatch.delenv("OPEN_STOCKS_CONFIG", raising=False)
+    monkeypatch.setenv("OPEN_STOCKS_CONFIG_FILE", str(path))
+
+    cfg = load_config()
+    assert cfg.name == "Env Path Config File"
+    assert cfg.is_feature_enabled("brokers.schwab") is True
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_feature_flags_resolve_per_environment(tmp_path: Path) -> None:
+    path = tmp_path / "feature-flags.yaml"
+    path.write_text(
+        """
+environment: prod
+feature_flags:
+  brokers.robinhood:
+    default: false
+    environments:
+      prod: true
+  brokers.schwab:
+    default: false
+""".strip()
+    )
+
+    cfg = load_config(config_path=path)
+    assert cfg.is_feature_enabled("brokers.robinhood") is True
+    assert cfg.is_feature_enabled("brokers.schwab") is False
+    assert cfg.is_feature_enabled("brokers.unknown") is False
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_invalid_feature_flag_schema_raises(tmp_path: Path) -> None:
+    path = tmp_path / "bad-feature-flags.yaml"
+    path.write_text(
+        """
+feature_flags:
+  brokers.robinhood:
+    default: maybe
+""".strip()
+    )
+
+    with pytest.raises(ConfigError, match=r"brokers\.robinhood"):
+        load_config(config_path=path)


### PR DESCRIPTION
Closes #157

## Changes
- add support for `OPEN_STOCKS_CONFIG` and `OPEN_STOCKS_CONFIG_FILE` (with legacy `OPEN_STOCKS_MCP_CONFIG` compatibility) in config path discovery
- add environment-scoped feature flag definitions with `ServerConfig.is_feature_enabled()` and unknown-flag-safe default (`false`)
- gate broker registration in startup using feature flags (`brokers.robinhood`, `brokers.schwab`) and config-driven Schwab credentials
- load config once in `main()` and thread through server creation and broker setup
- expand unit/server tests for config env vars, feature flag behavior, and broker startup gating
- update docs/examples for YAML environment + feature flag schema

## Test plan
- uv run pytest tests/unit/test_config.py tests/server/test_server_app.py -q
- uv run pytest tests/unit -k 'config or flag' -q
- uv run ruff check src/open_stocks_mcp/config.py src/open_stocks_mcp/server/app.py tests/unit/test_config.py tests/server/test_server_app.py
- uv run mypy src
