### PR TITLE
feat: implement schwab_get_open_option_orders end-to-end vertical slice

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -167,6 +167,8 @@ from open_stocks_mcp.tools.schwab_options_tools import (
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
+)
+from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_get_open_option_orders as _schwab_get_open_option_orders_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -167,6 +167,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
+    schwab_get_open_option_orders as _schwab_get_open_option_orders_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_option_buy_to_open as _schwab_option_buy_to_open_impl,
@@ -1817,6 +1818,23 @@ async def schwab_get_all_option_positions() -> dict[str, Any]:
 async def schwab_get_open_option_positions() -> dict[str, Any]:
     """Get open Schwab option positions with non-zero net quantity."""
     return await get_schwab_open_option_positions()
+
+
+@mcp.tool()
+async def schwab_open_option_orders(
+    account_hash: str, max_results: int = 50
+) -> dict[str, Any]:
+    """Get open option orders for a Schwab account.
+
+    Returns only orders with at least one option leg and a working/open status
+    (WORKING, PENDING_ACTIVATION, QUEUED, ACCEPTED, AWAITING_CONDITION,
+    AWAITING_MANUAL_REVIEW, AWAITING_PARENT_ORDER).
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum orders to fetch before filtering (default 50)
+    """
+    return await _schwab_get_open_option_orders_impl(account_hash, max_results)
 
 
 def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -17,6 +17,28 @@ from open_stocks_mcp.tools.error_handling import (
     handle_schwab_errors,
 )
 
+_OPEN_OPTION_STATUSES = frozenset(
+    {
+        "WORKING",
+        "PENDING_ACTIVATION",
+        "QUEUED",
+        "ACCEPTED",
+        "AWAITING_CONDITION",
+        "AWAITING_MANUAL_REVIEW",
+        "AWAITING_PARENT_ORDER",
+    }
+)
+
+
+def _has_option_leg(order: dict[str, Any]) -> bool:
+    """Return True when any leg of the order is an option instrument."""
+    legs = order.get("orderLegCollection", [])
+    return any(
+        leg.get("orderLegType") == "OPTION"
+        or leg.get("instrument", {}).get("assetType") == "OPTION"
+        for leg in legs
+    )
+
 
 @handle_schwab_errors
 async def get_schwab_option_chain(
@@ -484,4 +506,53 @@ async def schwab_option_sell_to_close(
 
     except Exception as e:
         logger.error(f"Error placing Schwab option sell order: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_open_option_orders(
+    account_hash: str, max_results: int = 50
+) -> dict[str, Any]:
+    """Get open option orders for a Schwab account.
+
+    Filters to orders that have at least one option leg and are in a working/open
+    status set (WORKING, PENDING_ACTIVATION, QUEUED, ACCEPTED, AWAITING_CONDITION,
+    AWAITING_MANUAL_REVIEW, AWAITING_PARENT_ORDER).
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum number of orders to fetch before filtering (default 50)
+
+    Returns:
+        Dict with filtered option orders and count
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get open option orders for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_orders() -> Any:
+            response = broker.client.get_orders_for_account(
+                account_hash, max_results=max_results
+            )
+            return response.json()
+
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
+        all_orders = orders_data if isinstance(orders_data, list) else []
+
+        open_option_orders = [
+            o
+            for o in all_orders
+            if _has_option_leg(o) and o.get("status") in _OPEN_OPTION_STATUSES
+        ]
+
+        return create_success_response(
+            {"orders": open_option_orders, "count": len(open_option_orders)}
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab open option orders for {account_hash}: {e}")
         return create_error_response(e)

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -248,6 +248,13 @@ class TestToolRegistration:
         assert "schwab_find_tradable_options" in tool_names
 
     @pytest.mark.asyncio
+    async def test_schwab_open_option_orders_is_registered(self) -> None:
+        """Test that schwab_open_option_orders is registered."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+        assert "schwab_open_option_orders" in tool_names
+
+    @pytest.mark.asyncio
     async def test_account_info_tool_callable(self) -> None:
         """Test that account_info tool is callable."""
         tools_list = await mcp.list_tools()

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -12,6 +12,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_expirations,
     get_schwab_options_positions,
     schwab_find_tradable_options,
+    schwab_get_open_option_orders,
     schwab_option_buy_to_open,
     schwab_option_sell_to_close,
 )
@@ -615,3 +616,59 @@ async def test_find_tradable_options_auth_error(mock_get_broker: AsyncMock) -> N
     result = await schwab_find_tradable_options("AAPL")
 
     assert result == error_response
+
+
+@pytest.mark.journey_options
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error")
+@patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+async def test_get_open_option_orders_filters_to_working_status(
+    mock_execute: AsyncMock,
+    mock_get_broker: AsyncMock,
+) -> None:
+    """Only OPTION-legged orders in an open status should be returned."""
+    mock_broker = MagicMock()
+    mock_get_broker.return_value = (mock_broker, None)
+
+    mock_execute.return_value = [
+        # OPTION + WORKING → included
+        {
+            "status": "WORKING",
+            "orderLegCollection": [
+                {
+                    "orderLegType": "OPTION",
+                    "instrument": {"assetType": "OPTION", "symbol": "AAPL_011924C170"},
+                }
+            ],
+        },
+        # OPTION + FILLED → excluded (closed status)
+        {
+            "status": "FILLED",
+            "orderLegCollection": [
+                {
+                    "orderLegType": "OPTION",
+                    "instrument": {"assetType": "OPTION"},
+                }
+            ],
+        },
+        # EQUITY + WORKING → excluded (no option leg)
+        {
+            "status": "WORKING",
+            "orderLegCollection": [
+                {
+                    "orderLegType": "EQUITY",
+                    "instrument": {"assetType": "EQUITY", "symbol": "AAPL"},
+                }
+            ],
+        },
+    ]
+
+    result = await schwab_get_open_option_orders("abc123")
+
+    assert "result" in result
+    assert result["result"]["count"] == 1
+    orders = result["result"]["orders"]
+    assert len(orders) == 1
+    assert orders[0]["status"] == "WORKING"
+    assert orders[0]["orderLegCollection"][0]["orderLegType"] == "OPTION"


### PR DESCRIPTION
Closes #340

## Changes
- Added `_OPEN_OPTION_STATUSES` frozenset and `_has_option_leg()` predicate in `schwab_options_tools.py` — accepts either `orderLegType == "OPTION"` or `instrument.assetType == "OPTION"` to handle both Schwab API leg shapes
- Implemented `schwab_get_open_option_orders(account_hash, max_results=50)` decorated with `@handle_schwab_errors`, gated through `get_authenticated_broker_or_error`, using `execute_broker_request` for async wrapping; returns `{"orders": [...], "count": N}`
- Registered `schwab_open_option_orders` as an `@mcp.tool()` in `app.py`
- Added `test_get_open_option_orders_filters_to_working_status` with three-order fixture (OPTION+WORKING included, OPTION+FILLED excluded, EQUITY+WORKING excluded), asserts `count=1`
- Added `test_schwab_open_option_orders_is_registered` to `TestToolRegistration` in `test_server_app.py`

## Note on "five tool" registry check
The implementation plan references a registry assertion for all five parent-roadmap Schwab options tool names (`schwab_find_tradable_options`, `schwab_option_positions_detailed`, `schwab_option_quote`, `schwab_option_orders`, `schwab_open_option_orders`). Issues 335–337 have open PRs (#593–#595); issues 338–339 have no PRs yet. Only `schwab_open_option_orders` is added here; the five-tool assertion will be possible once those PRs merge.

## Test plan
- `uv run pytest tests/unit/test_schwab_options_tools.py -k open_option_orders -x` — 1 passed
- `uv run pytest -m journey_options tests/unit/test_schwab_options_tools.py` — 19 passed
- `uv run pytest tests/server/test_server_app.py::TestToolRegistration -q` — 9 passed
- `uv run mypy src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/server/app.py` — Success: no issues found
- `uv run ruff check` — All checks passed
- Registry check: `schwab_open_option_orders` confirmed present