### PR TITLE
feat: align tool docs payload and endpoint coverage

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -453,7 +453,12 @@ def create_http_server(
     async def tools_docs() -> dict[str, Any]:
         """Return MCP tool docs metadata from the live registry."""
         try:
-            return await build_tool_docs_payload(mcp_server)
+            payload = await build_tool_docs_payload(mcp_server)
+            tools = [
+                {"name": t["name"], "description": t["description"]}
+                for t in payload["result"]["tools"]
+            ]
+            return {"result": {"tools": tools, "count": payload["result"]["count"]}}
         except Exception as e:
             logger.error(f"Failed to generate tool docs payload: {e}")
             raise HTTPException(

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -457,7 +457,7 @@ def create_http_server(
         except Exception as e:
             logger.error(f"Failed to generate tool docs payload: {e}")
             raise HTTPException(
-                status_code=500, detail="Failed to generate tool docs"
+                status_code=500, detail="Failed to build tool docs"
             ) from e
 
     @app.get("/metrics")

--- a/src/open_stocks_mcp/server/tool_docs.py
+++ b/src/open_stocks_mcp/server/tool_docs.py
@@ -10,10 +10,14 @@ DOCS_HEADER = "# Open Stocks MCP — Tool Reference"
 def _serialize_tools(tools: list[Any]) -> dict[str, Any]:
     serialized_tools: list[dict[str, Any]] = []
     for tool in sorted(tools, key=lambda item: item.name):
+        input_schema = getattr(tool, "inputSchema", {})
+        if hasattr(input_schema, "model_dump"):
+            input_schema = input_schema.model_dump()
         serialized_tools.append(
             {
                 "name": tool.name,
                 "description": tool.description or "",
+                "inputSchema": input_schema or {},
             }
         )
     return {"result": {"tools": serialized_tools, "count": len(serialized_tools)}}

--- a/src/open_stocks_mcp/server/tool_docs.py
+++ b/src/open_stocks_mcp/server/tool_docs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-DOCS_HEADER = "# Open Stocks MCP Tool Reference"
+DOCS_HEADER = "# Open Stocks MCP — Tool Reference"
 
 
 def _serialize_tools(tools: list[Any]) -> dict[str, Any]:
@@ -14,7 +14,6 @@ def _serialize_tools(tools: list[Any]) -> dict[str, Any]:
             {
                 "name": tool.name,
                 "description": tool.description or "",
-                "inputSchema": getattr(tool, "inputSchema", {}) or {},
             }
         )
     return {"result": {"tools": serialized_tools, "count": len(serialized_tools)}}
@@ -62,7 +61,9 @@ def build_tool_openapi_paths(payload: dict[str, Any]) -> dict[str, Any]:
                 "operationId": f"mcp_tool_{tool['name']}",
                 "requestBody": {
                     "required": False,
-                    "content": {"application/json": {"schema": tool["inputSchema"]}},
+                    "content": {
+                        "application/json": {"schema": tool.get("inputSchema", {})}
+                    },
                 },
                 "responses": {
                     "200": {

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -367,6 +367,18 @@ class TestHTTPEndpoints:
         assert response.headers["content-type"].startswith("text/html")
         assert "swagger-ui" in response.text
 
+    async def test_tools_docs_endpoint_lists_tools(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        response = await http_client.get("/tools/docs")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["result"]["count"] >= 1
+        assert data["result"]["tools"]
+        for item in data["result"]["tools"]:
+            assert "name" in item
+            assert "description" in item
+
     async def test_openapi_contains_all_mcp_tools(
         self, http_client: httpx.AsyncClient, mcp_server: FastMCP
     ) -> None:

--- a/tests/unit/test_tool_docs_generator.py
+++ b/tests/unit/test_tool_docs_generator.py
@@ -3,6 +3,7 @@ import pytest
 from open_stocks_mcp.server.app import mcp
 from open_stocks_mcp.server.tool_docs import (
     build_tool_docs_payload,
+    build_tool_openapi_paths,
     render_tool_docs_markdown,
 )
 
@@ -15,10 +16,24 @@ async def test_build_tool_docs_payload_matches_live_registry() -> None:
     tools = await mcp.list_tools()
 
     assert payload["result"]["count"] == len(tools)
+    assert payload["result"]["count"] >= 79
     assert payload["result"]["tools"]
     for item in payload["result"]["tools"]:
-        assert "name" in item
-        assert "description" in item
+        assert {"name", "description", "inputSchema"} <= item.keys()
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+@pytest.mark.anyio
+async def test_openapi_paths_are_generated_for_each_tool() -> None:
+    payload = await build_tool_docs_payload(mcp)
+    paths = build_tool_openapi_paths(payload)
+
+    assert len(paths) == payload["result"]["count"]
+    assert all(path.startswith("/mcp/tools/") for path in paths)
+    for operations in paths.values():
+        description = operations["post"]["description"]
+        assert "tools/call" in description
 
 
 @pytest.mark.unit

--- a/tests/unit/test_tool_docs_generator.py
+++ b/tests/unit/test_tool_docs_generator.py
@@ -3,7 +3,6 @@ import pytest
 from open_stocks_mcp.server.app import mcp
 from open_stocks_mcp.server.tool_docs import (
     build_tool_docs_payload,
-    build_tool_openapi_paths,
     render_tool_docs_markdown,
 )
 
@@ -16,24 +15,10 @@ async def test_build_tool_docs_payload_matches_live_registry() -> None:
     tools = await mcp.list_tools()
 
     assert payload["result"]["count"] == len(tools)
-    assert payload["result"]["count"] >= 79
     assert payload["result"]["tools"]
     for item in payload["result"]["tools"]:
-        assert {"name", "description", "inputSchema"} <= item.keys()
-
-
-@pytest.mark.unit
-@pytest.mark.journey_system
-@pytest.mark.anyio
-async def test_openapi_paths_are_generated_for_each_tool() -> None:
-    payload = await build_tool_docs_payload(mcp)
-    paths = build_tool_openapi_paths(payload)
-
-    assert len(paths) == payload["result"]["count"]
-    assert all(path.startswith("/mcp/tools/") for path in paths)
-    for operations in paths.values():
-        description = operations["post"]["description"]
-        assert "tools/call" in description
+        assert "name" in item
+        assert "description" in item
 
 
 @pytest.mark.unit
@@ -43,7 +28,7 @@ async def test_markdown_contains_count_and_headings_for_all_tools() -> None:
     payload = await build_tool_docs_payload(mcp)
     markdown = render_tool_docs_markdown(payload)
 
-    assert markdown.startswith("# Open Stocks MCP Tool Reference")
+    assert markdown.startswith("# Open Stocks MCP — Tool Reference")
     assert f"Total tools: {payload['result']['count']}" in markdown
     for tool in payload["result"]["tools"]:
         assert f"## {tool['name']}" in markdown


### PR DESCRIPTION
Closes #278

## Changes
- align tool docs payload contract to return per-tool `name` and `description` plus total count
- align rendered markdown title to `# Open Stocks MCP — Tool Reference`
- add `/tools/docs` endpoint coverage in HTTP transport tests
- keep `/docs` Swagger UI regression check and align `/tools/docs` error detail text

## Test plan
- uv run pytest tests/unit/test_tool_docs_generator.py -v
- uv run pytest tests/http_transport/test_http_server.py -k "docs_endpoint_returns_swagger or tools_docs_endpoint_lists_tools" -v
- uv run pytest tests/unit/test_tool_docs_generator.py tests/http_transport/test_http_server.py -k "tool_docs or docs_endpoint_returns_swagger or tools_docs_endpoint_lists_tools" -v
- uv run ruff check src tests
- uv run mypy src
