### PR TITLE
refactor: extract get_stock_ratings into market/ratings.py

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -35,6 +35,7 @@ from open_stocks_mcp.tools.market.movers import (
     get_top_movers,
     get_top_movers_sp500,
 )
+from open_stocks_mcp.tools.market.ratings import get_stock_ratings
 from open_stocks_mcp.tools.options import (
     find_tradable_options,
     get_aggregate_positions,
@@ -78,7 +79,6 @@ from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stock_events,
     get_stock_level2_data,
     get_stock_news,
-    get_stock_ratings,
     get_stock_splits,
 )
 from open_stocks_mcp.tools.robinhood_order_tools import (

--- a/src/open_stocks_mcp/tools/market/ratings.py
+++ b/src/open_stocks_mcp/tools/market/ratings.py
@@ -1,0 +1,87 @@
+"""Stock ratings tools."""
+
+from typing import Any
+
+import robin_stocks.robinhood as rh
+
+from open_stocks_mcp.brokers.session_state import get_session_manager
+from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.error_handling import (
+    create_error_response,
+    create_no_data_response,
+    create_success_response,
+    execute_with_retry,
+    handle_robin_stocks_errors,
+    log_api_call,
+    validate_symbol,
+)
+from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
+
+
+@handle_robin_stocks_errors
+async def get_stock_ratings(symbol: str) -> dict[str, Any]:
+    """Get analyst ratings for a stock.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+
+    Returns:
+        JSON object with analyst ratings in "result" field:
+        {
+            "result": {
+                "symbol": "AAPL",
+                "summary": {
+                    "num_buy_ratings": 15,
+                    "num_hold_ratings": 5,
+                    "num_sell_ratings": 2
+                },
+                "ratings": [
+                    {
+                        "published_at": "2024-07-09T10:00:00Z",
+                        "type": "buy",
+                        "text": "Strong buy recommendation",
+                        "rating": "buy"
+                    }
+                ],
+                "ratings_published_at": "2024-07-09T10:00:00Z"
+            }
+        }
+    """
+    try:
+        # Input validation
+        if not validate_symbol(symbol):
+            return create_error_response(
+                ValueError(f"Invalid symbol format: {symbol}"), "symbol validation"
+            )
+
+        symbol = symbol.strip().upper()
+
+        # Ensure authenticated
+        session_mgr = get_session_manager()
+        if not await session_mgr.ensure_authenticated():
+            return create_error_response(
+                ValueError("Authentication required"), "authentication"
+            )
+
+        # Apply rate limiting
+        rate_limiter = get_rate_limiter()
+        await rate_limiter.acquire()
+
+        log_api_call("get_stock_ratings", symbol=symbol)
+
+        # Get ratings with retry logic
+        ratings_data = await execute_with_retry(rh.get_ratings, symbol)
+
+        if not ratings_data:
+            return create_no_data_response(
+                f"No ratings data found for symbol: {symbol}", {"symbol": symbol}
+            )
+
+        # Add symbol to response for consistency
+        ratings_data["symbol"] = symbol
+
+        return create_success_response(ratings_data)
+
+    except Exception as e:
+        logger.error(f"Failed to get ratings for {symbol}: {e}")
+        return create_error_response(e, "get_stock_ratings")

--- a/src/open_stocks_mcp/tools/robinhood_market_data_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_market_data_tools.py
@@ -21,6 +21,7 @@ from open_stocks_mcp.tools.market.movers import (
     get_top_movers,
     get_top_movers_sp500,
 )
+from open_stocks_mcp.tools.market.ratings import get_stock_ratings
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 __all__ = [
@@ -35,75 +36,6 @@ __all__ = [
     "get_top_movers",
     "get_top_movers_sp500",
 ]
-
-
-@handle_robin_stocks_errors
-async def get_stock_ratings(symbol: str) -> dict[str, Any]:
-    """Get analyst ratings for a stock.
-
-    Args:
-        symbol: Stock ticker symbol (e.g., "AAPL")
-
-    Returns:
-        JSON object with analyst ratings in "result" field:
-        {
-            "result": {
-                "symbol": "AAPL",
-                "summary": {
-                    "num_buy_ratings": 15,
-                    "num_hold_ratings": 5,
-                    "num_sell_ratings": 2
-                },
-                "ratings": [
-                    {
-                        "published_at": "2024-07-09T10:00:00Z",
-                        "type": "buy",
-                        "text": "Strong buy recommendation",
-                        "rating": "buy"
-                    }
-                ],
-                "ratings_published_at": "2024-07-09T10:00:00Z"
-            }
-        }
-    """
-    try:
-        # Input validation
-        if not validate_symbol(symbol):
-            return create_error_response(
-                ValueError(f"Invalid symbol format: {symbol}"), "symbol validation"
-            )
-
-        symbol = symbol.strip().upper()
-
-        # Ensure authenticated
-        session_mgr = get_session_manager()
-        if not await session_mgr.ensure_authenticated():
-            return create_error_response(
-                ValueError("Authentication required"), "authentication"
-            )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
-
-        log_api_call("get_stock_ratings", symbol=symbol)
-
-        # Get ratings with retry logic
-        ratings_data = await execute_with_retry(rh.get_ratings, symbol)
-
-        if not ratings_data:
-            return create_no_data_response(
-                f"No ratings data found for symbol: {symbol}", {"symbol": symbol}
-            )
-
-        # Add symbol to response for consistency
-        ratings_data["symbol"] = symbol
-
-        return create_success_response(ratings_data)
-
-    except Exception as e:
-        logger.error(f"Failed to get ratings for {symbol}: {e}")
-        return create_error_response(e, "get_stock_ratings")
 
 
 @handle_robin_stocks_errors

--- a/tests/unit/test_market_data_module_split.py
+++ b/tests/unit/test_market_data_module_split.py
@@ -12,6 +12,12 @@ from open_stocks_mcp.tools.market.movers import (
 from open_stocks_mcp.tools.market.movers import (
     get_top_movers_sp500 as movers_get_top_movers_sp500,
 )
+from open_stocks_mcp.tools.market.ratings import (
+    get_stock_ratings as ratings_get_stock_ratings,
+)
+from open_stocks_mcp.tools.robinhood_market_data_tools import (
+    get_stock_ratings as legacy_get_stock_ratings,
+)
 from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stocks_by_tag as legacy_get_stocks_by_tag,
 )
@@ -40,3 +46,6 @@ class TestMarketDataModuleSplit:
 
     def test_get_stocks_by_tag_identity(self) -> None:
         assert legacy_get_stocks_by_tag is movers_get_stocks_by_tag
+
+    def test_get_stock_ratings_identity(self) -> None:
+        assert legacy_get_stock_ratings is ratings_get_stock_ratings

--- a/tests/unit/test_market_research_tools.py
+++ b/tests/unit/test_market_research_tools.py
@@ -6,12 +6,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from open_stocks_mcp.tools.market.movers import get_top_movers_sp500
+from open_stocks_mcp.tools.market.ratings import get_stock_ratings
 from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stock_earnings,
     get_stock_events,
     get_stock_level2_data,
     get_stock_news,
-    get_stock_ratings,
     get_stock_splits,
 )
 
@@ -193,9 +193,9 @@ class TestStockRatings:
 
     @pytest.mark.journey_research
     @pytest.mark.unit
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.execute_with_retry")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.market.ratings.execute_with_retry")
+    @patch("open_stocks_mcp.tools.market.ratings.get_session_manager")
+    @patch("open_stocks_mcp.tools.market.ratings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -260,9 +260,9 @@ class TestStockRatings:
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
     @pytest.mark.journey_research
     @pytest.mark.unit
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.execute_with_retry")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.market.ratings.execute_with_retry")
+    @patch("open_stocks_mcp.tools.market.ratings.get_session_manager")
+    @patch("open_stocks_mcp.tools.market.ratings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #575

## Changes
- Add `src/open_stocks_mcp/tools/market/ratings.py` with the full `get_stock_ratings` implementation (symbol validation, auth check, rate limiting, retry logic, error handling)
- Remove the local `get_stock_ratings` definition from `robinhood_market_data_tools.py` and re-export it from `market.ratings` for legacy import compatibility
- Update `server/app.py` to import `get_stock_ratings` directly from `open_stocks_mcp.tools.market.ratings`
- Update `tests/unit/test_market_research_tools.py` to import `get_stock_ratings` from `market.ratings` and patch `open_stocks_mcp.tools.market.ratings.*` namespaces for ratings-specific tests
- Add `get_stock_ratings` identity assertion to `tests/unit/test_market_data_module_split.py`

## Test plan
- `uv run pytest tests/unit/test_market_research_tools.py tests/unit/test_market_data_module_split.py -q` → 13 passed, 16 skipped
- `uv run ruff check src/open_stocks_mcp/tools/market src/open_stocks_mcp/tools/robinhood_market_data_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_market_research_tools.py tests/unit/test_market_data_module_split.py` → All checks passed
- `uv run mypy src/open_stocks_mcp/tools src/open_stocks_mcp/server/app.py` → Success: no issues found in 41 source files