### PR TITLE
refactor: extract get_stock_news into market/news.py

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -35,6 +35,7 @@ from open_stocks_mcp.tools.market.movers import (
     get_top_movers,
     get_top_movers_sp500,
 )
+from open_stocks_mcp.tools.market.news import get_stock_news
 from open_stocks_mcp.tools.market.ratings import get_stock_ratings
 from open_stocks_mcp.tools.options import (
     find_tradable_options,
@@ -78,7 +79,6 @@ from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stock_earnings,
     get_stock_events,
     get_stock_level2_data,
-    get_stock_news,
     get_stock_splits,
 )
 from open_stocks_mcp.tools.robinhood_order_tools import (

--- a/src/open_stocks_mcp/tools/market/news.py
+++ b/src/open_stocks_mcp/tools/market/news.py
@@ -1,0 +1,85 @@
+"""Stock news tools."""
+
+from typing import Any
+
+import robin_stocks.robinhood as rh
+
+from open_stocks_mcp.brokers.session_state import get_session_manager
+from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.error_handling import (
+    create_error_response,
+    create_no_data_response,
+    create_success_response,
+    execute_with_retry,
+    handle_robin_stocks_errors,
+    log_api_call,
+    validate_symbol,
+)
+from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
+
+
+@handle_robin_stocks_errors
+async def get_stock_news(symbol: str) -> dict[str, Any]:
+    """Get news stories for a stock.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+
+    Returns:
+        JSON object with news stories in "result" field:
+        {
+            "result": {
+                "symbol": "AAPL",
+                "news": [
+                    {
+                        "title": "Apple Reports Strong Q2 Results",
+                        "author": "Tech News Reporter",
+                        "published_at": "2024-07-09T14:30:00Z",
+                        "source": "TechCrunch",
+                        "summary": "Apple exceeded expectations...",
+                        "url": "https://...",
+                        "preview_image_url": "https://...",
+                        "num_clicks": 1250
+                    }
+                ],
+                "count": 20
+            }
+        }
+    """
+    try:
+        # Input validation
+        if not validate_symbol(symbol):
+            return create_error_response(
+                ValueError(f"Invalid symbol format: {symbol}"), "symbol validation"
+            )
+
+        symbol = symbol.strip().upper()
+
+        # Ensure authenticated
+        session_mgr = get_session_manager()
+        if not await session_mgr.ensure_authenticated():
+            return create_error_response(
+                ValueError("Authentication required"), "authentication"
+            )
+
+        # Apply rate limiting
+        rate_limiter = get_rate_limiter()
+        await rate_limiter.acquire()
+
+        log_api_call("get_stock_news", symbol=symbol)
+
+        # Get news with retry logic
+        news_data = await execute_with_retry(rh.get_news, symbol)
+
+        if not news_data:
+            return create_no_data_response(
+                f"No news data found for symbol: {symbol}", {"symbol": symbol}
+            )
+
+        return create_success_response(
+            {"symbol": symbol, "news": news_data, "count": len(news_data)}
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to get news for {symbol}: {e}")
+        return create_error_response(e, "get_stock_news")

--- a/src/open_stocks_mcp/tools/robinhood_market_data_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_market_data_tools.py
@@ -21,6 +21,7 @@ from open_stocks_mcp.tools.market.movers import (
     get_top_movers,
     get_top_movers_sp500,
 )
+from open_stocks_mcp.tools.market.news import get_stock_news
 from open_stocks_mcp.tools.market.ratings import get_stock_ratings
 from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
@@ -109,73 +110,6 @@ async def get_stock_earnings(symbol: str) -> dict[str, Any]:
     except Exception as e:
         logger.error(f"Failed to get earnings for {symbol}: {e}")
         return create_error_response(e, "get_stock_earnings")
-
-
-@handle_robin_stocks_errors
-async def get_stock_news(symbol: str) -> dict[str, Any]:
-    """Get news stories for a stock.
-
-    Args:
-        symbol: Stock ticker symbol (e.g., "AAPL")
-
-    Returns:
-        JSON object with news stories in "result" field:
-        {
-            "result": {
-                "symbol": "AAPL",
-                "news": [
-                    {
-                        "title": "Apple Reports Strong Q2 Results",
-                        "author": "Tech News Reporter",
-                        "published_at": "2024-07-09T14:30:00Z",
-                        "source": "TechCrunch",
-                        "summary": "Apple exceeded expectations...",
-                        "url": "https://...",
-                        "preview_image_url": "https://...",
-                        "num_clicks": 1250
-                    }
-                ],
-                "count": 20
-            }
-        }
-    """
-    try:
-        # Input validation
-        if not validate_symbol(symbol):
-            return create_error_response(
-                ValueError(f"Invalid symbol format: {symbol}"), "symbol validation"
-            )
-
-        symbol = symbol.strip().upper()
-
-        # Ensure authenticated
-        session_mgr = get_session_manager()
-        if not await session_mgr.ensure_authenticated():
-            return create_error_response(
-                ValueError("Authentication required"), "authentication"
-            )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
-
-        log_api_call("get_stock_news", symbol=symbol)
-
-        # Get news with retry logic
-        news_data = await execute_with_retry(rh.get_news, symbol)
-
-        if not news_data:
-            return create_no_data_response(
-                f"No news data found for symbol: {symbol}", {"symbol": symbol}
-            )
-
-        return create_success_response(
-            {"symbol": symbol, "news": news_data, "count": len(news_data)}
-        )
-
-    except Exception as e:
-        logger.error(f"Failed to get news for {symbol}: {e}")
-        return create_error_response(e, "get_stock_news")
 
 
 @handle_robin_stocks_errors

--- a/tests/unit/test_market_data_module_split.py
+++ b/tests/unit/test_market_data_module_split.py
@@ -12,8 +12,14 @@ from open_stocks_mcp.tools.market.movers import (
 from open_stocks_mcp.tools.market.movers import (
     get_top_movers_sp500 as movers_get_top_movers_sp500,
 )
+from open_stocks_mcp.tools.market.news import (
+    get_stock_news as news_get_stock_news,
+)
 from open_stocks_mcp.tools.market.ratings import (
     get_stock_ratings as ratings_get_stock_ratings,
+)
+from open_stocks_mcp.tools.robinhood_market_data_tools import (
+    get_stock_news as legacy_get_stock_news,
 )
 from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stock_ratings as legacy_get_stock_ratings,
@@ -49,3 +55,6 @@ class TestMarketDataModuleSplit:
 
     def test_get_stock_ratings_identity(self) -> None:
         assert legacy_get_stock_ratings is ratings_get_stock_ratings
+
+    def test_get_stock_news_identity(self) -> None:
+        assert legacy_get_stock_news is news_get_stock_news

--- a/tests/unit/test_market_research_tools.py
+++ b/tests/unit/test_market_research_tools.py
@@ -6,12 +6,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from open_stocks_mcp.tools.market.movers import get_top_movers_sp500
+from open_stocks_mcp.tools.market.news import get_stock_news
 from open_stocks_mcp.tools.market.ratings import get_stock_ratings
 from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stock_earnings,
     get_stock_events,
     get_stock_level2_data,
-    get_stock_news,
     get_stock_splits,
 )
 
@@ -399,9 +399,9 @@ class TestStockEarnings:
 class TestStockNews:
     """Test stock news functionality."""
 
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.execute_with_retry")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.market.news.execute_with_retry")
+    @patch("open_stocks_mcp.tools.market.news.get_session_manager")
+    @patch("open_stocks_mcp.tools.market.news.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -470,9 +470,9 @@ class TestStockNews:
 
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.execute_with_retry")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.market.news.execute_with_retry")
+    @patch("open_stocks_mcp.tools.market.news.get_session_manager")
+    @patch("open_stocks_mcp.tools.market.news.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #577

## Changes
- Add `src/open_stocks_mcp/tools/market/news.py` with the `get_stock_news` function and all its direct dependencies
- Remove the local `get_stock_news` implementation from `robinhood_market_data_tools.py`; re-export it from `market.news`
- Update `server/app.py` to import `get_stock_news` directly from `open_stocks_mcp.tools.market.news`
- Update `tests/unit/test_market_research_tools.py` to import from `market.news` and patch `open_stocks_mcp.tools.market.news.*` paths
- Add `test_get_stock_news_identity` assertion to `tests/unit/test_market_data_module_split.py`

## Test plan
- `uv run pytest tests/unit/test_market_research_tools.py tests/unit/test_market_data_module_split.py -q` — 14 passed, 16 skipped
- `uv run ruff check src/open_stocks_mcp/tools/market src/open_stocks_mcp/tools/robinhood_market_data_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_market_research_tools.py tests/unit/test_market_data_module_split.py` — all checks passed
- `uv run mypy src/open_stocks_mcp/tools src/open_stocks_mcp/server/app.py` — no issues found in 42 source files