### PR TITLE
chore: cleanup (ruff, mypy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,4 @@ examples/kubernetes/secret.yaml
 .foreman/
 .agents/
 .beads/
+timelapse-runs/

--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,4 @@ examples/kubernetes/secret.yaml
 .agents/
 .beads/
 timelapse-runs/
+foreman.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -379,5 +379,3 @@ examples/kubernetes/secret.yaml
 .foreman/
 .agents/
 .beads/
-timelapse-runs/
-foreman.yaml

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 
 class ConfigError(ValueError):

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -242,4 +242,3 @@ async def test_alert_dedup_cleanup_avoids_memory_growth() -> None:
 
     # Map should be empty since 1s > 0.1s
     assert "test_signal" not in collector._last_alert_at
-


### PR DESCRIPTION
## Summary

Automated code-quality cleanup run:

- **ruff format**: Removed trailing newline in `tests/unit/test_monitoring.py` (1 file reformatted)
- **mypy fix**: Removed unused `type: ignore[import-untyped]` comment on `yaml` import in `src/open_stocks_mcp/config.py` (resolved 1 mypy error)
- **ruff check**: All checks passed (no lint violations found)

### Validation
- mypy: 0 errors across 58 source files
- pytest: 1041 tests (running)

### Files changed: 3
| File | Change |
|------|--------|
| `.gitignore` | Pre-existing modification (timelapse-runs/) |
| `src/open_stocks_mcp/config.py` | Removed unused `type: ignore` comment |
| `tests/unit/test_monitoring.py` | Removed trailing newline |