### PR TITLE
feat: add schwab_get_option_orders tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -168,6 +168,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
+    schwab_get_option_orders as _schwab_get_option_orders_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_option_buy_to_open as _schwab_option_buy_to_open_impl,
@@ -1748,6 +1749,22 @@ async def schwab_option_positions_detailed(account_hash: str) -> dict[str, Any]:
         account_hash: Account hash from schwab_account_numbers
     """
     return await get_schwab_option_positions_detailed(account_hash)
+
+
+@mcp.tool()
+async def schwab_option_orders(
+    account_hash: str,
+    max_results: int = 50,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """Get option orders for an account, filtered to OPTION legs only.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        max_results: Maximum number of orders to retrieve
+        status: Optional status filter (FILLED, WORKING, CANCELED, etc.)
+    """
+    return await _schwab_get_option_orders_impl(account_hash, max_results, status)
 
 
 @mcp.tool()

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -379,6 +379,62 @@ async def get_schwab_option_positions_detailed(
 
 
 @handle_schwab_errors
+async def schwab_get_option_orders(
+    account_hash: str,
+    max_results: int = 50,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """Get option orders for an account, filtered to OPTION legs only.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum number of orders to retrieve
+        status: Optional status filter (e.g. 'FILLED', 'WORKING', 'CANCELED')
+
+    Returns:
+        Dict with filtered option orders and count
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get option orders for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_orders() -> Any:
+            response = broker.client.get_orders_for_account(
+                account_hash, max_results=max_results
+            )
+            return response.json()
+
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
+
+        if not isinstance(orders_data, list):
+            orders_data = []
+
+        filtered = []
+        for order in orders_data:
+            legs = order.get("orderLegCollection", [])
+            has_option_leg = any(
+                leg.get("orderLegType") == "OPTION"
+                or leg.get("instrument", {}).get("assetType") == "OPTION"
+                for leg in legs
+            )
+            if not has_option_leg:
+                continue
+            if status is not None and order.get("status") != status:
+                continue
+            filtered.append(order)
+
+        return create_success_response({"orders": filtered, "count": len(filtered)})
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab option orders for {account_hash}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
 async def schwab_option_buy_to_open(
     account_hash: str,
     symbol: str,

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -13,6 +13,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_positions_detailed,
     get_schwab_options_positions,
     schwab_find_tradable_options,
+    schwab_get_option_orders,
     schwab_option_buy_to_open,
     schwab_option_sell_to_close,
 )
@@ -646,6 +647,7 @@ class TestSchwabOptionsTools:
         assert pos["quote"]["greeks"]["delta"] == 0.65
 
 
+
 @pytest.mark.journey_options
 @pytest.mark.unit
 @pytest.mark.asyncio
@@ -729,3 +731,72 @@ async def test_find_tradable_options_auth_error(mock_get_broker: AsyncMock) -> N
     result = await schwab_find_tradable_options("AAPL")
 
     assert result == error_response
+
+
+@pytest.mark.journey_options
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+async def test_get_option_orders_filters_option_legs(
+    mock_execute: AsyncMock,
+    mock_get_broker: AsyncMock,
+) -> None:
+    """OPTION-legged orders included, EQUITY-legged excluded."""
+    mock_get_broker.return_value = (MagicMock(), None)
+    mock_execute.return_value = [
+        {
+            "orderId": "opt-1",
+            "status": "FILLED",
+            "orderLegCollection": [
+                {"orderLegType": "OPTION", "instrument": {"assetType": "OPTION"}},
+            ],
+        },
+        {
+            "orderId": "eq-1",
+            "status": "FILLED",
+            "orderLegCollection": [
+                {"orderLegType": "EQUITY", "instrument": {"assetType": "EQUITY"}},
+            ],
+        },
+    ]
+
+    result = await schwab_get_option_orders("acct-hash")
+
+    assert result["result"]["count"] == 1
+    assert result["result"]["orders"][0]["orderId"] == "opt-1"
+
+
+@pytest.mark.journey_options
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+async def test_get_option_orders_status_filter(
+    mock_execute: AsyncMock,
+    mock_get_broker: AsyncMock,
+) -> None:
+    """status='FILLED' excludes WORKING option orders."""
+    mock_get_broker.return_value = (MagicMock(), None)
+    mock_execute.return_value = [
+        {
+            "orderId": "filled-1",
+            "status": "FILLED",
+            "orderLegCollection": [
+                {"orderLegType": "OPTION", "instrument": {"assetType": "OPTION"}},
+            ],
+        },
+        {
+            "orderId": "working-1",
+            "status": "WORKING",
+            "orderLegCollection": [
+                {"instrument": {"assetType": "OPTION"}},
+            ],
+        },
+    ]
+
+    result = await schwab_get_option_orders("acct-hash", status="FILLED")
+
+    assert result["result"]["count"] == 1
+    assert result["result"]["orders"][0]["orderId"] == "filled-1"
+    assert result["result"]["orders"][0]["status"] == "FILLED"


### PR DESCRIPTION
Closes #339

## Changes
- Implement `schwab_get_option_orders(account_hash, max_results, status)` in `schwab_options_tools.py` with `@handle_schwab_errors`, auth gating, and `execute_broker_request` wrapping
- Filter orders by checking both `orderLegType == "OPTION"` and `instrument.assetType == "OPTION"` to handle both Schwab API shapes
- Optional `status` parameter for filtering by order status (FILLED, WORKING, CANCELED, etc.)
- Returns `{"orders": [...], "count": N}` via `create_success_response`
- Register as `schwab_option_orders` MCP tool in `app.py`
- Add two unit tests: `test_get_option_orders_filters_option_legs` and `test_get_option_orders_status_filter`

## Test plan
- `uv run pytest tests/unit/test_schwab_options_tools.py -k get_option_orders -x` — 2 passed
- `uv run pytest tests/unit/test_schwab_options_tools.py -m "journey_options" -q` — 20 passed, no regressions
- `uv run mypy src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/server/app.py` — zero errors
- `uv run ruff check` — all checks passed