### PR TITLE
refactor: finalize session pickle manager extraction

### DIFF
--- a/src/open_stocks_mcp/brokers/session_pickle.py
+++ b/src/open_stocks_mcp/brokers/session_pickle.py
@@ -124,3 +124,6 @@ class SessionPickleManager:
         return (
             self._consecutive_pickle_clear_failures >= self._max_pickle_clear_failures
         )
+
+    def reset_clear_failures(self) -> None:
+        self._consecutive_pickle_clear_failures = 0

--- a/src/open_stocks_mcp/brokers/session_state.py
+++ b/src/open_stocks_mcp/brokers/session_state.py
@@ -18,7 +18,12 @@ from open_stocks_mcp.logging_config import logger
 class SessionManager:
     """Manages Robin Stocks authentication session lifecycle."""
 
-    def __init__(self, session_timeout_hours: int = 23, max_failed_attempts: int = 3):
+    def __init__(
+        self,
+        session_timeout_hours: int = 23,
+        max_failed_attempts: int = 3,
+        pickle_manager: SessionPickleManager | None = None,
+    ) -> None:
         self.session_timeout_hours = session_timeout_hours
         self.max_failed_attempts = max_failed_attempts
         self.login_time: datetime | None = None
@@ -28,7 +33,7 @@ class SessionManager:
         self._lock = asyncio.Lock()
         self._is_authenticated = False
         self._failed_login_attempts = 0
-        self._pickle = SessionPickleManager()
+        self._pickle = pickle_manager or SessionPickleManager()
 
     def set_credentials(self, username: str, password: str) -> None:
         self.username = username
@@ -224,7 +229,7 @@ class SessionManager:
                 self.login_time = None
                 self.last_successful_call = None
                 self._failed_login_attempts = 0
-                self._pickle._consecutive_pickle_clear_failures = 0
+                self._pickle.reset_clear_failures()
 
     def clear_session_cache(self) -> bool:
         return self._clear_pickle_file()

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -6,11 +6,12 @@ import io
 from contextlib import redirect_stderr
 from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from open_stocks_mcp.brokers import session_state as session_manager_module
+from open_stocks_mcp.brokers.session_pickle import SessionPickleManager
 from open_stocks_mcp.brokers.session_state import SessionManager
 
 pytestmark = pytest.mark.unit
@@ -57,6 +58,26 @@ def test_clear_pickle_file_success_when_file_exists(tmp_path: Path) -> None:
         assert manager._clear_pickle_file() is True
 
     assert not pickle_path.exists()
+
+
+def test_session_manager_accepts_pickle_manager_dependency() -> None:
+    pickle_manager = Mock(spec=SessionPickleManager)
+    pickle_manager._clear_pickle_file.return_value = True
+    manager = SessionManager(pickle_manager=pickle_manager)
+
+    assert manager._clear_pickle_file() is True
+
+    pickle_manager._clear_pickle_file.assert_called_once_with("robinhood")
+
+
+def test_should_block_auth_retries_delegates_to_pickle_manager() -> None:
+    pickle_manager = Mock(spec=SessionPickleManager)
+    pickle_manager.should_block_auth_retries.return_value = True
+    manager = SessionManager(pickle_manager=pickle_manager)
+
+    assert manager.should_block_auth_retries() is True
+
+    pickle_manager.should_block_auth_retries.assert_called_once_with()
 
 
 def test_clear_pickle_file_success_when_file_missing(tmp_path: Path) -> None:
@@ -247,6 +268,19 @@ async def test_logout_clears_session_state() -> None:
     assert manager.login_time is None
     assert manager.last_successful_call is None
     assert manager._failed_login_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_logout_resets_pickle_clear_failures_via_manager() -> None:
+    manager = SessionManager()
+
+    with (
+        patch("open_stocks_mcp.brokers.session_state.rh.logout"),
+        patch.object(manager._pickle, "reset_clear_failures") as reset_clear_failures,
+    ):
+        await manager.logout()
+
+    reset_clear_failures.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_security.py
+++ b/tests/unit/test_session_security.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from cryptography.fernet import Fernet
 
+from open_stocks_mcp.brokers.session_pickle import SessionPickleManager
 from open_stocks_mcp.brokers.session_state import SessionManager
 
 
@@ -18,18 +19,18 @@ def tmp_tokens_dir(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def manager(tmp_tokens_dir: Path) -> Generator[SessionManager, None, None]:
-    """SessionManager with home directory patched to a temp location."""
+def manager(tmp_tokens_dir: Path) -> Generator[SessionPickleManager, None, None]:
+    """SessionPickleManager with home directory patched to a temp location."""
     with patch(
         "open_stocks_mcp.brokers.session_pickle.Path.home",
         return_value=tmp_tokens_dir.parent,
     ):
-        yield SessionManager()
+        yield SessionPickleManager()
 
 
 class TestTokensDirectoryPermissions:
     def test_directory_created_with_restricted_permissions(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         manager._get_tokens_dir()
         assert tmp_tokens_dir.exists()
@@ -37,7 +38,7 @@ class TestTokensDirectoryPermissions:
         assert mode == 0o700
 
     def test_existing_directory_permissions_are_hardened(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         # Create directory with looser permissions first
         tmp_tokens_dir.mkdir(mode=0o755, parents=True, exist_ok=True)
@@ -48,7 +49,7 @@ class TestTokensDirectoryPermissions:
 
 class TestFernetKeyManagement:
     def test_key_file_created_on_first_access(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         key = manager._get_or_create_fernet_key()
         key_path = tmp_tokens_dir / ".session.key"
@@ -56,7 +57,7 @@ class TestFernetKeyManagement:
         assert key == key_path.read_bytes()
 
     def test_key_file_has_restricted_permissions(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         manager._get_or_create_fernet_key()
         key_path = tmp_tokens_dir / ".session.key"
@@ -64,13 +65,15 @@ class TestFernetKeyManagement:
         assert mode == 0o600
 
     def test_same_key_returned_on_subsequent_calls(
-        self, manager: SessionManager
+        self, manager: SessionPickleManager
     ) -> None:
         key1 = manager._get_or_create_fernet_key()
         key2 = manager._get_or_create_fernet_key()
         assert key1 == key2
 
-    def test_valid_fernet_key_generated(self, manager: SessionManager) -> None:
+    def test_valid_fernet_key_generated(
+        self, manager: SessionPickleManager
+    ) -> None:
         key = manager._get_or_create_fernet_key()
         # Fernet key must be usable — if it's invalid Fernet() raises ValueError
         fernet = Fernet(key)
@@ -80,7 +83,7 @@ class TestFernetKeyManagement:
 
 class TestPickleEncryption:
     def test_encrypt_removes_plaintext(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -91,7 +94,7 @@ class TestPickleEncryption:
         assert not pickle_path.exists()
 
     def test_encrypt_creates_enc_file(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -103,7 +106,7 @@ class TestPickleEncryption:
         assert enc_path.exists()
 
     def test_enc_file_has_restricted_permissions(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -116,7 +119,7 @@ class TestPickleEncryption:
         assert mode == 0o600
 
     def test_encrypt_no_op_when_no_plaintext(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         manager._encrypt_pickle_if_exists()  # Should not raise
         enc_path = tmp_tokens_dir / "robinhood.pickle.enc"
@@ -125,7 +128,7 @@ class TestPickleEncryption:
 
 class TestPickleDecryption:
     def test_round_trip_preserves_content(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         original_data = b"serialized-oauth-token-data"
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
@@ -142,13 +145,13 @@ class TestPickleDecryption:
         assert pickle_path.read_bytes() == original_data
 
     def test_decrypt_returns_false_when_no_enc_file(
-        self, manager: SessionManager
+        self, manager: SessionPickleManager
     ) -> None:
         result = manager._decrypt_pickle_if_exists()
         assert result is False
 
     def test_corrupt_enc_file_is_removed(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         enc_path = tmp_tokens_dir / "robinhood.pickle.enc"
@@ -160,7 +163,7 @@ class TestPickleDecryption:
         assert not enc_path.exists()
 
     def test_decrypted_file_has_restricted_permissions(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -177,7 +180,7 @@ class TestLoginPickleReencryption:
     @pytest.mark.parametrize("login_result", [False, RuntimeError("login failed")])
     def test_login_failure_reencrypts_decrypted_pickle(
         self,
-        manager: SessionManager,
+        manager: SessionPickleManager,
         tmp_tokens_dir: Path,
         login_result: bool | RuntimeError,
     ) -> None:
@@ -199,7 +202,13 @@ class TestLoginPickleReencryption:
             return_value=return_value,
             side_effect=side_effect,
         ):
-            assert manager._login_with_device_verification("user", "pass") is False
+            session_manager = SessionManager()
+            session_manager._pickle = manager
+
+            assert (
+                session_manager._login_with_device_verification("user", "pass")
+                is False
+            )
 
         assert not pickle_path.exists()
         assert enc_path.exists()
@@ -207,7 +216,7 @@ class TestLoginPickleReencryption:
 
 class TestClearPickleFile:
     def test_clears_both_plaintext_and_encrypted(
-        self, manager: SessionManager, tmp_tokens_dir: Path
+        self, manager: SessionPickleManager, tmp_tokens_dir: Path
     ) -> None:
         tmp_tokens_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         pickle_path = tmp_tokens_dir / "robinhood.pickle"
@@ -221,6 +230,17 @@ class TestClearPickleFile:
         assert not pickle_path.exists()
         assert not enc_path.exists()
 
-    def test_clear_succeeds_when_no_files_exist(self, manager: SessionManager) -> None:
+    def test_clear_succeeds_when_no_files_exist(
+        self, manager: SessionPickleManager
+    ) -> None:
         result = manager._clear_pickle_file()
         assert result is True
+
+    def test_reset_clear_failures_allows_auth_retries(
+        self, manager: SessionPickleManager
+    ) -> None:
+        manager._consecutive_pickle_clear_failures = 3
+
+        manager.reset_clear_failures()
+
+        assert manager.should_block_auth_retries() is False


### PR DESCRIPTION
Closes #582

## Changes
- Add `SessionPickleManager.reset_clear_failures()` so retry-block state is owned by the pickle manager.
- Allow `SessionManager` to receive an injected `SessionPickleManager` and reset clear-failure state through delegation.
- Update focused tests to exercise `SessionPickleManager` directly and assert session-manager delegation.

## Test plan
- `uv run pytest tests/unit/test_session_security.py tests/unit/test_session_manager.py tests/unit/test_security_umask.py -q`
- `uv run ruff check src/open_stocks_mcp/brokers/session_pickle.py src/open_stocks_mcp/brokers/session_state.py src/open_stocks_mcp/tools/session_manager.py tests/unit/test_session_security.py tests/unit/test_session_manager.py tests/unit/test_security_umask.py`
- `uv run mypy src/open_stocks_mcp/brokers/session_pickle.py src/open_stocks_mcp/brokers/session_state.py src/open_stocks_mcp/tools/session_manager.py`