### PR TITLE
docs: add explicit 2_mkt eval run commands

### DIFF
--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -331,10 +331,13 @@ Files and tool coverage:
 - `tests/evals/2_mkt_schwab_price_history_test.json` - `schwab_price_history`
 - `tests/evals/2_mkt_schwab_search_instruments_test.json` - `schwab_search_instruments`
 
-Command pattern:
+Run with:
 
 ```bash
+adk eval examples/google_adk_agent tests/evals/2_mkt_stock_ratings_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_stock_earnings_test.json --config_file_path tests/evals/test_config.json
 adk eval examples/google_adk_agent tests/evals/2_mkt_stock_news_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/2_mkt_stock_splits_test.json --config_file_path tests/evals/test_config.json
 ```
 
 ### 7. Creating Custom Evaluation Tests


### PR DESCRIPTION
Closes #290

## Changes
- Added explicit `adk eval` commands for the four new read-only research/fundamentals market eval files in `tests/evals/ADK-testing-evals.md`.
- Kept changes scoped to documentation because the four target eval JSON files already existed and matched required prompts/tool args.
- Preserved the existing `2_mkt_*` file set (currently 15 files), noting the issue's fixed `len==12` assertion is stale in current repo state.

## Test plan
- `uv run python -m json.tool tests/evals/2_mkt_stock_ratings_test.json >/dev/null`
- `uv run python -m json.tool tests/evals/2_mkt_stock_earnings_test.json >/dev/null`
- `uv run python -m json.tool tests/evals/2_mkt_stock_news_test.json >/dev/null`
- `uv run python -m json.tool tests/evals/2_mkt_stock_splits_test.json >/dev/null`
- `uv run python -c "import json,glob; files=sorted(glob.glob('tests/evals/2_mkt_*_test.json')); print(f'count={len(files)}'); [json.load(open(p)) for p in files]"`
- `rg -l 'buy_|sell_|add_to_watchlist|remove_from_watchlist|order_' tests/evals/2_mkt_*_test.json`
- `adk eval examples/google_adk_agent tests/evals/2_mkt_stock_ratings_test.json tests/evals/2_mkt_stock_earnings_test.json tests/evals/2_mkt_stock_news_test.json tests/evals/2_mkt_stock_splits_test.json --config_file_path tests/evals/test_config.json` (fails in this environment: MCP session/connectivity/runtime error)
- `git diff --check`
