### PR TITLE
feat: implement Schwab option quote stream snapshots (#533)

### DIFF
--- a/src/open_stocks_mcp/brokers/schwab_stream.py
+++ b/src/open_stocks_mcp/brokers/schwab_stream.py
@@ -33,6 +33,7 @@ class SchwabStreamManager:
         self._task: asyncio.Task[None] | None = None
         self._handlers: list[Callable[[dict[str, Any]], None]] = []
         self._latest_quotes: dict[str, dict[str, Any]] = {}
+        self._latest_option_quotes: dict[str, dict[str, Any]] = {}
 
     @property
     def is_running(self) -> bool:
@@ -136,14 +137,20 @@ class SchwabStreamManager:
         service = message.get("service")
         content = message.get("content", [])
 
-        if service in ["LEVELONE_EQUITIES", "LEVELONE_OPTIONS"]:
+        if service == "LEVELONE_EQUITIES":
             for item in content:
                 symbol = item.get("key")
                 if symbol:
-                    # Merge update into cache
                     if symbol not in self._latest_quotes:
                         self._latest_quotes[symbol] = {}
                     self._latest_quotes[symbol].update(item)
+        elif service == "LEVELONE_OPTIONS":
+            for item in content:
+                symbol = item.get("key")
+                if symbol:
+                    if symbol not in self._latest_option_quotes:
+                        self._latest_option_quotes[symbol] = {}
+                    self._latest_option_quotes[symbol].update(item)
 
     async def subscribe_quotes(self, symbols: list[str]) -> bool:
         """Subscribe to Level One quotes for symbols."""
@@ -152,7 +159,6 @@ class SchwabStreamManager:
 
         try:
             # Split into equities and options based on symbol format
-            # Schwab option symbols typically contain spaces or follow a specific pattern
             equities = []
             options = []
             for s in symbols:
@@ -163,17 +169,45 @@ class SchwabStreamManager:
                 else:
                     equities.append(s.upper())
 
+            results = []
             if equities:
                 await self.stream_client.level_one_equity_subs(equities)
+                results.append(True)
             if options:
-                await self.stream_client.level_one_option_subs(options)
+                results.append(await self.subscribe_option_quotes(options))
 
             logger.info(f"Subscribed to Schwab quotes: {symbols}")
-            return True
+            return all(results) if results else True
         except Exception as e:
             logger.error(f"Failed to subscribe to Schwab quotes: {e}")
             return False
 
+    async def subscribe_option_quotes(self, symbols: list[str]) -> bool:
+        """Subscribe to Level One option quotes for symbols.
+
+        Args:
+            symbols: List of Schwab option symbols (e.g. 'AAPL  260619C00150000')
+
+        Returns:
+            True if subscription successful, False otherwise
+        """
+        if not self._is_running or not self.stream_client:
+            return False
+
+        try:
+            # Uppercase all symbols to ensure consistency
+            symbols = [s.upper() for s in symbols]
+            await self.stream_client.level_one_option_subs(symbols)
+            logger.info(f"Subscribed to Schwab option quotes: {symbols}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to subscribe to Schwab option quotes: {e}")
+            return False
+
     def get_latest_quote(self, symbol: str) -> dict[str, Any] | None:
-        """Get latest cached quote for symbol."""
+        """Get latest cached equity quote for symbol."""
         return self._latest_quotes.get(symbol.upper())
+
+    def get_latest_option_quote(self, symbol: str) -> dict[str, Any] | None:
+        """Get latest cached option quote for symbol."""
+        return self._latest_option_quotes.get(symbol.upper())

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -190,6 +190,9 @@ from open_stocks_mcp.tools.schwab_portfolio_tools import (
     get_schwab_day_trades,
     get_schwab_open_option_positions,
 )
+from open_stocks_mcp.tools.schwab_streaming_tools import (
+    schwab_stream_option_quotes as _schwab_stream_option_quotes_impl,
+)
 from open_stocks_mcp.tools.schwab_trading_tools import (
     cancel_schwab_order,
     get_schwab_order_by_id,
@@ -1869,6 +1872,17 @@ async def schwab_open_option_orders(
         max_results: Maximum orders to fetch before filtering (default 50)
     """
     return await _schwab_get_open_option_orders_impl(account_hash, max_results)
+
+
+# Schwab Streaming Tools
+@mcp.tool()
+async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
+    """Get real-time option quote snapshots from Schwab streaming.
+
+    Args:
+        symbols: List of Schwab option symbols (e.g. ['AAPL  260619C00150000'])
+    """
+    return await _schwab_stream_option_quotes_impl(symbols)
 
 
 def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:

--- a/src/open_stocks_mcp/tools/schwab_streaming_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_streaming_tools.py
@@ -1,0 +1,89 @@
+"""Tools for Schwab real-time streaming data."""
+
+from typing import Any
+
+from open_stocks_mcp.tools.broker_utils import (
+    get_authenticated_broker_or_error,
+)
+from open_stocks_mcp.tools.error_handling import (
+    create_success_response,
+)
+
+
+async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
+    """Get real-time option quote snapshots from Schwab streaming.
+
+    Args:
+        symbols: List of Schwab option symbols (e.g. ['AAPL  260619C00150000'])
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", "stream option quotes"
+    )
+    if error:
+        return error
+
+    # Check streaming capability
+    health = broker.get_health_status()
+    if not health.get("capabilities", {}).get("streaming_quotes"):
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "streaming capability disabled",
+            }
+        )
+
+    # Check stream manager readiness
+    manager = getattr(broker, "stream_manager", None)
+    if manager is None:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "stream manager unavailable",
+            }
+        )
+
+    if not manager.is_running:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "stream manager stopped",
+            }
+        )
+
+    # Subscribe to option symbols
+    sub_success = await manager.subscribe_option_quotes(symbols)
+    if not sub_success:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "option quote subscription failed",
+            }
+        )
+
+    # Retrieve cached snapshots
+    quotes = {}
+    for symbol in symbols:
+        quote = manager.get_latest_option_quote(symbol)
+        if quote:
+            quotes[symbol] = quote
+
+    if not quotes:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "no cached option quote snapshot",
+            }
+        )
+
+    return create_success_response(
+        {
+            "status": "success",
+            "quotes": quotes,
+            "count": len(quotes),
+        }
+    )

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -255,6 +255,13 @@ class TestToolRegistration:
         assert "schwab_open_option_orders" in tool_names
 
     @pytest.mark.asyncio
+    async def test_schwab_streaming_tools_are_registered(self) -> None:
+        """Test that Schwab streaming tools are registered."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+        assert "schwab_stream_option_quotes" in tool_names
+
+    @pytest.mark.asyncio
     async def test_account_info_tool_callable(self) -> None:
         """Test that account_info tool is callable."""
         tools_list = await mcp.list_tools()

--- a/tests/unit/test_capabilities_and_streaming.py
+++ b/tests/unit/test_capabilities_and_streaming.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -19,36 +20,36 @@ class MockBroker(BaseBroker):
     async def logout(self) -> None:
         pass
 
-    async def get_account_info(self):
+    async def get_account_info(self) -> dict[str, Any]:
         return {}
 
-    async def get_portfolio(self):
+    async def get_portfolio(self) -> dict[str, Any]:
         return {}
 
-    async def get_positions(self):
+    async def get_positions(self) -> dict[str, Any]:
         return {}
 
-    async def get_stock_quote(self, symbol):
+    async def get_stock_quote(self, symbol: str) -> dict[str, Any]:
         return {}
 
-    async def get_stock_price(self, symbol):
+    async def get_stock_price(self, symbol: str) -> dict[str, Any]:
         return {}
 
-    async def order_buy_market(self, symbol, quantity):
+    async def order_buy_market(self, symbol: str, quantity: float) -> dict[str, Any]:
         return {}
 
-    async def order_sell_market(self, symbol, quantity):
+    async def order_sell_market(self, symbol: str, quantity: float) -> dict[str, Any]:
         return {}
 
 
-def test_broker_capabilities_defaults():
+def test_broker_capabilities_defaults() -> None:
     capabilities = BrokerCapabilities()
     assert not capabilities.streaming_quotes
     assert not capabilities.options
     assert not capabilities.crypto
 
 
-def test_base_broker_health_status():
+def test_base_broker_health_status() -> None:
     broker = MockBroker("test_broker")
     broker._auth_info.status = BrokerAuthStatus.AUTHENTICATED
     broker._capabilities.streaming_quotes = True
@@ -62,7 +63,7 @@ def test_base_broker_health_status():
 
 
 @pytest.mark.asyncio
-async def test_schwab_stream_manager_handling():
+async def test_schwab_stream_manager_handling() -> None:
     from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
 
     mock_broker = MagicMock()
@@ -76,13 +77,72 @@ async def test_schwab_stream_manager_handling():
 
     manager._handle_message(message)
     quote = manager.get_latest_quote("AAPL")
+    assert quote is not None
     assert quote["1"] == 150.0
     assert quote["2"] == 151.0
 
 
+@pytest.mark.asyncio
+async def test_schwab_stream_manager_option_quote_handling() -> None:
+    from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
+
+    mock_broker = MagicMock()
+    manager = SchwabStreamManager(mock_broker)
+
+    # Test option message handling
+    message = {
+        "service": "LEVELONE_OPTIONS",
+        "content": [{"key": "AAPL  260619C00150000", "1": 12.34, "2": 12.55}],
+    }
+
+    manager._handle_message(message)
+    quote = manager.get_latest_option_quote("AAPL  260619C00150000")
+    assert quote is not None
+    assert quote["1"] == 12.34
+    assert quote["2"] == 12.55
+
+    # Verify equity cache is separate
+    assert manager.get_latest_quote("AAPL") is None
+
+
+@pytest.mark.asyncio
+async def test_schwab_stream_manager_subscribe_option_quotes() -> None:
+    from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
+
+    mock_broker = MagicMock()
+    manager = SchwabStreamManager(mock_broker)
+    manager._is_running = True
+    manager.stream_client = AsyncMock()
+
+    success = await manager.subscribe_option_quotes(["AAPL  260619C00150000"])
+    assert success is True
+    manager.stream_client.level_one_option_subs.assert_awaited_once_with(
+        ["AAPL  260619C00150000"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_schwab_stream_manager_subscribe_quotes_splitting() -> None:
+    from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
+
+    mock_broker = MagicMock()
+    manager = SchwabStreamManager(mock_broker)
+    manager._is_running = True
+    manager.stream_client = AsyncMock()
+
+    symbols = ["AAPL", "AAPL  260619C00150000"]
+    success = await manager.subscribe_quotes(symbols)
+    assert success is True
+
+    manager.stream_client.level_one_equity_subs.assert_awaited_once_with(["AAPL"])
+    manager.stream_client.level_one_option_subs.assert_awaited_once_with(
+        ["AAPL  260619C00150000"]
+    )
+
+
 @patch("schwab.streaming.StreamClient")
 @pytest.mark.asyncio
-async def test_schwab_stream_manager_start(mock_stream_client_class):
+async def test_schwab_stream_manager_start(mock_stream_client_class: MagicMock) -> None:
     from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
 
     mock_broker = MagicMock()
@@ -94,7 +154,7 @@ async def test_schwab_stream_manager_start(mock_stream_client_class):
     # Mock login to avoid actual connection
     mock_stream_client = mock_stream_client_class.return_value
 
-    async def async_none():
+    async def async_none() -> None:
         return None
 
     mock_stream_client.login = MagicMock(return_value=async_none())

--- a/tests/unit/test_schwab_streaming_tools.py
+++ b/tests/unit/test_schwab_streaming_tools.py
@@ -1,0 +1,75 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.schwab_streaming_tools import schwab_stream_option_quotes
+
+
+@pytest.mark.asyncio
+async def test_schwab_stream_option_quotes_success() -> None:
+    mock_broker = MagicMock()
+    mock_broker.get_health_status.return_value = {
+        "capabilities": {"streaming_quotes": True}
+    }
+    mock_broker.stream_manager.is_running = True
+    mock_broker.stream_manager.subscribe_option_quotes = AsyncMock(return_value=True)
+    mock_broker.stream_manager.get_latest_option_quote.return_value = {
+        "key": "AAPL  260619C00150000",
+        "1": 12.34,
+        "2": 12.55,
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.schwab_streaming_tools.get_authenticated_broker_or_error",
+        AsyncMock(return_value=(mock_broker, None)),
+    ):
+        result = await schwab_stream_option_quotes(["AAPL  260619C00150000"])
+
+    assert result["result"]["status"] == "success"
+    assert "AAPL  260619C00150000" in result["result"]["quotes"]
+    assert result["result"]["count"] == 1
+    assert result["result"]["quotes"]["AAPL  260619C00150000"]["1"] == 12.34
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "capability, manager_exists, is_running, sub_success, cached_quote, expected_reason",
+    [
+        (False, True, True, True, {"1": 1.0}, "streaming capability disabled"),
+        (True, False, True, True, {"1": 1.0}, "stream manager unavailable"),
+        (True, True, False, True, {"1": 1.0}, "stream manager stopped"),
+        (True, True, True, False, {"1": 1.0}, "option quote subscription failed"),
+        (True, True, True, True, None, "no cached option quote snapshot"),
+    ],
+)
+async def test_schwab_stream_option_quotes_unavailable(
+    capability: bool,
+    manager_exists: bool,
+    is_running: bool,
+    sub_success: bool,
+    cached_quote: dict[str, Any] | None,
+    expected_reason: str,
+) -> None:
+    mock_broker = MagicMock()
+    mock_broker.get_health_status.return_value = {
+        "capabilities": {"streaming_quotes": capability}
+    }
+    if not manager_exists:
+        mock_broker.stream_manager = None
+    else:
+        mock_broker.stream_manager.is_running = is_running
+        mock_broker.stream_manager.subscribe_option_quotes = AsyncMock(
+            return_value=sub_success
+        )
+        mock_broker.stream_manager.get_latest_option_quote.return_value = cached_quote
+
+    with patch(
+        "open_stocks_mcp.tools.schwab_streaming_tools.get_authenticated_broker_or_error",
+        AsyncMock(return_value=(mock_broker, None)),
+    ):
+        result = await schwab_stream_option_quotes(["AAPL  260619C00150000"])
+
+    assert result["result"]["status"] == "stream_unavailable"
+    assert result["result"]["reason"] == expected_reason
+    assert result["result"]["symbols"] == ["AAPL  260619C00150000"]


### PR DESCRIPTION
Closes #533

## Changes
- Updated `SchwabStreamManager` to separate equity and option quote caches.
- Added `subscribe_option_quotes` and `get_latest_option_quote` to `SchwabStreamManager`.
- Implemented `schwab_stream_option_quotes` tool in a new module `schwab_streaming_tools.py`.
- Registered `schwab_stream_option_quotes` in the MCP server.
- Added comprehensive unit tests for the stream manager and the new tool.
- Added server registration tests for the new tool.

## Test plan
- Run `uv run pytest tests/unit/test_capabilities_and_streaming.py tests/unit/test_schwab_streaming_tools.py tests/server/test_server_app.py -k "option_quotes or schwab_streaming_tools_are_registered"` to verify the core logic.
- Run `uv run ruff check` and `uv run mypy` to verify linting and types.