### PR TITLE
feat: add schwab_option_positions_detailed with live quote enrichment

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -163,6 +163,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_chain,
     get_schwab_option_chain_by_expiration,
     get_schwab_option_expirations,
+    get_schwab_option_positions_detailed,
     get_schwab_options_positions,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
@@ -1737,6 +1738,16 @@ async def schwab_options_positions(account_hash: str) -> dict[str, Any]:
         account_hash: Account hash from schwab_account_numbers
     """
     return await get_schwab_options_positions(account_hash)
+
+
+@mcp.tool()
+async def schwab_option_positions_detailed(account_hash: str) -> dict[str, Any]:
+    """Get options positions enriched with live quote data (bid/ask/last/mark/greeks).
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+    """
+    return await get_schwab_option_positions_detailed(account_hash)
 
 
 @mcp.tool()

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -248,6 +248,137 @@ async def get_schwab_options_positions(account_hash: str) -> dict[str, Any]:
 
 
 @handle_schwab_errors
+async def get_schwab_option_positions_detailed(
+    account_hash: str,
+) -> dict[str, Any]:
+    """Get options positions enriched with live quote data from option chains.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+
+    Returns:
+        Dict with enriched options positions including bid/ask/last/mark/greeks
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get detailed option positions for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_account() -> Any:
+            response = broker.client.get_account(
+                account_hash, fields=Client.Account.Fields.POSITIONS
+            )
+            return response.json()
+
+        account_data = await execute_broker_request(_get_account, retry_safe=True)
+
+        securities_account = account_data.get("securitiesAccount", {})
+        all_positions = securities_account.get("positions", [])
+
+        option_positions = [
+            p
+            for p in all_positions
+            if p.get("instrument", {}).get("assetType") == "OPTION"
+        ]
+
+        if not option_positions:
+            return create_success_response(
+                {"positions": [], "count": 0, "enrichment_success_rate": "0%"}
+            )
+
+        underlyings = {
+            p["instrument"]["underlyingSymbol"]
+            for p in option_positions
+            if p.get("instrument", {}).get("underlyingSymbol")
+        }
+
+        chain_cache: dict[str, Any] = {}
+        for underlying in underlyings:
+            try:
+
+                def _get_chain(sym: str = underlying) -> Any:
+                    response = broker.client.get_option_chain(
+                        sym.upper(), include_underlying_quote=False
+                    )
+                    return response.json()
+
+                chain_cache[underlying] = await execute_broker_request(
+                    _get_chain, retry_safe=True
+                )
+            except Exception:
+                logger.warning(f"Failed to fetch option chain for {underlying}")
+
+        enriched: list[dict[str, Any]] = []
+        enriched_count = 0
+
+        for position in option_positions:
+            instrument = position.get("instrument", {})
+            pos_symbol = instrument.get("symbol", "")
+            underlying = instrument.get("underlyingSymbol", "")
+            put_call = instrument.get("putCall", "")
+
+            pos_dict: dict[str, Any] = {
+                "symbol": pos_symbol,
+                "underlying_symbol": underlying,
+                "option_type": put_call,
+                "strike_price": instrument.get("strikePrice"),
+                "expiration_date": instrument.get("expirationDate"),
+                "quantity": position.get("longQuantity", 0)
+                + position.get("shortQuantity", 0),
+                "average_price": position.get("averagePrice"),
+                "market_value": position.get("marketValue"),
+                "current_day_pl": position.get("currentDayProfitLoss"),
+                "quote": None,
+            }
+
+            chain = chain_cache.get(underlying)
+            if chain:
+                exp_map_key = (
+                    "callExpDateMap" if put_call == "CALL" else "putExpDateMap"
+                )
+                exp_map = chain.get(exp_map_key, {})
+                matched = False
+                for _exp_date, strikes in exp_map.items():
+                    for _strike, contracts in strikes.items():
+                        for contract in contracts:
+                            if contract.get("symbol") == pos_symbol:
+                                pos_dict["quote"] = {
+                                    "bid": contract.get("bid"),
+                                    "ask": contract.get("ask"),
+                                    "last": contract.get("last"),
+                                    "mark": contract.get("mark"),
+                                    "greeks": contract.get("greeks"),
+                                }
+                                enriched_count += 1
+                                matched = True
+                                break
+                        if matched:
+                            break
+                    if matched:
+                        break
+
+            enriched.append(pos_dict)
+
+        total = len(enriched)
+        rate = f"{round(enriched_count / total * 100)}%" if total > 0 else "0%"
+
+        return create_success_response(
+            {
+                "positions": enriched,
+                "count": total,
+                "enrichment_success_rate": rate,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab detailed option positions: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
 async def schwab_option_buy_to_open(
     account_hash: str,
     symbol: str,

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -10,6 +10,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_chain,
     get_schwab_option_chain_by_expiration,
     get_schwab_option_expirations,
+    get_schwab_option_positions_detailed,
     get_schwab_options_positions,
     schwab_find_tradable_options,
     schwab_option_buy_to_open,
@@ -530,6 +531,119 @@ class TestSchwabOptionsTools:
                 "HASH", "AAPL", 1, "CALL", 150.0, "2026-06-19"
             )
             assert result == {"result": {"status": "order_placed"}}
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_positions_detailed_no_positions(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+        mock_execute.return_value = {"securitiesAccount": {"positions": []}}
+
+        result = await get_schwab_option_positions_detailed("abc123")
+
+        assert result["result"]["positions"] == []
+        assert result["result"]["count"] == 0
+        assert result["result"]["enrichment_success_rate"] == "0%"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_positions_detailed_enriches_with_quote(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Account.Fields.POSITIONS = "positions"
+
+        positions_response = {
+            "securitiesAccount": {
+                "positions": [
+                    {
+                        "shortQuantity": 0.0,
+                        "averagePrice": 6.50,
+                        "currentDayProfitLoss": 50.0,
+                        "longQuantity": 1.0,
+                        "instrument": {
+                            "assetType": "OPTION",
+                            "symbol": "AAPL  240119C00170000",
+                            "underlyingSymbol": "AAPL",
+                            "putCall": "CALL",
+                            "strikePrice": 170.0,
+                            "expirationDate": "2024-01-19",
+                        },
+                        "marketValue": 700.0,
+                    },
+                    {
+                        "shortQuantity": 0.0,
+                        "averagePrice": 150.0,
+                        "longQuantity": 10.0,
+                        "instrument": {
+                            "assetType": "EQUITY",
+                            "symbol": "AAPL",
+                        },
+                        "marketValue": 1750.0,
+                    },
+                ]
+            }
+        }
+
+        chain_response = {
+            "status": "SUCCESS",
+            "symbol": "AAPL",
+            "callExpDateMap": {
+                "2024-01-19:5": {
+                    "170.0": [
+                        {
+                            "symbol": "AAPL  240119C00170000",
+                            "bid": 6.50,
+                            "ask": 6.55,
+                            "last": 6.52,
+                            "mark": 6.525,
+                            "greeks": {
+                                "delta": 0.65,
+                                "gamma": 0.03,
+                                "theta": -0.05,
+                                "vega": 0.12,
+                            },
+                        }
+                    ]
+                }
+            },
+            "putExpDateMap": {},
+        }
+
+        mock_execute.side_effect = [positions_response, chain_response]
+
+        result = await get_schwab_option_positions_detailed("abc123")
+
+        assert result["result"]["count"] == 1
+        assert result["result"]["enrichment_success_rate"] == "100%"
+        pos = result["result"]["positions"][0]
+        assert pos["quote"]["bid"] == 6.50
+        assert pos["quote"]["ask"] == 6.55
+        assert pos["quote"]["last"] == 6.52
+        assert pos["quote"]["mark"] == 6.525
+        assert pos["quote"]["greeks"]["delta"] == 0.65
 
 
 @pytest.mark.journey_options


### PR DESCRIPTION
Closes #336

## Changes
- Implement `get_schwab_option_positions_detailed(account_hash)` in `schwab_options_tools.py` that enriches open option positions with live bid/ask/last/mark/greeks from option chains
- Deduplicates underlying-symbol chain fetches to avoid N+1 chattiness
- Returns `{positions, count, enrichment_success_rate}` with graceful degradation when chain lookups fail
- Register as `@mcp.tool()` `schwab_option_positions_detailed` in `app.py`
- Add two unit tests: empty positions path and enrichment with quote data

## Test plan
- `uv run pytest tests/unit/test_schwab_options_tools.py -k option_positions_detailed -x` — 2 new tests pass
- `uv run pytest tests/unit/test_schwab_options_tools.py -q` — all 22 tests pass (no regressions)
- `uv run mypy src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/server/app.py` — zero errors
- `uv run ruff check` and `ruff format` — clean