### PR TITLE
feat: add VS Code debug tooling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,30 +1,14 @@
 {
   "recommendations": [
-    // Python language support
     "ms-python.python",
-
-    // Ruff linter and formatter
-    "charliermarsh.ruff",
-
-    // Test runner integration
     "ms-python.vscode-pylance",
-
-    // EditorConfig support
+    "charliermarsh.ruff",
+    "ms-python.mypy-type-checker",
     "editorconfig.editorconfig",
-
-    // GitHub integration
     "github.vscode-pull-request-github",
-
-    // YAML support
     "redhat.vscode-yaml",
-
-    // TOML support
     "tamasfe.even-better-toml",
-
-    // Markdown preview
     "yzhang.markdown-all-in-one",
-
-    // Git integration
     "eamodio.gitlens"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,18 @@
       "type": "python",
       "request": "launch",
       "module": "open_stocks_mcp.server.app",
-      "args": ["--transport", "http", "--port", "3001"],
+      "args": [
+        "--transport",
+        "http",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "3001",
+        "--debug"
+      ],
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
       "console": "integratedTerminal",
       "justMyCode": false
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "python.defaultInterpreterPath": ".venv/bin/python",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
   "python.testing.pytestArgs": ["tests"],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,20 +50,21 @@ VS Code Test Explorer uses `python.testing.pytestArgs` from `.vscode/settings.js
 
 The workspace launch file `.vscode/launch.json` provides two common entry points:
 
-- `Run MCP server (HTTP)` starts `open_stocks_mcp.server.app` with `--transport http --port 3001` in the integrated terminal.
+- `Run MCP server (HTTP)` starts `open_stocks_mcp.server.app` with `--transport http --host 127.0.0.1 --port 3001 --debug` in the integrated terminal.
 - `Pytest: current file` runs the currently open test file through `pytest -v`.
 
-For command-line debugging, start the HTTP server with Python development checks enabled:
+For command-line debugging, use `--debug` for one invocation or `DEBUG=true` for environment-driven DEBUG logging. An explicit `LOG_LEVEL` value takes precedence over `DEBUG=true`, while `--debug` forces DEBUG logging for that command.
 
 ```bash
-uv run python -X dev -m open_stocks_mcp.server.app --transport http --port 3001
+uv run python -X dev -m open_stocks_mcp.server.app --transport http --host 127.0.0.1 --port 3001 --debug
+DEBUG=true uv run open-stocks-mcp-server --transport http --host 127.0.0.1 --port 3001
 ```
 
 Inspect the local server from another terminal:
 
 ```bash
-curl http://localhost:3001/health
-curl http://localhost:3001/metrics
+curl -sf http://127.0.0.1:3001/health
+curl http://127.0.0.1:3001/metrics
 ```
 
 Use the standard debugger by setting `PYTHONBREAKPOINT` before running a focused test or server command:

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -58,6 +58,13 @@ def _parse_bool(value: Any, field_name: str) -> bool:
     raise ConfigError(f"{field_name} must be a boolean")
 
 
+def _env_flag_is_truthy(name: str) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return False
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _env_optional_int(name: str) -> int | None:
     raw_value = os.getenv(name)
     if raw_value is None or raw_value == "":
@@ -355,9 +362,14 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
         )
 
     name = os.getenv("MCP_SERVER_NAME", str(server.get("name", "Open Stocks MCP")))
-    log_level = _validate_log_level(
-        os.getenv("LOG_LEVEL", str(server.get("log_level", "INFO")))
-    )
+    raw_log_level = os.getenv("LOG_LEVEL")
+    if raw_log_level is None:
+        raw_log_level = (
+            "DEBUG"
+            if _env_flag_is_truthy("DEBUG")
+            else str(server.get("log_level", "INFO"))
+        )
+    log_level = _validate_log_level(raw_log_level)
 
     calls_per_minute = _validate_positive_int(
         _parse_int(

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1936,6 +1936,7 @@ def attempt_login(username: str, password: str) -> None:
     default="stdio",
     help="Transport type (stdio or http)",
 )
+@click.option("--debug", is_flag=True, help="Enable DEBUG logging")
 @click.option(
     "--username", help="Robinhood username.", default=os.getenv("ROBINHOOD_USERNAME")
 )
@@ -1961,6 +1962,7 @@ def main(
     port: int,
     host: str,
     transport: str,
+    debug: bool,
     username: str | None,
     password: str | None,
     api_key: str | None,
@@ -1992,6 +1994,8 @@ def main(
 
     # Create MCP server
     config = load_config()
+    if debug:
+        config.log_level = "DEBUG"
     server = create_mcp_server(config)
 
     # Setup broker authentication (non-blocking)

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 import secrets
 import time
 from collections.abc import AsyncGenerator
@@ -124,6 +125,53 @@ READ_ONLY_HTTP_TOOL_NAMES = frozenset(
         "watchlist_performance",
     }
 )
+
+
+def _mcp_log_value(value: object) -> str:
+    if value is None:
+        return "null"
+    return str(value)
+
+
+def _log_mcp_request(method: object, request_id: object) -> None:
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "MCP request received method=%s request_id=%s",
+            _mcp_log_value(method),
+            _mcp_log_value(request_id),
+        )
+
+
+def _mcp_json_response(
+    response_data: dict[str, Any],
+    *,
+    status_code: int,
+    method: object,
+    request_id: object,
+    outcome: str,
+    error_code: int | None = None,
+    error_type: str | None = None,
+) -> Response:
+    content = json.dumps(response_data).encode()
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            (
+                "MCP response sent method=%s request_id=%s outcome=%s "
+                "status_code=%s error_code=%s error_type=%s response_bytes=%s"
+            ),
+            _mcp_log_value(method),
+            _mcp_log_value(request_id),
+            outcome,
+            status_code,
+            _mcp_log_value(error_code),
+            _mcp_log_value(error_type),
+            len(content),
+        )
+    return Response(
+        content=content,
+        status_code=status_code,
+        headers={"content-type": "application/json"},
+    )
 
 
 def is_loopback_host(host: str) -> bool:
@@ -488,41 +536,46 @@ def create_http_server(
             body = await request.body()
 
             if len(body) > MAX_MCP_REQUEST_BODY_SIZE:
-                return Response(
-                    content=json.dumps(
-                        {
-                            "jsonrpc": "2.0",
-                            "error": {
-                                "code": -32700,
-                                "message": "Request body too large",
-                            },
-                            "id": None,
-                        }
-                    ).encode(),
+                return _mcp_json_response(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32700,
+                            "message": "Request body too large",
+                        },
+                        "id": None,
+                    },
                     status_code=413,
-                    headers={"content-type": "application/json"},
+                    method=None,
+                    request_id=None,
+                    outcome="error",
+                    error_code=-32700,
+                    error_type="body_too_large",
                 )
 
             # Parse the JSON-RPC request
             try:
                 json_request = json.loads(body.decode())
             except json.JSONDecodeError:
-                return Response(
-                    content=json.dumps(
-                        {
-                            "jsonrpc": "2.0",
-                            "error": {"code": -32700, "message": "Parse error"},
-                            "id": None,
-                        }
-                    ).encode(),
+                return _mcp_json_response(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32700, "message": "Parse error"},
+                        "id": None,
+                    },
                     status_code=400,
-                    headers={"content-type": "application/json"},
+                    method=None,
+                    request_id=None,
+                    outcome="error",
+                    error_code=-32700,
+                    error_type="parse_error",
                 )
 
             # Handle different MCP methods
             method = json_request.get("method")
             request_id = json_request.get("id")
             params = json_request.get("params", {})
+            _log_mcp_request(method, request_id)
 
             try:
                 result: dict[str, Any]
@@ -566,41 +619,45 @@ def create_http_server(
                     arguments = params.get("arguments", {})
 
                     if not tool_name:
-                        return Response(
-                            content=json.dumps(
-                                {
-                                    "jsonrpc": "2.0",
-                                    "error": {
-                                        "code": -32602,
-                                        "message": "Invalid params: missing tool name",
-                                    },
-                                    "id": request_id,
-                                }
-                            ).encode(),
+                        return _mcp_json_response(
+                            {
+                                "jsonrpc": "2.0",
+                                "error": {
+                                    "code": -32602,
+                                    "message": "Invalid params: missing tool name",
+                                },
+                                "id": request_id,
+                            },
                             status_code=200,
-                            headers={"content-type": "application/json"},
+                            method=method,
+                            request_id=request_id,
+                            outcome="error",
+                            error_code=-32602,
+                            error_type="invalid_params",
                         )
 
                     if not _is_tool_allowed(tool_name):
                         logger.warning(
                             "Blocked MCP tool call in read-only mode: %s", tool_name
                         )
-                        return Response(
-                            content=json.dumps(
-                                {
-                                    "jsonrpc": "2.0",
-                                    "error": {
-                                        "code": -32600,
-                                        "message": (
-                                            "Tool is not allowed in read-only mode. "
-                                            "Enable --allow-trading to permit mutating tools."
-                                        ),
-                                    },
-                                    "id": request_id,
-                                }
-                            ).encode(),
+                        return _mcp_json_response(
+                            {
+                                "jsonrpc": "2.0",
+                                "error": {
+                                    "code": -32600,
+                                    "message": (
+                                        "Tool is not allowed in read-only mode. "
+                                        "Enable --allow-trading to permit mutating tools."
+                                    ),
+                                },
+                                "id": request_id,
+                            },
                             status_code=403,
-                            headers={"content-type": "application/json"},
+                            method=method,
+                            request_id=request_id,
+                            outcome="error",
+                            error_code=-32600,
+                            error_type="forbidden_tool",
                         )
 
                     # Record duration and success/failure for tool calls only.
@@ -670,31 +727,48 @@ def create_http_server(
                 elif method == "notifications/initialized":
                     # Handle initialization notification (no response needed for notifications)
                     logger.info("Client initialization notification received")
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            "MCP response sent method=%s request_id=%s outcome=%s "
+                            "status_code=%s error_code=%s error_type=%s "
+                            "response_bytes=%s",
+                            _mcp_log_value(method),
+                            _mcp_log_value(request_id),
+                            "success",
+                            200,
+                            "null",
+                            "null",
+                            0,
+                        )
                     return Response(status_code=200)
 
                 else:
-                    return Response(
-                        content=json.dumps(
-                            {
-                                "jsonrpc": "2.0",
-                                "error": {
-                                    "code": -32601,
-                                    "message": f"Method not found: {method}",
-                                },
-                                "id": request_id,
-                            }
-                        ).encode(),
+                    return _mcp_json_response(
+                        {
+                            "jsonrpc": "2.0",
+                            "error": {
+                                "code": -32601,
+                                "message": f"Method not found: {method}",
+                            },
+                            "id": request_id,
+                        },
                         status_code=200,
-                        headers={"content-type": "application/json"},
+                        method=method,
+                        request_id=request_id,
+                        outcome="error",
+                        error_code=-32601,
+                        error_type="method_not_found",
                     )
 
                 # Return successful response
                 response_data = {"jsonrpc": "2.0", "result": result, "id": request_id}
 
-                return Response(
-                    content=json.dumps(response_data).encode(),
+                return _mcp_json_response(
+                    response_data,
                     status_code=200,
-                    headers={"content-type": "application/json"},
+                    method=method,
+                    request_id=request_id,
+                    outcome="success",
                 )
 
             except Exception as e:
@@ -704,10 +778,14 @@ def create_http_server(
                     "error": {"code": -32603, "message": str(e)},
                     "id": request_id,
                 }
-                return Response(
-                    content=json.dumps(error_response).encode(),
+                return _mcp_json_response(
+                    error_response,
                     status_code=500,
-                    headers={"content-type": "application/json"},
+                    method=method,
+                    request_id=request_id,
+                    outcome="error",
+                    error_code=-32603,
+                    error_type=type(e).__name__,
                 )
 
         except Exception as e:
@@ -717,10 +795,14 @@ def create_http_server(
                 "error": {"code": -32603, "message": f"Internal error: {e!s}"},
                 "id": None,
             }
-            return Response(
-                content=json.dumps(error_response).encode(),
+            return _mcp_json_response(
+                error_response,
                 status_code=500,
-                headers={"content-type": "application/json"},
+                method=None,
+                request_id=None,
+                outcome="error",
+                error_code=-32603,
+                error_type=type(e).__name__,
             )
 
     # SSE endpoint for server-sent events

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -410,6 +411,61 @@ class TestMCPIntegration:
         response = await http_client.get("/mcp")
         # Should get a method not allowed or proper response, not 404
         assert response.status_code != 404
+
+    @pytest.mark.anyio
+    async def test_mcp_debug_logging_records_safe_request_response_metadata(
+        self, caplog: pytest.LogCaptureFixture, http_client: httpx.AsyncClient
+    ) -> None:
+        """DEBUG logs include request metadata without full sensitive payloads."""
+        caplog.set_level(logging.DEBUG, logger="open_stocks_mcp")
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "debug-1",
+            "method": "initialize",
+            "params": {
+                "password": "secret-password",
+                "token": "secret-token",
+                "account_number": "123456789",
+            },
+        }
+
+        response = await http_client.post("/mcp", json=payload)
+
+        assert response.status_code == 200
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert "MCP request" in messages
+        assert "MCP response" in messages
+        assert "method=initialize" in messages
+        assert "request_id=debug-1" in messages
+        assert "outcome=success" in messages
+        assert "status_code=200" in messages
+        assert "secret-password" not in messages
+        assert "secret-token" not in messages
+        assert "123456789" not in messages
+
+    @pytest.mark.anyio
+    async def test_mcp_debug_logging_records_error_status(
+        self, caplog: pytest.LogCaptureFixture, http_client: httpx.AsyncClient
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="open_stocks_mcp")
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 404,
+            "method": "unknown/method",
+            "params": {"password": "do-not-log"},
+        }
+
+        response = await http_client.post("/mcp", json=payload)
+
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == -32601
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert "method=unknown/method" in messages
+        assert "request_id=404" in messages
+        assert "outcome=error" in messages
+        assert "error_code=-32601" in messages
+        assert "error_type=method_not_found" in messages
+        assert "do-not-log" not in messages
 
     async def test_sse_endpoint(self, mcp_server: FastMCP) -> None:
         """Test SSE endpoint is registered."""

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -1,13 +1,16 @@
 """Tests for server app module."""
 
+import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from open_stocks_mcp.server.app import (
     attempt_login,
     create_mcp_server,
     health_check,
+    main,
     mcp,
     setup_brokers,
 )
@@ -371,3 +374,30 @@ async def test_setup_brokers_registers_schwab_when_enabled_and_configured() -> N
         await setup_brokers(None, None, config=config)
 
     mock_registry.register.assert_called_once()
+
+
+def test_main_debug_flag_passes_debug_config_to_server() -> None:
+    runner = CliRunner()
+    server = MagicMock()
+
+    async def noop(*_args: object) -> None:
+        return None
+
+    server.run_stdio_async.side_effect = noop
+
+    def fake_asyncio_run(awaitable: object) -> None:
+        if inspect.iscoroutine(awaitable):
+            awaitable.close()
+
+    with (
+        patch("open_stocks_mcp.server.app.create_mcp_server") as mock_create,
+        patch("open_stocks_mcp.server.app.setup_brokers", side_effect=noop),
+        patch("open_stocks_mcp.server.app.asyncio.run", side_effect=fake_asyncio_run),
+    ):
+        mock_create.return_value = server
+
+        result = runner.invoke(main, ["--debug", "--transport", "stdio"])
+
+    assert result.exit_code == 0
+    config = mock_create.call_args.args[0]
+    assert config.log_level == "DEBUG"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -98,6 +98,47 @@ feature_flags:
 
 @pytest.mark.unit
 @pytest.mark.journey_system
+@pytest.mark.parametrize("debug_value", ["1", "true", "TRUE", "yes", "on"])
+def test_debug_env_enables_debug_log_level(
+    monkeypatch: pytest.MonkeyPatch, debug_value: str
+) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.setenv("DEBUG", debug_value)
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.log_level == "DEBUG"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_log_level_env_takes_precedence_over_debug_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("LOG_LEVEL", "WARNING")
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.log_level == "WARNING"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+@pytest.mark.parametrize("debug_value", ["", "0", "false", "no", "off"])
+def test_false_debug_env_keeps_default_log_level(
+    monkeypatch: pytest.MonkeyPatch, debug_value: str
+) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.setenv("DEBUG", debug_value)
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.log_level == "INFO"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
 def test_missing_file_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in (
         "MCP_SERVER_NAME",

--- a/tests/unit/test_vscode_workspace.py
+++ b/tests/unit/test_vscode_workspace.py
@@ -1,0 +1,78 @@
+"""Tests for VS Code workspace configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+VSCODE = ROOT / ".vscode"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.unit
+def test_vscode_workspace_files_are_valid_json() -> None:
+    for filename in ("launch.json", "settings.json", "extensions.json"):
+        assert _load_json(VSCODE / filename)
+
+
+@pytest.mark.unit
+def test_vscode_launch_runs_http_server_with_debug_flag() -> None:
+    launch = _load_json(VSCODE / "launch.json")
+
+    config = next(
+        item
+        for item in launch["configurations"]
+        if item["name"] == "Run MCP server (HTTP)"
+    )
+
+    assert config["type"] == "python"
+    assert config["request"] == "launch"
+    assert config["module"] == "open_stocks_mcp.server.app"
+    assert config["console"] == "integratedTerminal"
+    assert config["env"]["PYTHONPATH"] == "${workspaceFolder}/src"
+    assert config["args"] == [
+        "--transport",
+        "http",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "3001",
+        "--debug",
+    ]
+
+
+@pytest.mark.unit
+def test_vscode_settings_configure_uv_python_ruff_pytest_and_mypy() -> None:
+    settings = _load_json(VSCODE / "settings.json")
+
+    assert (
+        settings["python.defaultInterpreterPath"]
+        == "${workspaceFolder}/.venv/bin/python"
+    )
+    assert settings["python.testing.pytestEnabled"] is True
+    assert settings["python.testing.unittestEnabled"] is False
+    assert settings["python.testing.pytestArgs"] == ["tests"]
+    assert settings["[python]"]["editor.defaultFormatter"] == "charliermarsh.ruff"
+    assert settings["ruff.lint.run"] == "onSave"
+    assert settings["mypy-type-checker.args"] == ["--config-file=pyproject.toml"]
+
+
+@pytest.mark.unit
+def test_vscode_extensions_recommend_python_pylance_ruff_and_mypy() -> None:
+    extensions = _load_json(VSCODE / "extensions.json")
+
+    recommendations = set(extensions["recommendations"])
+
+    assert {
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+    } <= recommendations


### PR DESCRIPTION
Closes #164

## Changes
- Add strict VS Code workspace validation plus launch/settings/extensions updates for HTTP debug runs on 127.0.0.1:3001.
- Wire DEBUG=true and --debug into ServerConfig/setup_logging.
- Add sanitized DEBUG metadata logs for HTTP MCP JSON-RPC requests and responses.
- Document the VS Code F5 and command-line debug workflows.

## Test plan
- uv run pytest tests/unit/test_vscode_workspace.py tests/unit/test_config.py tests/server/test_server_app.py tests/http_transport/test_http_server.py -q -k "vscode or debug or mcp_debug_logging"
- uv run python -m json.tool .vscode/launch.json >/dev/null && uv run python -m json.tool .vscode/settings.json >/dev/null && uv run python -m json.tool .vscode/extensions.json >/dev/null
- uv run ruff check src/open_stocks_mcp/config.py src/open_stocks_mcp/logging_config.py src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py tests/unit/test_config.py tests/server/test_server_app.py tests/http_transport/test_http_server.py tests/unit/test_vscode_workspace.py
- uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/logging_config.py src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py
- DEBUG=true uv run open-stocks-mcp-server --transport http --host 127.0.0.1 --port 3001 ... health check + initialize JSON-RPC smoke test
- uv run pytest tests/unit/test_vscode_workspace.py tests/unit/test_config.py tests/server/test_server_app.py tests/http_transport/test_http_server.py -q
- git diff --check