### PR TITLE
docs: clarify schwab deferrals and status metadata

### DIFF
--- a/SCHWAB_STATUS.md
+++ b/SCHWAB_STATUS.md
@@ -1,6 +1,6 @@
 # Schwab Integration Status
 
-**Version**: v0.7.0-dev
+**Version**: 0.6.5
 **Branch**: main (merged from feature/schwab-integration)
 **Date**: 2025-10-06
 **Status**: ✅ **IMPLEMENTATION COMPLETE** - 🔒 **BLOCKED BY API CREDENTIALS**
@@ -30,6 +30,17 @@ The broader comparison-roadmap target (67 parity tools plus 9 Schwab bonus tools
 - #127 Schwab transaction history bonus tools
 
 Roadmap deferral and not-applicable scope decisions are tracked in #201 and mirrored in `docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md`.
+
+## Deferred and Not-Applicable Robinhood Categories
+
+This section captures the non-parity categories for Schwab and mirrors the canonical decisions in `docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md#decisions`.
+
+- **Watchlists** — **Deferred**: Schwab has no watchlist API endpoint; recommended workaround is client-managed JSON storage.
+- **Cryptocurrency** — **Not Applicable**: Schwab does not expose crypto trading in this MCP broker surface.
+- **Earnings / News / Ratings / Events / Splits** — **Deferred**: these research endpoints are not in Schwab and require third-party integration for future coverage.
+- **Robinhood-specific features (referrals, subscriptions, Gold, account features)** — **Not Applicable**: these are Robinhood platform concepts without Schwab equivalents.
+- **Historical options pricing (`get_option_historicals`)** — **Deferred**: Schwab does not expose historical options pricing data.
+- **Streaming expansion** — **Tracked Elsewhere**: tracked under issue #199 and broker-capability baseline work.
 
 ---
 

--- a/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
+++ b/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
@@ -451,12 +451,29 @@ The current implementation remains a 24-tool Schwab core. The broader parity roa
 
 ## Decisions
 
-- Watchlists: deferred to client-side storage patterns; no Schwab-native watchlist API is available.
-- Missing research data (earnings, ratings, news, events, splits): deferred to a future third-party integration; we will not add a transparent Schwab fallback that implies this data exists in Schwab.
-- Historical options pricing: unavailable in the Schwab API; this remains a documented gap unless a new external data source is added.
-- Cryptocurrency tools: not applicable to Schwab scope because Schwab does not expose crypto trading in this MCP surface.
-- Robinhood-specific referrals, subscriptions, and account-feature flags: not applicable to Schwab scope.
-- Streaming exposure: tracked through broker capability baseline work and the dedicated Schwab streaming expansion issue #199.
+### Watchlists
+- **Status**: Deferred
+- **Rationale**: Schwab does not expose a watchlist endpoint; the current workaround is client-side JSON storage (local file or database).
+
+### Cryptocurrency
+- **Status**: Not Applicable
+- **Rationale**: Schwab does not support cryptocurrency trading in this broker surface.
+
+### Earnings / News / Ratings / Events / Splits
+- **Status**: Deferred
+- **Rationale**: Schwab does not provide these research endpoints; future coverage requires third-party data integration rather than a misleading Schwab fallback.
+
+### Robinhood-Specific Platform Features (Referrals / Subscriptions / Gold / Account Features)
+- **Status**: Not Applicable
+- **Rationale**: These capabilities are Robinhood platform features with no Schwab analog.
+
+### Historical Options Pricing (`get_option_historicals`)
+- **Status**: Deferred
+- **Rationale**: Schwab does not provide historical options pricing data; this remains a documented gap unless an external data source is added.
+
+### Streaming Expansion
+- **Status**: Tracked Elsewhere
+- **Rationale**: Streaming expansion is tracked under issue #199 and broker capability baseline work, not treated as a deferred no-equivalent gap in this issue.
 
 ## Conclusion
 


### PR DESCRIPTION
Closes #201

## Changes
- rewrote `docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md` Decisions into explicit status+rationale blocks for each deferred/not-applicable category
- corrected `SCHWAB_STATUS.md` version label to `0.6.5`
- added `SCHWAB_STATUS.md` section that explicitly lists deferred/not-applicable/tracked-elsewhere Robinhood categories and rationale

## Test plan
- `grep -n "Option A\|Option B\|Option C" docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md`
- `rg -n "## Decisions" docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md`
- `rg -n "Open Questions" docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md`
- `rg -n "v0.7.0-dev" SCHWAB_STATUS.md`
- `rg -n "0.6.5" SCHWAB_STATUS.md`
- `rg -n "Deferred and Not-Applicable" SCHWAB_STATUS.md`