### PR TITLE
feat: add schwab_get_dividends_by_symbol tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -174,6 +174,9 @@ from open_stocks_mcp.tools.schwab_options_tools import (
 from open_stocks_mcp.tools.schwab_payment_tools import (
     schwab_get_dividends as _schwab_get_dividends_impl,
 )
+from open_stocks_mcp.tools.schwab_payment_tools import (
+    schwab_get_dividends_by_symbol as _schwab_get_dividends_by_symbol_impl,
+)
 from open_stocks_mcp.tools.schwab_portfolio_tools import (
     get_schwab_aggregate_positions,
     get_schwab_all_option_positions,
@@ -1506,6 +1509,26 @@ async def schwab_get_dividends(
         end_date: Optional end date (YYYY-MM-DD)
     """
     return await _schwab_get_dividends_impl(account_hash, start_date, end_date)
+
+
+@mcp.tool()
+async def schwab_get_dividends_by_symbol(
+    account_hash: str,
+    symbol: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> dict[str, Any]:
+    """Get dividend payments for a specific symbol in a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Stock symbol to filter dividends by (case-insensitive)
+        start_date: Optional start date (YYYY-MM-DD)
+        end_date: Optional end date (YYYY-MM-DD)
+    """
+    return await _schwab_get_dividends_by_symbol_impl(
+        account_hash, symbol, start_date, end_date
+    )
 
 
 @mcp.tool()

--- a/src/open_stocks_mcp/tools/schwab_payment_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_payment_tools.py
@@ -108,3 +108,76 @@ async def schwab_get_dividends(
     except Exception as e:
         logger.error(f"Error getting Schwab dividends for {account_hash}: {e}")
         return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_dividends_by_symbol(
+    account_hash: str,
+    symbol: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> dict[str, Any]:
+    """Get dividend payments for a specific symbol in a Schwab account.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        symbol: Stock symbol to filter dividends by (case-insensitive)
+        start_date: Optional start date (YYYY-MM-DD)
+        end_date: Optional end date (YYYY-MM-DD)
+
+    Returns:
+        Dict with list of dividends, total amount, and symbol
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get dividends for {symbol} in {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+        normalized_symbol = symbol.upper()
+
+        parsed_start_date = (
+            datetime.date.fromisoformat(start_date) if start_date is not None else None
+        )
+        parsed_end_date = (
+            datetime.date.fromisoformat(end_date) if end_date is not None else None
+        )
+
+        response = await asyncio.to_thread(
+            broker.client.get_transactions,
+            account_hash,
+            start_date=parsed_start_date,
+            end_date=parsed_end_date,
+            transaction_types=["DIVIDEND_OR_INTEREST"],
+            symbol=normalized_symbol,
+        )
+
+        transactions = response.json() if hasattr(response, "json") else response
+
+        if not isinstance(transactions, list):
+            transactions = []
+
+        dividends = []
+        total_amount = Decimal("0.00")
+
+        for tx in transactions:
+            if _classify_transaction(tx) == "dividend":
+                dividends.append(tx)
+                net_amount = tx.get("netAmount", 0)
+                total_amount += Decimal(str(net_amount))
+
+        return create_success_response(
+            {
+                "symbol": normalized_symbol,
+                "dividends": dividends,
+                "total_amount": str(total_amount.quantize(Decimal("0.01"))),
+                "count": len(dividends),
+            }
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Error getting Schwab dividends for {symbol} in {account_hash}: {e}"
+        )
+        return create_error_response(e)

--- a/tests/unit/test_schwab_payment_tools.py
+++ b/tests/unit/test_schwab_payment_tools.py
@@ -6,6 +6,7 @@ import pytest
 from open_stocks_mcp.tools.schwab_payment_tools import (
     _classify_transaction,
     schwab_get_dividends,
+    schwab_get_dividends_by_symbol,
 )
 
 
@@ -137,3 +138,83 @@ async def test_schwab_get_dividends_auth_error(mock_to_thread, mock_get_broker):
     assert result["result"]["status"] == "error"
     assert result["result"]["error"] == "Auth failed"
     mock_to_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_by_symbol_passes_symbol_to_client(
+    mock_to_thread, mock_get_broker
+):
+    broker = MagicMock()
+    mock_get_broker.return_value = (broker, None)
+    mock_to_thread.return_value = []
+
+    await schwab_get_dividends_by_symbol("abc123", "AAPL")
+
+    mock_to_thread.assert_called_once()
+    _, kwargs = mock_to_thread.call_args
+    assert kwargs["symbol"] == "AAPL"
+    assert kwargs["transaction_types"] == ["DIVIDEND_OR_INTEREST"]
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_by_symbol_returns_symbol_in_result(
+    mock_to_thread, mock_get_broker
+):
+    broker = MagicMock()
+    mock_get_broker.return_value = (broker, None)
+    mock_to_thread.return_value = []
+
+    result = await schwab_get_dividends_by_symbol("abc123", "AAPL")
+
+    assert result["result"]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_by_symbol_filters_classification_to_dividend_only(
+    mock_to_thread, mock_get_broker
+):
+    broker = MagicMock()
+    mock_get_broker.return_value = (broker, None)
+    mock_to_thread.return_value = [
+        {
+            "type": "DIVIDEND_OR_INTEREST",
+            "description": "QUALIFIED DIVIDEND",
+            "netAmount": 1.50,
+            "symbol": "AAPL",
+        },
+        {
+            "type": "DIVIDEND_OR_INTEREST",
+            "description": "FREE BALANCE INTEREST ADJUSTMENT",
+            "netAmount": 0.05,
+            "symbol": "AAPL",
+        },
+    ]
+
+    result = await schwab_get_dividends_by_symbol("abc123", "AAPL")
+
+    assert result["result"]["count"] == 1
+    assert len(result["result"]["dividends"]) == 1
+    assert result["result"]["dividends"][0]["description"] == "QUALIFIED DIVIDEND"
+
+
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
+async def test_schwab_get_dividends_by_symbol_uppercases_symbol(
+    mock_to_thread, mock_get_broker
+):
+    broker = MagicMock()
+    mock_get_broker.return_value = (broker, None)
+    mock_to_thread.return_value = []
+
+    result = await schwab_get_dividends_by_symbol("abc123", "aapl")
+
+    _, kwargs = mock_to_thread.call_args
+    assert kwargs["symbol"] == "AAPL"
+    assert result["result"]["symbol"] == "AAPL"


### PR DESCRIPTION
Closes #528

## Changes
- Added `schwab_get_dividends_by_symbol(account_hash, symbol, start_date, end_date)` to `schwab_payment_tools.py`, reusing `_classify_transaction` and the date-parsing/`asyncio.to_thread` pattern from `schwab_get_dividends`
- Symbol is uppercased before being passed to `broker.client.get_transactions` alongside `transaction_types=["DIVIDEND_OR_INTEREST"]`
- Response includes `"symbol"` in addition to `dividends`, `total_amount`, and `count`
- Registered `@mcp.tool()` wrapper in `server/app.py` adjacent to `schwab_get_dividends`
- Added four new unit tests covering: symbol passthrough, response shape, dividend-only filtering, and uppercase normalization

## Test plan
- `uv run pytest tests/unit/test_schwab_payment_tools.py -q` — 14 passed
- `uv run mypy src/open_stocks_mcp/tools/schwab_payment_tools.py src/open_stocks_mcp/server/app.py` — clean
- `uv run ruff check src/open_stocks_mcp/tools/schwab_payment_tools.py tests/unit/test_schwab_payment_tools.py src/open_stocks_mcp/server/app.py` — clean