### PR TITLE
refactor: remove redundant try/except in movers module

### DIFF
--- a/src/open_stocks_mcp/tools/market/movers.py
+++ b/src/open_stocks_mcp/tools/market/movers.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import robin_stocks.robinhood as rh
 
-from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_no_data_response,
@@ -45,45 +44,40 @@ async def get_top_movers_sp500(direction: str = "up") -> dict[str, Any]:
             }
         }
     """
-    try:
-        # Validate direction parameter
-        direction = direction.lower().strip()
-        if direction not in ["up", "down"]:
-            return create_error_response(
-                ValueError("Direction must be 'up' or 'down'"), "parameter validation"
-            )
-
-        # Ensure authenticated
-        session_mgr = get_session_manager()
-        if not await session_mgr.ensure_authenticated():
-            return create_error_response(
-                ValueError("Authentication required"), "authentication"
-            )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
-
-        log_api_call("get_top_movers_sp500", direction=direction)
-
-        # Get S&P 500 movers with retry logic
-        movers_data = await execute_with_retry(rh.get_top_movers_sp500, direction)
-
-        if not movers_data:
-            return create_no_data_response(
-                f"No S&P 500 {direction} movers found", {"direction": direction}
-            )
-
-        # Filter out None values and ensure we have valid data
-        movers = [mover for mover in movers_data if mover is not None]
-
-        return create_success_response(
-            {"direction": direction, "movers": movers, "count": len(movers)}
+    # Validate direction parameter
+    direction = direction.lower().strip()
+    if direction not in ["up", "down"]:
+        return create_error_response(
+            ValueError("Direction must be 'up' or 'down'"), "parameter validation"
         )
 
-    except Exception as e:
-        logger.error(f"Failed to get S&P 500 {direction} movers: {e}")
-        return create_error_response(e, "get_top_movers_sp500")
+    # Ensure authenticated
+    session_mgr = get_session_manager()
+    if not await session_mgr.ensure_authenticated():
+        return create_error_response(
+            ValueError("Authentication required"), "authentication"
+        )
+
+    # Apply rate limiting
+    rate_limiter = get_rate_limiter()
+    await rate_limiter.acquire()
+
+    log_api_call("get_top_movers_sp500", direction=direction)
+
+    # Get S&P 500 movers with retry logic
+    movers_data = await execute_with_retry(rh.get_top_movers_sp500, direction)
+
+    if not movers_data:
+        return create_no_data_response(
+            f"No S&P 500 {direction} movers found", {"direction": direction}
+        )
+
+    # Filter out None values and ensure we have valid data
+    movers = [mover for mover in movers_data if mover is not None]
+
+    return create_success_response(
+        {"direction": direction, "movers": movers, "count": len(movers)}
+    )
 
 
 @handle_robin_stocks_errors
@@ -129,34 +123,29 @@ async def get_top_100() -> dict[str, Any]:
             }
         }
     """
-    try:
-        # Ensure authenticated
-        session_mgr = get_session_manager()
-        if not await session_mgr.ensure_authenticated():
-            return create_error_response(
-                ValueError("Authentication required"), "authentication"
-            )
+    # Ensure authenticated
+    session_mgr = get_session_manager()
+    if not await session_mgr.ensure_authenticated():
+        return create_error_response(
+            ValueError("Authentication required"), "authentication"
+        )
 
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
+    # Apply rate limiting
+    rate_limiter = get_rate_limiter()
+    await rate_limiter.acquire()
 
-        log_api_call("get_top_100")
+    log_api_call("get_top_100")
 
-        # Get top 100 stocks with retry logic
-        stocks_data = await execute_with_retry(rh.get_top_100)
+    # Get top 100 stocks with retry logic
+    stocks_data = await execute_with_retry(rh.get_top_100)
 
-        if not stocks_data:
-            return create_no_data_response("No top 100 stocks data found", {})
+    if not stocks_data:
+        return create_no_data_response("No top 100 stocks data found", {})
 
-        # Filter out None values and ensure we have valid data
-        stocks = [stock for stock in stocks_data if stock is not None]
+    # Filter out None values and ensure we have valid data
+    stocks = [stock for stock in stocks_data if stock is not None]
 
-        return create_success_response({"stocks": stocks, "count": len(stocks)})
-
-    except Exception as e:
-        logger.error(f"Failed to get top 100 stocks: {e}")
-        return create_error_response(e, "get_top_100")
+    return create_success_response({"stocks": stocks, "count": len(stocks)})
 
 
 @handle_robin_stocks_errors
@@ -202,34 +191,29 @@ async def get_top_movers() -> dict[str, Any]:
             }
         }
     """
-    try:
-        # Ensure authenticated
-        session_mgr = get_session_manager()
-        if not await session_mgr.ensure_authenticated():
-            return create_error_response(
-                ValueError("Authentication required"), "authentication"
-            )
+    # Ensure authenticated
+    session_mgr = get_session_manager()
+    if not await session_mgr.ensure_authenticated():
+        return create_error_response(
+            ValueError("Authentication required"), "authentication"
+        )
 
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
+    # Apply rate limiting
+    rate_limiter = get_rate_limiter()
+    await rate_limiter.acquire()
 
-        log_api_call("get_top_movers")
+    log_api_call("get_top_movers")
 
-        # Get top movers with retry logic
-        movers_data = await execute_with_retry(rh.get_top_movers)
+    # Get top movers with retry logic
+    movers_data = await execute_with_retry(rh.get_top_movers)
 
-        if not movers_data:
-            return create_no_data_response("No top movers data found", {})
+    if not movers_data:
+        return create_no_data_response("No top movers data found", {})
 
-        # Filter out None values and ensure we have valid data
-        movers = [mover for mover in movers_data if mover is not None]
+    # Filter out None values and ensure we have valid data
+    movers = [mover for mover in movers_data if mover is not None]
 
-        return create_success_response({"movers": movers, "count": len(movers)})
-
-    except Exception as e:
-        logger.error(f"Failed to get top movers: {e}")
-        return create_error_response(e, "get_top_movers")
+    return create_success_response({"movers": movers, "count": len(movers)})
 
 
 @handle_robin_stocks_errors
@@ -258,44 +242,40 @@ async def get_stocks_by_tag(tag: str) -> dict[str, Any]:
             }
         }
     """
-    try:
-        # Validate tag parameter
-        if not tag or not isinstance(tag, str):
-            return create_error_response(
-                ValueError("Tag parameter is required and must be a string"),
-                "parameter validation",
-            )
-
-        tag = tag.strip().lower()
-
-        # Ensure authenticated
-        session_mgr = get_session_manager()
-        if not await session_mgr.ensure_authenticated():
-            return create_error_response(
-                ValueError("Authentication required"), "authentication"
-            )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
-
-        log_api_call("get_stocks_by_tag", tag=tag)
-
-        # Get stocks by tag with retry logic
-        stocks_data = await execute_with_retry(rh.get_all_stocks_from_market_tag, tag)
-
-        if not stocks_data or stocks_data == [None]:
-            return create_no_data_response(
-                f"No stocks found for tag: {tag}", {"tag": tag}
-            )
-
-        # Filter out None values and ensure we have valid data
-        stocks = [stock for stock in stocks_data if stock is not None]
-
-        return create_success_response(
-            {"tag": tag, "stocks": stocks, "count": len(stocks)}
+    # Validate tag parameter
+    if not tag or not isinstance(tag, str):
+        return create_error_response(
+            ValueError("Tag parameter is required and must be a string"),
+            "parameter validation",
         )
 
-    except Exception as e:
-        logger.error(f"Failed to get stocks for tag {tag}: {e}")
-        return create_error_response(e, "get_stocks_by_tag")
+    tag = tag.strip().lower()
+
+    # Ensure authenticated
+    session_mgr = get_session_manager()
+    if not await session_mgr.ensure_authenticated():
+        return create_error_response(
+            ValueError("Authentication required"), "authentication"
+        )
+
+    # Apply rate limiting
+    rate_limiter = get_rate_limiter()
+    await rate_limiter.acquire()
+
+    log_api_call("get_stocks_by_tag", tag=tag)
+
+    # Get stocks by tag with retry logic
+    stocks_data = await execute_with_retry(rh.get_all_stocks_from_market_tag, tag)
+
+    if not stocks_data or stocks_data == [None]:
+        return create_no_data_response(
+            f"No stocks found for tag: {tag}", {"tag": tag}
+        )
+
+    # Filter out None values and ensure we have valid data
+    stocks = [stock for stock in stocks_data if stock is not None]
+
+    return create_success_response(
+        {"tag": tag, "stocks": stocks, "count": len(stocks)}
+    )
+


### PR DESCRIPTION
Closes #574

## Changes
- Removed redundant try/except blocks in src/open_stocks_mcp/tools/market/movers.py that were duplicating the behavior of the @handle_robin_stocks_errors decorator.
- Removed unused logger import in the same file.
- Verified that existing tests still pass and legacy re-exports are maintained.

Note: Although #574 was previously merged, this PR provides a follow-up cleanup to the movers module extraction.

## Test plan
- uv run pytest tests/unit/test_market_research_tools.py tests/unit/test_market_data_module_split.py tests/unit/test_market_tools.py -q — 15 passed, 17 skipped
- uv run ruff check src/open_stocks_mcp/tools/market/movers.py — clean
- uv run mypy src/open_stocks_mcp/tools/market/movers.py — clean
