### PR TITLE
fix: register schwab_transactions MCP tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1449,6 +1449,7 @@ async def schwab_get_order(account_hash: str, order_id: str) -> dict[str, Any]:
     return await get_schwab_order_by_id(account_hash, order_id)
 
 
+@mcp.tool()
 async def schwab_transactions(
     account_hash: str,
     start_date: str | None = None,

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -226,6 +226,21 @@ class TestToolRegistration:
             assert tool_name in tool_names, f"Tool {tool_name} not registered"
 
     @pytest.mark.asyncio
+    async def test_schwab_transaction_tools_are_registered(self) -> None:
+        """Test that Schwab transaction tools are registered."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+
+        expected_tools = [
+            "schwab_transactions",
+            "schwab_transactions_by_date",
+            "schwab_get_transaction",
+        ]
+
+        for tool_name in expected_tools:
+            assert tool_name in tool_names, f"Tool {tool_name} not registered"
+
+    @pytest.mark.asyncio
     async def test_account_info_tool_callable(self) -> None:
         """Test that account_info tool is callable."""
         tools_list = await mcp.list_tools()


### PR DESCRIPTION
Closes #585

## Changes
- add missing @mcp.tool() decorator to schwab_transactions in server app
- add registration test asserting all three Schwab transaction tools are exposed

## Test plan
- uv run pytest tests/server/test_server_app.py -k transaction -v
- uv run ruff check src/open_stocks_mcp/server/app.py tests/server/test_server_app.py
- uv run mypy src/open_stocks_mcp/server/app.py
