### PR TITLE
refactor: import options market data directly from submodule (#580)

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -43,9 +43,11 @@ from open_stocks_mcp.tools.options import (
     get_all_option_positions,
     get_open_option_positions,
     get_open_option_positions_with_details,
+    get_options_chains,
+)
+from open_stocks_mcp.tools.options.market_data import (
     get_option_historicals,
     get_option_market_data,
-    get_options_chains,
 )
 from open_stocks_mcp.tools.rate_limiter import configure_global_rate_limiter
 from open_stocks_mcp.tools.robinhood_account_features_tools import (


### PR DESCRIPTION
Closes #580

## Changes
- Updated `server/app.py` to import `get_option_market_data` and `get_option_historicals` directly from `open_stocks_mcp.tools.options.market_data` instead of from the `open_stocks_mcp.tools.options` package re-export.
- The `options/market_data.py` module, re-exports in `robinhood_options_tools.py`, and test updates were already completed by prior work (#579 and related PRs).

## Test plan
- `uv run pytest tests/unit/test_options_tools.py tests/unit/test_robinhood_options_module_split.py -q -o addopts=''` — 16 passed, 6 skipped
- `uv run ruff check` and `uv run mypy` on affected files — all clean
- `uv run pytest tests/unit/ -q -o addopts=''` — 828 passed, no regressions