### PR TITLE
feat: implement schwab_get_option_quote end-to-end vertical slice (#337)

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -163,6 +163,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_expirations,
     get_schwab_option_positions_detailed,
     get_schwab_options_positions,
+    schwab_get_option_quote,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
@@ -1681,6 +1682,21 @@ async def schwab_replace_order(
 
 
 # Schwab Options Tools
+@mcp.tool()
+async def schwab_option_quote(
+    symbol: str, expiration_date: str, strike: float, option_type: str
+) -> dict[str, Any]:
+    """Get a single option contract quote for a Schwab symbol.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., 'AAPL')
+        expiration_date: Expiration date in YYYY-MM-DD format
+        strike: Strike price
+        option_type: 'CALL' or 'PUT'
+    """
+    return await schwab_get_option_quote(symbol, expiration_date, strike, option_type)
+
+
 @mcp.tool()
 async def schwab_option_chain(
     symbol: str,

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -41,6 +41,99 @@ def _has_option_leg(order: dict[str, Any]) -> bool:
 
 
 @handle_schwab_errors
+async def schwab_get_option_quote(
+    symbol: str,
+    expiration_date: str,
+    strike: float,
+    option_type: str,
+) -> dict[str, Any]:
+    """Get a single option contract quote.
+
+    Args:
+        symbol: Stock ticker symbol
+        expiration_date: Expiration date (YYYY-MM-DD)
+        strike: Strike price
+        option_type: 'CALL' or 'PUT'
+
+    Returns:
+        Dict with option contract data
+    """
+    ot_upper = option_type.upper()
+    if ot_upper not in ("CALL", "PUT"):
+        return create_error_response(
+            ValueError(
+                f"Invalid option_type: {ot_upper}. Must be 'CALL' or 'PUT' for {symbol.upper()} {expiration_date} {strike:.1f}"
+            )
+        )
+
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get option quote for {symbol}"
+    )
+    if error:
+        return error
+
+    try:
+        contract_type = (
+            Client.Options.ContractType.CALL
+            if ot_upper == "CALL"
+            else Client.Options.ContractType.PUT
+        )
+
+        def _get_option_chain() -> Any:
+            response = broker.client.get_option_chain(
+                symbol.upper(),
+                contract_type=contract_type,
+                include_underlying_quote=False,
+            )
+            return response.json()
+
+        chain_data = await execute_broker_request(_get_option_chain, retry_safe=True)
+
+        # Select the correct map based on option type
+        exp_map_key = "callExpDateMap" if ot_upper == "CALL" else "putExpDateMap"
+        exp_map = chain_data.get(exp_map_key, {})
+
+        # Expiration lookup (prefix match for YYYY-MM-DD:N)
+        target_exp_key = None
+        for key in exp_map:
+            if key.startswith(expiration_date):
+                target_exp_key = key
+                break
+
+        if not target_exp_key:
+            return create_error_response(
+                ValueError(
+                    f"Option contract not found for {symbol.upper()} {expiration_date} {strike:.1f} {ot_upper} (Expiration not found)"
+                )
+            )
+
+        # Strike lookup (string form "170.0")
+        strike_map = exp_map[target_exp_key]
+        strike_key = f"{strike:.1f}"
+
+        if strike_key not in strike_map:
+            return create_error_response(
+                ValueError(
+                    f"Option contract not found for {symbol.upper()} {expiration_date} {strike_key} {ot_upper} (Strike not found)"
+                )
+            )
+
+        contracts = strike_map[strike_key]
+        if not contracts:
+            return create_error_response(
+                ValueError(
+                    f"Option contract not found for {symbol.upper()} {expiration_date} {strike_key} {ot_upper} (Empty contract list)"
+                )
+            )
+
+        return create_success_response(contracts[0])
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab option quote for {symbol}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
 async def get_schwab_option_chain(
     symbol: str,
     contract_type: str | None = None,

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -58,11 +58,11 @@ async def schwab_get_option_quote(
     Returns:
         Dict with option contract data
     """
-    ot_upper = option_type.upper()
+    ot_upper = option_type.strip().upper()
     if ot_upper not in ("CALL", "PUT"):
         return create_error_response(
             ValueError(
-                f"Invalid option_type: {ot_upper}. Must be 'CALL' or 'PUT' for {symbol.upper()} {expiration_date} {strike:.1f}"
+                f"Invalid option_type: '{option_type}'. Must be 'CALL' or 'PUT' (case-insensitive)."
             )
         )
 
@@ -109,20 +109,36 @@ async def schwab_get_option_quote(
 
         # Strike lookup (string form "170.0")
         strike_map = exp_map[target_exp_key]
-        strike_key = f"{strike:.1f}"
+        
+        # Flexible strike lookup: try string formats first, then float comparison
+        target_strike_key = None
+        for k in (f"{strike:.1f}", f"{strike:.2f}", str(int(strike)) if strike == int(strike) else str(strike)):
+            if k in strike_map:
+                target_strike_key = k
+                break
+        
+        if not target_strike_key:
+            # Fallback: iterate and compare as floats
+            for k in strike_map:
+                try:
+                    if abs(float(k) - strike) < 0.001:
+                        target_strike_key = k
+                        break
+                except ValueError:
+                    continue
 
-        if strike_key not in strike_map:
+        if not target_strike_key:
             return create_error_response(
                 ValueError(
-                    f"Option contract not found for {symbol.upper()} {expiration_date} {strike_key} {ot_upper} (Strike not found)"
+                    f"Option contract not found for {symbol.upper()} {expiration_date} {strike} {ot_upper} (Strike not found)"
                 )
             )
 
-        contracts = strike_map[strike_key]
+        contracts = strike_map[target_strike_key]
         if not contracts:
             return create_error_response(
                 ValueError(
-                    f"Option contract not found for {symbol.upper()} {expiration_date} {strike_key} {ot_upper} (Empty contract list)"
+                    f"Option contract not found for {symbol.upper()} {expiration_date} {target_strike_key} {ot_upper} (Empty contract list)"
                 )
             )
 

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -144,6 +144,13 @@ class TestToolRegistration:
     """Test that all tools are properly registered."""
 
     @pytest.mark.asyncio
+    async def test_schwab_option_quote_tool_is_registered(self) -> None:
+        """Test that the schwab_option_quote tool is registered."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+        assert "schwab_option_quote" in tool_names
+
+    @pytest.mark.asyncio
     async def test_tools_are_registered(self) -> None:
         """Test that all expected tools are registered on the mcp server."""
         # Get the list of registered tools via list_tools method

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -195,6 +195,17 @@ class TestSchwabOptionsTools:
     @pytest.mark.journey_options
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_get_option_quote_invalid_type(self) -> None:
+        """Test option quote with invalid option type."""
+        result = await schwab_get_option_quote("AAPL", "2024-01-19", 170.0, "INVALID")
+
+        assert result["result"]["status"] == "error"
+        assert "Invalid option_type" in result["result"]["error"]
+        assert "INVALID" in result["result"]["error"]
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     @patch(
         "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
     )

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -14,6 +14,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_options_positions,
     schwab_find_tradable_options,
     schwab_get_open_option_orders,
+    schwab_get_option_quote,
     schwab_option_buy_to_open,
     schwab_option_sell_to_close,
 )
@@ -105,6 +106,91 @@ async def test_schwab_option_order_wrappers_preserve_auth_error_response() -> No
 
 class TestSchwabOptionsTools:
     """Test Schwab options tools with mocked responses."""
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_quote_returns_contract(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test successful option quote retrieval."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_client.Options.ContractType.CALL = "CALL"
+
+        # Mock chain response
+        mock_execute.return_value = {
+            "symbol": "AAPL",
+            "status": "SUCCESS",
+            "callExpDateMap": {
+                "2024-01-19:7": {
+                    "170.0": [
+                        {
+                            "putCall": "CALL",
+                            "symbol": "AAPL  240119C00170000",
+                            "bid": 6.5,
+                            "ask": 6.55,
+                            "last": 6.52,
+                            "delta": 0.54,
+                            "gamma": 0.03,
+                            "theta": -0.08,
+                            "vega": 0.12,
+                            "volatility": 0.22,
+                            "openInterest": 1234,
+                            "totalVolume": 56,
+                        }
+                    ]
+                }
+            },
+        }
+
+        result = await schwab_get_option_quote("AAPL", "2024-01-19", 170.0, "CALL")
+
+        assert "result" in result
+        assert result["result"]["bid"] == 6.5
+        assert result["result"]["ask"] == 6.55
+        assert result["result"]["putCall"] == "CALL"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_quote_not_found(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Test option quote when contract is not found."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+
+        mock_client.Options.ContractType.CALL = "CALL"
+
+        # Empty chain
+        mock_execute.return_value = {
+            "symbol": "AAPL",
+            "status": "SUCCESS",
+            "callExpDateMap": {},
+        }
+
+        result = await schwab_get_option_quote("AAPL", "2024-01-19", 170.0, "CALL")
+
+        assert result["result"]["status"] == "error"
+        assert "not found" in result["result"]["error"]
 
     @pytest.mark.journey_options
     @pytest.mark.unit


### PR DESCRIPTION
Closes #337

## Changes
- Implemented schwab_get_option_quote in schwab_options_tools.py.
- Registered schwab_option_quote MCP tool in app.py.
- Added unit tests for schwab_get_option_quote.
- Added tool registration test.

## Test plan
- Run unit tests: uv run pytest tests/unit/test_schwab_options_tools.py -k option_quote
- Run registration test: uv run pytest tests/server/test_server_app.py::TestToolRegistration::test_schwab_option_quote_tool_is_registered