### PR TITLE
refactor: extract Level II market data to market.level2 (#578)

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -34,6 +34,7 @@ from open_stocks_mcp.tools.market.earnings import (
     get_stock_events,
     get_stock_splits,
 )
+from open_stocks_mcp.tools.market.level2 import get_stock_level2_data
 from open_stocks_mcp.tools.market.movers import (
     get_stocks_by_tag,
     get_top_100,
@@ -81,9 +82,6 @@ from open_stocks_mcp.tools.robinhood_dividend_tools import (
     get_interest_payments,
     get_stock_loan_payments,
     get_total_dividends,
-)
-from open_stocks_mcp.tools.robinhood_market_data_tools import (
-    get_stock_level2_data,
 )
 from open_stocks_mcp.tools.robinhood_order_tools import (
     get_options_orders,

--- a/src/open_stocks_mcp/tools/market/level2.py
+++ b/src/open_stocks_mcp/tools/market/level2.py
@@ -1,0 +1,87 @@
+"""Level II market data tools for Robin Stocks integration."""
+
+from typing import Any
+
+import robin_stocks.robinhood as rh
+
+from open_stocks_mcp.brokers.session_state import get_session_manager
+from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.error_handling import (
+    create_error_response,
+    create_no_data_response,
+    create_success_response,
+    execute_with_retry,
+    handle_robin_stocks_errors,
+    log_api_call,
+    validate_symbol,
+)
+from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
+
+
+@handle_robin_stocks_errors
+async def get_stock_level2_data(symbol: str) -> dict[str, Any]:
+    """Get Level II market data for a stock (Gold subscription required).
+
+    Args:
+        symbol: Stock ticker symbol (e.g., "AAPL")
+
+    Returns:
+        JSON object with Level II data in "result" field:
+        {
+            "result": {
+                "symbol": "AAPL",
+                "asks": [
+                    {
+                        "price": "150.10",
+                        "quantity": "100"
+                    }
+                ],
+                "bids": [
+                    {
+                        "price": "149.90",
+                        "quantity": "200"
+                    }
+                ],
+                "updated_at": "2024-07-09T16:00:00Z"
+            }
+        }
+    """
+    try:
+        # Input validation
+        if not validate_symbol(symbol):
+            return create_error_response(
+                ValueError(f"Invalid symbol format: {symbol}"), "symbol validation"
+            )
+
+        symbol = symbol.strip().upper()
+
+        # Ensure authenticated
+        session_mgr = get_session_manager()
+        if not await session_mgr.ensure_authenticated():
+            return create_error_response(
+                ValueError("Authentication required"), "authentication"
+            )
+
+        # Apply rate limiting
+        rate_limiter = get_rate_limiter()
+        await rate_limiter.acquire()
+
+        log_api_call("get_stock_level2_data", symbol=symbol)
+
+        # Get Level II data with retry logic
+        level2_data = await execute_with_retry(rh.get_pricebook_by_symbol, symbol)
+
+        if not level2_data:
+            return create_no_data_response(
+                f"No Level II data found for symbol: {symbol} (Gold subscription may be required)",
+                {"symbol": symbol},
+            )
+
+        # Add symbol to response for consistency
+        level2_data["symbol"] = symbol
+
+        return create_success_response(level2_data)
+
+    except Exception as e:
+        logger.error(f"Failed to get Level II data for {symbol}: {e}")
+        return create_error_response(e, "get_stock_level2_data")

--- a/src/open_stocks_mcp/tools/robinhood_market_data_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_market_data_tools.py
@@ -1,25 +1,11 @@
 """Advanced market data tools for Robin Stocks integration."""
 
-from typing import Any
-
-import robin_stocks.robinhood as rh
-
-from open_stocks_mcp.brokers.session_state import get_session_manager
-from open_stocks_mcp.logging_config import logger
-from open_stocks_mcp.tools.error_handling import (
-    create_error_response,
-    create_no_data_response,
-    create_success_response,
-    execute_with_retry,
-    handle_robin_stocks_errors,
-    log_api_call,
-    validate_symbol,
-)
 from open_stocks_mcp.tools.market.earnings import (
     get_stock_earnings,
     get_stock_events,
     get_stock_splits,
 )
+from open_stocks_mcp.tools.market.level2 import get_stock_level2_data
 from open_stocks_mcp.tools.market.movers import (
     get_stocks_by_tag,
     get_top_100,
@@ -28,7 +14,6 @@ from open_stocks_mcp.tools.market.movers import (
 )
 from open_stocks_mcp.tools.market.news import get_stock_news
 from open_stocks_mcp.tools.market.ratings import get_stock_ratings
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 __all__ = [
     "get_stock_earnings",
@@ -42,74 +27,3 @@ __all__ = [
     "get_top_movers",
     "get_top_movers_sp500",
 ]
-
-
-
-
-@handle_robin_stocks_errors
-async def get_stock_level2_data(symbol: str) -> dict[str, Any]:
-    """Get Level II market data for a stock (Gold subscription required).
-
-    Args:
-        symbol: Stock ticker symbol (e.g., "AAPL")
-
-    Returns:
-        JSON object with Level II data in "result" field:
-        {
-            "result": {
-                "symbol": "AAPL",
-                "asks": [
-                    {
-                        "price": "150.10",
-                        "quantity": "100"
-                    }
-                ],
-                "bids": [
-                    {
-                        "price": "149.90",
-                        "quantity": "200"
-                    }
-                ],
-                "updated_at": "2024-07-09T16:00:00Z"
-            }
-        }
-    """
-    try:
-        # Input validation
-        if not validate_symbol(symbol):
-            return create_error_response(
-                ValueError(f"Invalid symbol format: {symbol}"), "symbol validation"
-            )
-
-        symbol = symbol.strip().upper()
-
-        # Ensure authenticated
-        session_mgr = get_session_manager()
-        if not await session_mgr.ensure_authenticated():
-            return create_error_response(
-                ValueError("Authentication required"), "authentication"
-            )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
-
-        log_api_call("get_stock_level2_data", symbol=symbol)
-
-        # Get Level II data with retry logic
-        level2_data = await execute_with_retry(rh.get_pricebook_by_symbol, symbol)
-
-        if not level2_data:
-            return create_no_data_response(
-                f"No Level II data found for symbol: {symbol} (Gold subscription may be required)",
-                {"symbol": symbol},
-            )
-
-        # Add symbol to response for consistency
-        level2_data["symbol"] = symbol
-
-        return create_success_response(level2_data)
-
-    except Exception as e:
-        logger.error(f"Failed to get Level II data for {symbol}: {e}")
-        return create_error_response(e, "get_stock_level2_data")

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -56,6 +56,34 @@ class TestServerApp:
             mock_logging.assert_called_once_with(mock_config)
 
 
+@pytest.mark.journey_system
+class TestMarketToolRegistration:
+    """Verify that all market and research tools remain registered after refactoring."""
+
+    @pytest.mark.asyncio
+    async def test_market_research_tools_are_registered(self) -> None:
+        """Test that all 10 market/research tools are registered on the mcp server."""
+        # Get the list of registered tools via list_tools method
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+
+        expected_tools = [
+            "top_movers_sp500",
+            "top_100_stocks",
+            "top_movers",
+            "stocks_by_tag",
+            "stock_ratings",
+            "stock_earnings",
+            "stock_news",
+            "stock_splits",
+            "stock_events",
+            "stock_level2_data",
+        ]
+
+        for tool_name in expected_tools:
+            assert tool_name in tool_names, f"Tool {tool_name} not registered"
+
+
 @pytest.mark.journey_account
 class TestAttemptLogin:
     """Test attempt_login functionality."""

--- a/tests/unit/test_market_data_module_split.py
+++ b/tests/unit/test_market_data_module_split.py
@@ -9,6 +9,9 @@ from open_stocks_mcp.tools.market.earnings import (
 from open_stocks_mcp.tools.market.earnings import (
     get_stock_splits as earnings_get_stock_splits,
 )
+from open_stocks_mcp.tools.market.level2 import (
+    get_stock_level2_data as level2_get_stock_level2_data,
+)
 from open_stocks_mcp.tools.market.movers import (
     get_stocks_by_tag as movers_get_stocks_by_tag,
 )
@@ -28,16 +31,19 @@ from open_stocks_mcp.tools.market.ratings import (
     get_stock_ratings as ratings_get_stock_ratings,
 )
 from open_stocks_mcp.tools.robinhood_market_data_tools import (
-    get_stock_news as legacy_get_stock_news,
-)
-from open_stocks_mcp.tools.robinhood_market_data_tools import (
-    get_stock_ratings as legacy_get_stock_ratings,
-)
-from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stock_earnings as legacy_get_stock_earnings,
 )
 from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stock_events as legacy_get_stock_events,
+)
+from open_stocks_mcp.tools.robinhood_market_data_tools import (
+    get_stock_level2_data as legacy_get_stock_level2_data,
+)
+from open_stocks_mcp.tools.robinhood_market_data_tools import (
+    get_stock_news as legacy_get_stock_news,
+)
+from open_stocks_mcp.tools.robinhood_market_data_tools import (
+    get_stock_ratings as legacy_get_stock_ratings,
 )
 from open_stocks_mcp.tools.robinhood_market_data_tools import (
     get_stock_splits as legacy_get_stock_splits,
@@ -85,3 +91,6 @@ class TestMarketDataModuleSplit:
 
     def test_get_stock_events_identity(self) -> None:
         assert legacy_get_stock_events is earnings_get_stock_events
+
+    def test_get_stock_level2_data_identity(self) -> None:
+        assert legacy_get_stock_level2_data is level2_get_stock_level2_data

--- a/tests/unit/test_market_research_tools.py
+++ b/tests/unit/test_market_research_tools.py
@@ -10,12 +10,10 @@ from open_stocks_mcp.tools.market.earnings import (
     get_stock_events,
     get_stock_splits,
 )
+from open_stocks_mcp.tools.market.level2 import get_stock_level2_data
 from open_stocks_mcp.tools.market.movers import get_top_movers_sp500
 from open_stocks_mcp.tools.market.news import get_stock_news
 from open_stocks_mcp.tools.market.ratings import get_stock_ratings
-from open_stocks_mcp.tools.robinhood_market_data_tools import (
-    get_stock_level2_data,
-)
 
 
 class TestTopMoversSP500:
@@ -690,9 +688,9 @@ class TestStockEvents:
 class TestStockLevel2Data:
     """Test stock Level II data functionality."""
 
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.execute_with_retry")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.market.level2.execute_with_retry")
+    @patch("open_stocks_mcp.tools.market.level2.get_session_manager")
+    @patch("open_stocks_mcp.tools.market.level2.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -750,9 +748,9 @@ class TestStockLevel2Data:
 
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.execute_with_retry")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.market.level2.execute_with_retry")
+    @patch("open_stocks_mcp.tools.market.level2.get_session_manager")
+    @patch("open_stocks_mcp.tools.market.level2.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -781,9 +779,9 @@ class TestStockLevel2Data:
 
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.execute_with_retry")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_market_data_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.market.level2.execute_with_retry")
+    @patch("open_stocks_mcp.tools.market.level2.get_session_manager")
+    @patch("open_stocks_mcp.tools.market.level2.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #578

## Changes
- Moved `get_stock_level2_data` implementation from `src/open_stocks_mcp/tools/robinhood_market_data_tools.py` to a new focused module `src/open_stocks_mcp/tools/market/level2.py`.
- Re-exported `get_stock_level2_data` in `src/open_stocks_mcp/tools/robinhood_market_data_tools.py` for backward compatibility.
- Updated `src/open_stocks_mcp/server/app.py` to import `get_stock_level2_data` from the new module.
- Updated `tests/unit/test_market_research_tools.py` to verify the function via the new module path and updated mock patch paths.
- Added identity assertion in `tests/unit/test_market_data_module_split.py` to ensure re-export correctness.
- Added registration test in `tests/server/test_server_app.py` to verify all 10 market/research tools remain registered as MCP tools.

## Test plan
- Verified with unit tests: `uv run pytest tests/unit/test_market_research_tools.py tests/unit/test_market_data_module_split.py -q`
- Verified server registration: `uv run pytest tests/server/test_server_app.py -q`
- Validated types and linting: `uv run ruff check` and `uv run mypy`