### PR TITLE
docs: verify and close profiles ADK eval tranche

### DIFF
--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -318,15 +318,6 @@ adk eval examples/google_adk_agent tests/evals/4_ntf_account_features_test.json 
 ```
 
 
-Issue #289 market-data additions:
-
-```bash
-adk eval examples/google_adk_agent tests/evals/2_mkt_price_history_test.json --config_file_path tests/evals/test_config.json
-adk eval examples/google_adk_agent tests/evals/2_mkt_top_movers_sp500_test.json --config_file_path tests/evals/test_config.json
-adk eval examples/google_adk_agent tests/evals/2_mkt_top_100_stocks_test.json --config_file_path tests/evals/test_config.json
-adk eval examples/google_adk_agent tests/evals/2_mkt_top_movers_test.json --config_file_path tests/evals/test_config.json
-```
-
 ### 7. Creating Custom Evaluation Tests
 
 #### Test File Structure


### PR DESCRIPTION
Closes #317

## Changes
- All six `tests/evals/6_prf_*_test.json` files were already present on `main` and fully satisfy the issue acceptance criteria (JSON parse, correct schema, registered tool names, no mutating tools).
- Removed an orphaned `Issue #289 market-data additions:` block with duplicate `adk eval` commands from `tests/evals/ADK-testing-evals.md`; those commands are already covered under the Market & Research section.
- The `### 5. Profiles Tests` subsection with credential note and all six `adk eval` commands remains intact.

## Verification
- `uv run python -c "import json,sys; [json.load(open(p)) for p in sys.argv[1:]]" tests/evals/6_prf_*_test.json` → all 6 files parse OK
- `grep -n "async def \(account_profile\|basic_profile\|investment_profile\|security_profile\|user_profile\|complete_profile\)" src/open_stocks_mcp/server/app.py` → 6 matches confirmed
- `grep -lE '"(buy_|sell_|cancel_|add_to_watchlist|remove_from_watchlist)' tests/evals/6_prf_*_test.json` → no output (no mutating tools)
- `rg -n "Profiles Tests|ROBINHOOD_USERNAME|6_prf_.*_test\.json" tests/evals/ADK-testing-evals.md` → subsection, credential note, and all 6 file references present

## Test plan
- [ ] Confirm all six `6_prf_*_test.json` files parse as valid JSON
- [ ] Confirm the `Profiles Tests` subsection in `ADK-testing-evals.md` lists all six files with credential note and exact `adk eval` commands