### PR TITLE
feat: add schwab level2 stream snapshot tool

### DIFF
--- a/src/open_stocks_mcp/brokers/schwab_stream.py
+++ b/src/open_stocks_mcp/brokers/schwab_stream.py
@@ -34,6 +34,7 @@ class SchwabStreamManager:
         self._handlers: list[Callable[[dict[str, Any]], None]] = []
         self._latest_quotes: dict[str, dict[str, Any]] = {}
         self._latest_option_quotes: dict[str, dict[str, Any]] = {}
+        self._latest_level2_books: dict[str, dict[str, Any]] = {}
         self._latest_activity: list[dict[str, Any]] = []
 
     @property
@@ -72,10 +73,12 @@ class SchwabStreamManager:
                     except Exception as e:
                         logger.error(f"Error in Schwab stream custom handler: {e}")
 
-            # Register handlers for Level One data and account activity
+            # Register handlers for Level One, Level 2 and account activity
             assert self.stream_client is not None
             self.stream_client.add_level_one_equity_handler(_core_handler)
             self.stream_client.add_level_one_option_handler(_core_handler)
+            self.stream_client.add_nasdaq_book_handler(_core_handler)
+            self.stream_client.add_nyse_book_handler(_core_handler)
             self.stream_client.add_account_activity_handler(_core_handler)
 
             await self.stream_client.login()
@@ -153,6 +156,20 @@ class SchwabStreamManager:
                     if symbol not in self._latest_option_quotes:
                         self._latest_option_quotes[symbol] = {}
                     self._latest_option_quotes[symbol].update(item)
+        elif service in {"NASDAQ_BOOK", "NYSE_BOOK"}:
+            for item in content:
+                symbol = item.get("SYMBOL")
+                if not symbol:
+                    continue
+                symbol_upper = symbol.upper()
+                cache_key = f"{symbol_upper}:{service}"
+                self._latest_level2_books[cache_key] = {
+                    "symbol": symbol_upper,
+                    "service": service,
+                    "book_time": item.get("BOOK_TIME"),
+                    "bids": item.get("BIDS", []),
+                    "asks": item.get("ASKS", []),
+                }
         elif service == "ACCT_ACTIVITY":
             for item in content:
                 self._latest_activity.append(item)
@@ -240,3 +257,31 @@ class SchwabStreamManager:
     def get_latest_option_quote(self, symbol: str) -> dict[str, Any] | None:
         """Get latest cached option quote for symbol."""
         return self._latest_option_quotes.get(symbol.upper())
+
+    async def subscribe_level2(self, symbol: str, venue: str = "nasdaq") -> bool:
+        """Subscribe to Level 2 order-book stream for a symbol."""
+        if not self._is_running or not self.stream_client:
+            return False
+
+        symbol_upper = symbol.upper()
+        venue_lower = venue.lower()
+
+        try:
+            if venue_lower == "nasdaq":
+                await self.stream_client.nasdaq_book_subs([symbol_upper])
+                return True
+            if venue_lower == "nyse":
+                await self.stream_client.nyse_book_subs([symbol_upper])
+                return True
+            return False
+        except Exception as e:
+            logger.error(
+                f"Failed to subscribe Level 2 for {symbol_upper} on {venue_lower}: {e}"
+            )
+            return False
+
+    def get_latest_level2(self, symbol: str, venue: str = "nasdaq") -> dict[str, Any] | None:
+        """Get latest cached Level 2 book snapshot for symbol and venue."""
+        service = "NASDAQ_BOOK" if venue.lower() == "nasdaq" else "NYSE_BOOK"
+        cache_key = f"{symbol.upper()}:{service}"
+        return self._latest_level2_books.get(cache_key)

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -199,6 +199,9 @@ from open_stocks_mcp.tools.schwab_streaming_tools import (
     schwab_stream_account_activity as _schwab_stream_account_activity_impl,
 )
 from open_stocks_mcp.tools.schwab_streaming_tools import (
+    schwab_stream_level2 as _schwab_stream_level2_impl,
+)
+from open_stocks_mcp.tools.schwab_streaming_tools import (
     schwab_stream_option_quotes as _schwab_stream_option_quotes_impl,
 )
 from open_stocks_mcp.tools.schwab_trading_tools import (
@@ -1896,6 +1899,8 @@ async def schwab_open_option_orders(
         max_results: Maximum orders to fetch before filtering (default 50)
     """
     return await _schwab_get_open_option_orders_impl(account_hash, max_results)
+
+
 # Schwab Streaming Tools
 @mcp.tool()
 async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
@@ -1905,6 +1910,12 @@ async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
         symbols: List of Schwab option symbols (e.g. ['AAPL  260619C00150000'])
     """
     return await _schwab_stream_option_quotes_impl(symbols)
+
+
+@mcp.tool()
+async def schwab_stream_level2(symbol: str, venue: str = "nasdaq") -> dict[str, Any]:
+    """Get a Level 2 snapshot from Schwab streaming cache for a symbol."""
+    return await _schwab_stream_level2_impl(symbol, venue)
 
 
 @mcp.tool()

--- a/src/open_stocks_mcp/tools/schwab_streaming_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_streaming_tools.py
@@ -89,6 +89,95 @@ async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
     )
 
 
+async def schwab_stream_level2(symbol: str, venue: str = "nasdaq") -> dict[str, Any]:
+    """Get a Level 2 snapshot from Schwab streaming cache for a symbol.
+
+    Note: this endpoint follows a subscribe-then-read pattern; the first call may
+    return `stream_unavailable` until an async book update arrives and is cached.
+    """
+    symbol_upper = symbol.upper()
+    venue_lower = venue.lower()
+
+    if venue_lower not in {"nasdaq", "nyse"}:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbol": symbol_upper,
+                "venue": venue_lower,
+                "reason": "unsupported venue",
+            }
+        )
+
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"stream level2 for {symbol_upper}"
+    )
+    if error:
+        return error
+
+    health = broker.get_health_status()
+    if not health.get("capabilities", {}).get("streaming_quotes"):
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbol": symbol_upper,
+                "venue": venue_lower,
+                "reason": "streaming capability disabled",
+            }
+        )
+
+    manager = getattr(broker, "stream_manager", None)
+    if manager is None:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbol": symbol_upper,
+                "venue": venue_lower,
+                "reason": "stream manager unavailable",
+            }
+        )
+
+    if not manager.is_running:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbol": symbol_upper,
+                "venue": venue_lower,
+                "reason": "stream manager stopped",
+            }
+        )
+
+    subscribed = await manager.subscribe_level2(symbol_upper, venue_lower)
+    if not subscribed:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbol": symbol_upper,
+                "venue": venue_lower,
+                "reason": "subscription failed",
+            }
+        )
+
+    snapshot = manager.get_latest_level2(symbol_upper, venue_lower)
+    if snapshot is None:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbol": symbol_upper,
+                "venue": venue_lower,
+                "reason": "no snapshot available",
+            }
+        )
+
+    return create_success_response(
+        {
+            "status": "success",
+            "symbol": symbol_upper,
+            "venue": venue_lower,
+            "snapshot": snapshot,
+        }
+    )
+
+
 async def schwab_stream_account_activity() -> dict[str, Any]:
     """Get latest account activity events from Schwab streaming."""
     broker, error = await get_authenticated_broker_or_error(

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -299,6 +299,7 @@ class TestToolRegistration:
         tools_list = await mcp.list_tools()
         tool_names = [tool.name for tool in tools_list]
         assert "schwab_stream_option_quotes" in tool_names
+        assert "schwab_stream_level2" in tool_names
         assert "schwab_stream_account_activity" in tool_names
 
     @pytest.mark.asyncio

--- a/tests/unit/test_capabilities_and_streaming.py
+++ b/tests/unit/test_capabilities_and_streaming.py
@@ -122,6 +122,60 @@ async def test_schwab_stream_manager_subscribe_option_quotes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_schwab_stream_manager_handles_level2_by_venue() -> None:
+    from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
+
+    mock_broker = MagicMock()
+    manager = SchwabStreamManager(mock_broker)
+
+    manager._handle_message(
+        {
+            "service": "NASDAQ_BOOK",
+            "content": [
+                {"SYMBOL": "AAPL", "BOOK_TIME": 111, "BIDS": [{"p": 1}], "ASKS": []}
+            ],
+        }
+    )
+    manager._handle_message(
+        {
+            "service": "NYSE_BOOK",
+            "content": [
+                {"SYMBOL": "AAPL", "BOOK_TIME": 222, "BIDS": [], "ASKS": [{"p": 2}]}
+            ],
+        }
+    )
+
+    nasdaq_book = manager.get_latest_level2("AAPL", "nasdaq")
+    nyse_book = manager.get_latest_level2("AAPL", "nyse")
+    assert nasdaq_book is not None
+    assert nyse_book is not None
+    assert nasdaq_book["service"] == "NASDAQ_BOOK"
+    assert nyse_book["service"] == "NYSE_BOOK"
+    assert nasdaq_book["book_time"] == 111
+    assert nyse_book["book_time"] == 222
+
+
+@pytest.mark.asyncio
+async def test_schwab_stream_manager_subscribe_level2() -> None:
+    from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
+
+    mock_broker = MagicMock()
+    manager = SchwabStreamManager(mock_broker)
+    manager._is_running = True
+    manager.stream_client = AsyncMock()
+
+    success_nasdaq = await manager.subscribe_level2("AAPL", "nasdaq")
+    success_nyse = await manager.subscribe_level2("AAPL", "nyse")
+    unsupported = await manager.subscribe_level2("AAPL", "arca")
+
+    assert success_nasdaq is True
+    assert success_nyse is True
+    assert unsupported is False
+    manager.stream_client.nasdaq_book_subs.assert_awaited_once_with(["AAPL"])
+    manager.stream_client.nyse_book_subs.assert_awaited_once_with(["AAPL"])
+
+
+@pytest.mark.asyncio
 async def test_schwab_stream_manager_subscribe_quotes_splitting() -> None:
     from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
 

--- a/tests/unit/test_schwab_streaming_tools.py
+++ b/tests/unit/test_schwab_streaming_tools.py
@@ -5,10 +5,12 @@ import pytest
 
 from open_stocks_mcp.tools.schwab_streaming_tools import (
     schwab_stream_account_activity,
+    schwab_stream_level2,
     schwab_stream_option_quotes,
 )
 
 
+@pytest.mark.journey_market_data
 @pytest.mark.asyncio
 async def test_schwab_stream_option_quotes_success() -> None:
     mock_broker = MagicMock()
@@ -135,6 +137,84 @@ async def test_schwab_stream_account_activity_unavailable(
         AsyncMock(return_value=(mock_broker, None)),
     ):
         result = await schwab_stream_account_activity()
+
+    assert result["result"]["status"] == "stream_unavailable"
+    assert result["result"]["reason"] == expected_reason
+
+
+@pytest.mark.journey_market_data
+@pytest.mark.asyncio
+async def test_schwab_stream_level2_success() -> None:
+    mock_broker = MagicMock()
+    mock_broker.get_health_status.return_value = {
+        "capabilities": {"streaming_quotes": True}
+    }
+    mock_broker.stream_manager.is_running = True
+    mock_broker.stream_manager.subscribe_level2 = AsyncMock(return_value=True)
+    mock_broker.stream_manager.get_latest_level2.return_value = {
+        "symbol": "AAPL",
+        "service": "NASDAQ_BOOK",
+        "book_time": 1710000000,
+        "bids": [],
+        "asks": [],
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.schwab_streaming_tools.get_authenticated_broker_or_error",
+        AsyncMock(return_value=(mock_broker, None)),
+    ):
+        result = await schwab_stream_level2("aapl", "nasdaq")
+
+    assert result["result"]["status"] == "success"
+    assert result["result"]["symbol"] == "AAPL"
+    assert result["result"]["venue"] == "nasdaq"
+    mock_broker.stream_manager.subscribe_level2.assert_awaited_once_with(
+        "AAPL", "nasdaq"
+    )
+    mock_broker.stream_manager.get_latest_level2.assert_called_once_with(
+        "AAPL", "nasdaq"
+    )
+
+
+@pytest.mark.journey_market_data
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "symbol,venue,capability,manager_exists,is_running,sub_success,snapshot,expected_reason",
+    [
+        ("AAPL", "arca", True, True, True, True, {"x": 1}, "unsupported venue"),
+        ("AAPL", "nasdaq", False, True, True, True, {"x": 1}, "streaming capability disabled"),
+        ("AAPL", "nasdaq", True, False, True, True, {"x": 1}, "stream manager unavailable"),
+        ("AAPL", "nasdaq", True, True, False, True, {"x": 1}, "stream manager stopped"),
+        ("AAPL", "nasdaq", True, True, True, False, {"x": 1}, "subscription failed"),
+        ("AAPL", "nasdaq", True, True, True, True, None, "no snapshot available"),
+    ],
+)
+async def test_schwab_stream_level2_unavailable(
+    symbol: str,
+    venue: str,
+    capability: bool,
+    manager_exists: bool,
+    is_running: bool,
+    sub_success: bool,
+    snapshot: dict[str, Any] | None,
+    expected_reason: str,
+) -> None:
+    mock_broker = MagicMock()
+    mock_broker.get_health_status.return_value = {
+        "capabilities": {"streaming_quotes": capability}
+    }
+    if manager_exists:
+        mock_broker.stream_manager.is_running = is_running
+        mock_broker.stream_manager.subscribe_level2 = AsyncMock(return_value=sub_success)
+        mock_broker.stream_manager.get_latest_level2.return_value = snapshot
+    else:
+        mock_broker.stream_manager = None
+
+    with patch(
+        "open_stocks_mcp.tools.schwab_streaming_tools.get_authenticated_broker_or_error",
+        AsyncMock(return_value=(mock_broker, None)),
+    ):
+        result = await schwab_stream_level2(symbol, venue)
 
     assert result["result"]["status"] == "stream_unavailable"
     assert result["result"]["reason"] == expected_reason


### PR DESCRIPTION
Closes #532

## Changes
- added Level 2 order-book caching to `SchwabStreamManager` for NASDAQ/NYSE book events
- added `subscribe_level2(symbol, venue)` and `get_latest_level2(symbol)` helpers in stream manager
- added new tool module `schwab_stream_level2(symbol, venue)` with capability checks and structured `stream_unavailable` responses
- registered `schwab_stream_level2` in MCP server app
- added Level 2 stream-manager tests, Schwab streaming tool tests, and server registration coverage

## Test plan
- uv run pytest tests/unit/test_capabilities_and_streaming.py tests/unit/test_schwab_streaming_tools.py -k "level2" -q
- uv run pytest tests/unit/test_capabilities_and_streaming.py tests/unit/test_schwab_streaming_tools.py tests/server/test_server_app.py -k "level2 or schwab_streaming_tools_are_registered" -q
- uv run pytest tests/unit/test_capabilities_and_streaming.py tests/unit/test_schwab_streaming_tools.py tests/server/test_server_app.py -q
- uv run ruff check src/open_stocks_mcp/brokers/schwab_stream.py src/open_stocks_mcp/tools/schwab_streaming_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_capabilities_and_streaming.py tests/unit/test_schwab_streaming_tools.py tests/server/test_server_app.py
- uv run mypy src/open_stocks_mcp/brokers/schwab_stream.py src/open_stocks_mcp/tools/schwab_streaming_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_capabilities_and_streaming.py tests/unit/test_schwab_streaming_tools.py tests/server/test_server_app.py