### PR TITLE
docs: add explicit market eval commands

### DIFF
--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -337,6 +337,15 @@ Command pattern:
 adk eval examples/google_adk_agent tests/evals/2_mkt_stock_news_test.json --config_file_path tests/evals/test_config.json
 ```
 
+Issue #289 market-data additions:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/2_mkt_price_history_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_top_movers_sp500_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_top_100_stocks_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_top_movers_test.json --config_file_path tests/evals/test_config.json
+```
+
 ### 7. Creating Custom Evaluation Tests
 
 #### Test File Structure


### PR DESCRIPTION
Closes #289

## Changes
- added explicit `adk eval` commands for the four issue-289 market-data eval files in `tests/evals/ADK-testing-evals.md`
- verified the four targeted `2_mkt_*` eval JSON files already match the issue acceptance criteria and tool args

## Test plan
- `python -c "import json,glob; [json.load(open(p)) for p in glob.glob('tests/evals/2_mkt_*_test.json')]"` (fails in this environment: `python` not found)
- `python3 -c "import json,glob; [json.load(open(p)) for p in glob.glob('tests/evals/2_mkt_*_test.json')]"` (passes)
- `rg --files tests/evals | rg '2_mkt_.*_test\.json$'` (passes)
- `adk eval examples/google_adk_agent tests/evals/2_mkt_*_test.json --config_file_path tests/evals/test_config.json` (fails: MCP session/connectivity/runtime errors in current environment)
- `git diff --check` (passes)
