### PR TITLE
chore: cleanup (ruff, mypy)

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 
 class ConfigError(ValueError):

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -242,4 +242,3 @@ async def test_alert_dedup_cleanup_avoids_memory_growth() -> None:
 
     # Map should be empty since 1s > 0.1s
     assert "test_signal" not in collector._last_alert_at
-


### PR DESCRIPTION
## Automated code-quality cleanup

### Changes

**ruff format** (1 file):
- `tests/unit/test_monitoring.py` — removed trailing blank line

**mypy fix** (1 file):
- `src/open_stocks_mcp/config.py` — removed unused `# type: ignore[import-untyped]` on `import yaml` (stubs now available)

### Validation

| Tool | Status |
|---|---|
| `ruff check` | ✅ All checks passed |
| `ruff format` | ✅ 1 file reformatted |
| `mypy` | ✅ 0 errors (58 files) |
| `pytest` (unit) | ✅ 795 passed, 69 skipped |