### PR TITLE
docs: add full read-only ADK eval suite reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,7 @@ if isinstance(order_result, dict) and 'non_field_errors' in order_result:
 2. Set environment variables (see above)
 3. Start Docker server: `cd examples/open-stocks-mcp-docker && docker-compose up -d`
 4. From project root: `MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json`
+5. **Full Read-Only Suite**: For the complete read-only eval suite covering all 7 categories (`0_sys_*`, `2_mkt_*`, `3_wth_*`, `4_ntf_*`, `6_prf_*`, `8_opt_*`, `9_adv_*`), see `tests/evals/ADK-testing-evals.md` for the full manifest and per-category run commands. Each category eval uses the same pattern: `MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/<category>_test.json --config_file_path tests/evals/test_config.json`
 
 ### Phase 8 Development Priorities
 - **Advanced Error Handling**: Granular recovery and circuit breaker patterns


### PR DESCRIPTION
Closes #184
Parent: #177

## Changes
- Added step 5 to the "Running ADK Evaluations" section in CLAUDE.md referencing the full read-only eval suite
- Points contributors to `tests/evals/ADK-testing-evals.md` for the complete 7-category manifest (`0_sys_*`, `2_mkt_*`, `3_wth_*`, `4_ntf_*`, `6_prf_*`, `8_opt_*`, `9_adv_*`) and per-category run commands

## Verification
All implementation plan checks pass on current codebase:
- ✅ All 7 read-only categories have at least one eval JSON in `tests/evals/`
- ✅ No mutating tool names (`buy_`, `sell_`, `cancel_`, `add_to_watchlist`, `remove_from_watchlist`) found in read-only eval files
- ✅ `tests/evals/ADK-testing-evals.md`, `CLAUDE.md`, and `README.md` all reference the read-only suite/`examples/google_adk_agent`
- ✅ All grandchildren (#289, #290, #292, #317, #318, #319) are CLOSED
- ✅ All direct children (#180, #181, #182, #183) are CLOSED; #184 closes with this PR

## Test plan
- Confirm `rg 'Full Read-Only Suite' CLAUDE.md` returns a match
- Confirm the format of the ADK eval command pattern in CLAUDE.md step 5 matches the standard project pattern used in ADK-testing-evals.md