### PR TITLE
test: finalize http transport validation coverage

### DIFF
--- a/tests/integration/live_market_harness.py
+++ b/tests/integration/live_market_harness.py
@@ -65,7 +65,7 @@ def assert_live_market_read_only(tool_name: str) -> None:
 
 
 @pytest.fixture(scope="module")
-def live_robinhood_session(request: Any) -> Any:  # type: ignore[misc]
+def live_robinhood_session(request: Any) -> Any:
     """Module-scoped fixture that opens a real Robinhood session.
 
     Skips the test module when the live-market opt-in is absent or credentials

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -176,5 +176,5 @@ class TestHttpTransportUnit:
                 "Access-Control-Request-Headers": "content-type",
             },
         )
-        assert response.status_code == 200
-        assert "POST" in response.headers.get("access-control-allow-methods", "")
+        assert response.status_code in {200, 204}
+        assert "POST" in response.headers["access-control-allow-methods"]

--- a/tests/unit/test_rate_limited_marker.py
+++ b/tests/unit/test_rate_limited_marker.py
@@ -54,6 +54,13 @@ _PYTESTER_MODULE = dedent("""
 """)
 
 
+def _config_with_markexpr(markexpr: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        option=SimpleNamespace(markexpr=markexpr),
+        getoption=lambda name, default=False: default,
+    )
+
+
 class DummyItem:
     """Small pytest item double for marker hook tests."""
 
@@ -94,7 +101,7 @@ def test_rate_limited_tests_are_skipped_without_explicit_opt_in(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("RUN_RATE_LIMITED", raising=False)
-    config = SimpleNamespace(option=SimpleNamespace(markexpr="not slow"))
+    config = _config_with_markexpr("not slow")
     rate_limited_item = DummyItem({"rate_limited"})
     unmarked_item = DummyItem(set())
 
@@ -125,7 +132,7 @@ def test_rate_limited_tests_are_not_skipped_when_explicitly_selected(
     else:
         monkeypatch.setenv("RUN_RATE_LIMITED", run_rate_limited)
     item = DummyItem({"rate_limited"})
-    config = SimpleNamespace(option=SimpleNamespace(markexpr=markexpr))
+    config = _config_with_markexpr(markexpr)
 
     shared_conftest.pytest_collection_modifyitems(config, [item])
 


### PR DESCRIPTION
Closes #255

## Changes
- Align the `/mcp` CORS preflight unit assertion with the issue acceptance criteria by allowing either 200 or 204 and requiring the allow-methods header.
- Update the rate-limited marker hook test double so the required `unit and journey_system` validation path passes against the real hook contract.
- Remove a stale unused mypy ignore from the live-market fixture helper.

## Test plan
- `uv run pytest tests/unit/test_http_transport.py tests/unit/test_rate_limited_marker.py -v`
- `uv run pytest tests/unit/test_http_transport.py -v`
- `uv run pytest tests/unit/ -m "unit and journey_system" -v`
- `uv run ruff check tests/unit/test_http_transport.py tests/unit/test_rate_limited_marker.py tests/integration/live_market_harness.py`
- `uv run mypy tests/unit/test_http_transport.py`
- `uv run mypy tests/unit/test_http_transport.py tests/unit/test_rate_limited_marker.py`