### PR TITLE
feat: add schwab_find_tradable_options MCP tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -164,6 +164,9 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_options_positions,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
+    schwab_find_tradable_options as _schwab_find_tradable_options_impl,
+)
+from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_option_buy_to_open as _schwab_option_buy_to_open_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
@@ -1761,6 +1764,26 @@ async def schwab_option_sell_to_close(
     """Sell an option to close a position (Schwab)."""
     return await _schwab_option_sell_to_close_impl(
         account_hash, symbol, quantity, option_type, strike, expiration
+    )
+
+
+@mcp.tool()
+async def schwab_find_tradable_options(
+    symbol: str,
+    expiration_date: str | None = None,
+    option_type: str | None = None,
+    strike: float | None = None,
+) -> dict[str, Any]:
+    """Find tradable option contracts filtered by expiration, type, and strike.
+
+    Args:
+        symbol: Stock ticker symbol
+        expiration_date: Filter to contracts expiring on this date (YYYY-MM-DD)
+        option_type: 'call' or 'put'
+        strike: Strike price to filter on
+    """
+    return await _schwab_find_tradable_options_impl(
+        symbol, expiration_date, option_type, strike
     )
 
 

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -322,6 +322,100 @@ async def schwab_option_buy_to_open(
 
 
 @handle_schwab_errors
+async def schwab_find_tradable_options(
+    symbol: str,
+    expiration_date: str | None = None,
+    option_type: str | None = None,
+    strike: float | None = None,
+) -> dict[str, Any]:
+    """Find tradable option contracts filtered by expiration, type, and strike.
+
+    Args:
+        symbol: Stock ticker symbol
+        expiration_date: Filter to contracts expiring on this date (YYYY-MM-DD)
+        option_type: 'call' or 'put'
+        strike: Strike price to filter on
+
+    Returns:
+        Dict with matching options list, total_found count, and applied filters
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"find tradable options for {symbol}"
+    )
+    if error:
+        return error
+
+    try:
+        valid_option_types = {"call", "put"}
+        if option_type is not None and option_type.lower() not in valid_option_types:
+            return create_error_response(
+                ValueError(
+                    f"Invalid option_type '{option_type}'. Valid options: {sorted(valid_option_types)}"
+                )
+            )
+
+        # Map to Schwab SDK contract type enum so the API call is scoped when possible
+        contract_type_map = {
+            "call": Client.Options.ContractType.CALL,
+            "put": Client.Options.ContractType.PUT,
+        }
+        ct = contract_type_map.get(option_type.lower()) if option_type else None
+
+        expiry_dt = None
+        if expiration_date:
+            expiry_dt = date.fromisoformat(expiration_date)
+
+        def _get_option_chain() -> Any:
+            response = broker.client.get_option_chain(
+                symbol.upper(),
+                contract_type=ct,
+                from_date=expiry_dt,
+                to_date=expiry_dt,
+            )
+            return response.json()
+
+        chain_data = await execute_broker_request(_get_option_chain, retry_safe=True)
+
+        # Flatten callExpDateMap and putExpDateMap into a single list of contracts
+        options: list[dict[str, Any]] = []
+
+        maps_to_scan: list[tuple[str, dict[str, Any]]] = []
+        if option_type is None or option_type.lower() == "call":
+            maps_to_scan.append(("call", chain_data.get("callExpDateMap", {})))
+        if option_type is None or option_type.lower() == "put":
+            maps_to_scan.append(("put", chain_data.get("putExpDateMap", {})))
+
+        for _side, exp_map in maps_to_scan:
+            for exp_key, strikes_map in exp_map.items():
+                # Schwab keys may carry a DTE suffix: "YYYY-MM-DD:DTE"
+                exp_prefix = exp_key.split(":")[0]
+                if expiration_date and exp_prefix != expiration_date:
+                    continue
+
+                for strike_key, contracts in strikes_map.items():
+                    if strike is not None and float(strike_key) != strike:
+                        continue
+                    options.extend(contracts)
+
+        return create_success_response(
+            {
+                "options": options,
+                "total_found": len(options),
+                "filters": {
+                    "symbol": symbol.upper(),
+                    "expiration_date": expiration_date,
+                    "option_type": option_type,
+                    "strike": strike,
+                },
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error finding tradable options for {symbol}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
 async def schwab_option_sell_to_close(
     account_hash: str,
     symbol: str,

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -241,6 +241,13 @@ class TestToolRegistration:
             assert tool_name in tool_names, f"Tool {tool_name} not registered"
 
     @pytest.mark.asyncio
+    async def test_schwab_find_tradable_options_is_registered(self) -> None:
+        """Test that schwab_find_tradable_options is registered as an MCP tool."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+        assert "schwab_find_tradable_options" in tool_names
+
+    @pytest.mark.asyncio
     async def test_account_info_tool_callable(self) -> None:
         """Test that account_info tool is callable."""
         tools_list = await mcp.list_tools()

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -11,6 +11,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_chain_by_expiration,
     get_schwab_option_expirations,
     get_schwab_options_positions,
+    schwab_find_tradable_options,
     schwab_option_buy_to_open,
     schwab_option_sell_to_close,
 )
@@ -529,3 +530,88 @@ class TestSchwabOptionsTools:
                 "HASH", "AAPL", 1, "CALL", 150.0, "2026-06-19"
             )
             assert result == {"result": {"status": "order_placed"}}
+
+
+@pytest.mark.journey_options
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+async def test_find_tradable_options_filters_by_type_and_expiration(
+    mock_execute: AsyncMock,
+    mock_get_broker: AsyncMock,
+) -> None:
+    """Filtering by call type and expiration returns only matching contracts."""
+    mock_broker = MagicMock()
+    mock_get_broker.return_value = (mock_broker, None)
+
+    # Synthetic chain with calls and puts; only the AAPL_011924C170 call at 2024-01-19
+    # should survive the filter for option_type="call", expiration_date="2024-01-19",
+    # strike=170.0.  The put at the same expiration and the call at a different
+    # expiration must be excluded.
+    mock_execute.return_value = {
+        "callExpDateMap": {
+            "2024-01-19:30": {
+                "170.0": [
+                    {
+                        "putCall": "CALL",
+                        "symbol": "AAPL_011924C170",
+                        "bid": 6.50,
+                        "ask": 6.55,
+                        "strikePrice": 170.0,
+                    }
+                ]
+            },
+            "2024-02-16:48": {
+                "170.0": [
+                    {
+                        "putCall": "CALL",
+                        "symbol": "AAPL_021624C170",
+                        "bid": 8.00,
+                        "ask": 8.10,
+                        "strikePrice": 170.0,
+                    }
+                ]
+            },
+        },
+        "putExpDateMap": {
+            "2024-01-19:30": {
+                "170.0": [
+                    {
+                        "putCall": "PUT",
+                        "symbol": "AAPL_011924P170",
+                        "bid": 2.50,
+                        "ask": 2.55,
+                        "strikePrice": 170.0,
+                    }
+                ]
+            }
+        },
+    }
+
+    result = await schwab_find_tradable_options(
+        "AAPL", expiration_date="2024-01-19", option_type="call", strike=170.0
+    )
+
+    assert "result" in result
+    data = result["result"]
+    assert data["total_found"] == 1
+    assert len(data["options"]) == 1
+    assert data["options"][0]["symbol"] == "AAPL_011924C170"
+    assert data["filters"]["option_type"] == "call"
+    assert data["filters"]["expiration_date"] == "2024-01-19"
+    assert data["filters"]["strike"] == 170.0
+
+
+@pytest.mark.journey_options
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error")
+async def test_find_tradable_options_auth_error(mock_get_broker: AsyncMock) -> None:
+    """Auth error payload is returned unchanged."""
+    error_response = {"result": {"error": "Not authenticated", "status": "error"}}
+    mock_get_broker.return_value = (None, error_response)
+
+    result = await schwab_find_tradable_options("AAPL")
+
+    assert result == error_response


### PR DESCRIPTION
Closes #335

## Changes
- Implements `schwab_find_tradable_options(symbol, expiration_date, option_type, strike)` in `src/open_stocks_mcp/tools/schwab_options_tools.py` with `@handle_schwab_errors`, auth gating via `get_authenticated_broker_or_error`, and Schwab SDK calls routed through `execute_broker_request`
- Flattens `callExpDateMap` and `putExpDateMap`, prefix-matches expiration keys (handles `YYYY-MM-DD:DTE` Schwab format), and float-compares strike keys
- Validates `option_type` against `call`/`put`, returning a structured error for invalid values
- Registers `@mcp.tool()` wrapper `schwab_find_tradable_options` in `src/open_stocks_mcp/server/app.py`
- Adds `test_find_tradable_options_filters_by_type_and_expiration` and `test_find_tradable_options_auth_error` (both `journey_options`, `unit`, `asyncio`)
- Adds `test_schwab_find_tradable_options_is_registered` to server registration tests

## Test plan
- `uv run pytest tests/unit/test_schwab_options_tools.py -k find_tradable_options -x` — 2 passed
- `uv run pytest tests/server/test_server_app.py -k schwab_find_tradable_options -x` — 1 passed
- `uv run mypy src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/server/app.py` — zero errors
- `uv run ruff check ...` — all checks passed
- Full suite `tests/unit/test_schwab_options_tools.py tests/server/test_server_app.py` — 42 passed