### PR TITLE
fix: remove dead circuit breaker feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Environment variables always win over YAML values, including:
 - `MCP_SERVER_NAME`, `LOG_LEVEL`
 - `RATE_LIMIT_CALLS_PER_MINUTE`, `RATE_LIMIT_CALLS_PER_HOUR`, `RATE_LIMIT_BURST_SIZE`
 - `CACHE_TTL_MARKET_SECONDS`, `CACHE_TTL_ACCOUNT_SECONDS`, `CACHE_MAX_SIZE`
-- `ENABLE_CACHE`, `ENABLE_CIRCUIT_BREAKER`
+- `ENABLE_CACHE`
 
 Feature flags support safe defaults plus per-environment overrides:
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -23,7 +23,6 @@ cache:
 
 feature_flags:
   enable_cache: true
-  enable_circuit_breaker: false
   brokers.robinhood:
     default: true
     environments:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ dev = [
     "black>=25.0.0",
     "pre-commit>=4.5.0",
     "nbformat>=5.10",
+    "types-pyyaml>=6.0.12.20260518",
 ]
 
 [tool.hatch.build]

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -167,7 +167,6 @@ class FeatureFlagConfig:
     """Feature flags for optional behavior."""
 
     enable_cache: bool = True
-    enable_circuit_breaker: bool = False
 
 
 @dataclass
@@ -282,8 +281,6 @@ class ServerConfig:
     def is_feature_enabled(self, flag_name: str) -> bool:
         if flag_name == "enable_cache":
             return self.feature_flags.enable_cache
-        if flag_name == "enable_circuit_breaker":
-            return self.feature_flags.enable_circuit_breaker
 
         definition = self.feature_flag_definitions.get(flag_name)
         if definition is None:
@@ -343,7 +340,7 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
 
     feature_flag_definitions: dict[str, FeatureFlagDefinition] = {}
     for flag_name, flag_value in feature_flags.items():
-        if flag_name in {"enable_cache", "enable_circuit_breaker"}:
+        if flag_name == "enable_cache":
             continue
         if isinstance(flag_value, bool):
             feature_flag_definitions[flag_name] = FeatureFlagDefinition(
@@ -440,13 +437,6 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
         os.getenv("ENABLE_CACHE", str(feature_flags.get("enable_cache", True))),
         "ENABLE_CACHE",
     )
-    enable_circuit_breaker = _parse_bool(
-        os.getenv(
-            "ENABLE_CIRCUIT_BREAKER",
-            str(feature_flags.get("enable_circuit_breaker", False)),
-        ),
-        "ENABLE_CIRCUIT_BREAKER",
-    )
 
     monitoring_enabled = _parse_bool(
         os.getenv("MONITORING_ENABLED", "true"),
@@ -483,7 +473,6 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
         ),
         feature_flags=FeatureFlagConfig(
             enable_cache=enable_cache,
-            enable_circuit_breaker=enable_circuit_breaker,
         ),
         cache=CacheConfig(
             enabled=cache_enabled,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,7 +28,6 @@ cache:
   max_size: 2048
 feature_flags:
   enable_cache: false
-  enable_circuit_breaker: true
 """.strip()
     )
 
@@ -43,7 +42,6 @@ feature_flags:
     assert cfg.cache.ttl_account_seconds == 33
     assert cfg.cache.max_size == 2048
     assert cfg.feature_flags.enable_cache is False
-    assert cfg.feature_flags.enable_circuit_breaker is True
 
 
 @pytest.mark.unit
@@ -67,7 +65,6 @@ cache:
   max_size: 7
 feature_flags:
   enable_cache: true
-  enable_circuit_breaker: false
 """.strip()
     )
 
@@ -80,7 +77,6 @@ feature_flags:
     monkeypatch.setenv("CACHE_TTL_ACCOUNT_SECONDS", "35")
     monkeypatch.setenv("CACHE_MAX_SIZE", "300")
     monkeypatch.setenv("ENABLE_CACHE", "false")
-    monkeypatch.setenv("ENABLE_CIRCUIT_BREAKER", "true")
 
     cfg = load_config(config_path=path)
 
@@ -93,7 +89,6 @@ feature_flags:
     assert cfg.cache.ttl_account_seconds == 35
     assert cfg.cache.max_size == 300
     assert cfg.feature_flags.enable_cache is False
-    assert cfg.feature_flags.enable_circuit_breaker is True
 
 
 @pytest.mark.unit
@@ -150,7 +145,6 @@ def test_missing_file_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
         "CACHE_TTL_ACCOUNT_SECONDS",
         "CACHE_MAX_SIZE",
         "ENABLE_CACHE",
-        "ENABLE_CIRCUIT_BREAKER",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -165,7 +159,6 @@ def test_missing_file_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.cache.ttl_account_seconds > 0
     assert cfg.cache.max_size > 0
     assert cfg.feature_flags.enable_cache is True
-    assert cfg.feature_flags.enable_circuit_breaker is False
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -1787,6 +1787,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1838,6 +1839,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.15.0" },
     { name = "ruff", specifier = ">=0.14.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 
 [[package]]
@@ -3033,6 +3035,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #515

## Changes
- Removed the dead `feature_flags.enable_circuit_breaker` / `ENABLE_CIRCUIT_BREAKER` config field, loader path, and test assertions.
- Removed stale README and example YAML references while keeping `OPEN_STOCKS_MCP_CIRCUIT_BREAKER_ENABLED` documented as the operational control.
- Added the PyYAML stub package to dev dependencies so the required focused mypy validation passes on current `main`.

## Test plan
- `rg -n "ENABLE_CIRCUIT_BREAKER|enable_circuit_breaker" src/open_stocks_mcp/config.py tests/unit/test_config.py` exits 1 with no output.
- `rg -n "ENABLE_CIRCUIT_BREAKER|enable_circuit_breaker" README.md config.yaml.example` exits 1 with no output.
- `rg -n "OPEN_STOCKS_MCP_CIRCUIT_BREAKER_ENABLED" README.md config.yaml.example` keeps the README operational default entry.
- `uv run pytest tests/unit/test_config.py`
- `uv run ruff check src/open_stocks_mcp/config.py tests/unit/test_config.py`
- `uv run mypy src/open_stocks_mcp/config.py`
- `uv run pytest tests/unit/test_config.py tests/unit/test_simple_rate_limiter.py tests/server/test_server_app.py -q`
- `git diff --check`
