### PR TITLE
test: enforce json-rpc invalid params message

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -624,7 +624,7 @@ def create_http_server(
                                 "jsonrpc": "2.0",
                                 "error": {
                                     "code": -32602,
-                                    "message": "Invalid params: missing tool name",
+                                    "message": "Invalid params: missing 'name'",
                                 },
                                 "id": request_id,
                             },

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -101,6 +101,7 @@ class TestHttpTransportUnit:
         assert response.status_code == 200
         body = response.json()
         assert body["error"]["code"] == -32602
+        assert body["error"]["message"] == "Invalid params: missing 'name'"
         assert "invalid params" in body["error"]["message"].lower()
         assert body["id"] == 8
 


### PR DESCRIPTION
Closes #254

## Changes
- Tighten the unit assertion for missing `tools/call` `name` params to require the exact JSON-RPC error message from the implementation plan.
- Update the /mcp `tools/call` invalid-params branch to return `Invalid params: missing 'name'` with code `-32602`.

## TDD red evidence
- `uv run pytest tests/unit/test_http_transport.py::TestHttpTransportUnit::test_mcp_tools_call_missing_name_returns_invalid_params_minus_32602 -v` failed before the source edit because the handler returned `Invalid params: missing tool name` instead of `Invalid params: missing 'name'`.

## Test plan
- `uv run pytest tests/unit/test_http_transport.py::TestHttpTransportUnit::test_mcp_unknown_method_returns_method_not_found_minus_32601 tests/unit/test_http_transport.py::TestHttpTransportUnit::test_mcp_tools_call_missing_name_returns_invalid_params_minus_32602 -v` — 2 passed
- `uv run pytest tests/unit/test_http_transport.py -v` — 12 passed
- `uv run ruff check src/open_stocks_mcp/server/http_transport.py tests/unit/test_http_transport.py` — passed
- `uv run mypy src/open_stocks_mcp/server/http_transport.py tests/unit/test_http_transport.py` — passed
- `uv run pytest tests/http_transport/ -v -m "not slow"` — interrupted after 298.20s with 53 passed / 4 skipped; it hung at the existing SSE stream accessibility test `tests/http_transport/test_http_integration.py::TestHTTPIntegration::test_mcp_endpoint_accessibility` before reaching this change's code path.
