### PR TITLE
feat: add schwab margin status and interest tools

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -149,6 +149,12 @@ from open_stocks_mcp.tools.schwab_account_tools import (
     get_schwab_portfolio,
     get_schwab_user_preferences,
 )
+from open_stocks_mcp.tools.schwab_account_tools import (
+    schwab_check_margin_status as schwab_check_margin_status_impl,
+)
+from open_stocks_mcp.tools.schwab_account_tools import (
+    schwab_get_margin_interest as schwab_get_margin_interest_impl,
+)
 from open_stocks_mcp.tools.schwab_market_tools import (
     get_schwab_instrument,
     get_schwab_instrument_by_cusip,
@@ -1184,6 +1190,20 @@ async def schwab_account_balances(account_hash: str) -> dict[str, Any]:
         account_hash: Account hash from schwab_account_numbers
     """
     return await get_schwab_account_balances(account_hash)
+
+
+@mcp.tool()
+async def schwab_check_margin_status(account_hash: str) -> dict[str, Any]:
+    """Derive margin-call status from Schwab account balances."""
+    return await schwab_check_margin_status_impl(account_hash)
+
+
+@mcp.tool()
+async def schwab_get_margin_interest(
+    account_hash: str, start_date: str | None = None, end_date: str | None = None
+) -> dict[str, Any]:
+    """Get Schwab margin-interest charges from transaction history."""
+    return await schwab_get_margin_interest_impl(account_hash, start_date, end_date)
 
 
 @mcp.tool()

--- a/src/open_stocks_mcp/tools/schwab_account_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_account_tools.py
@@ -1,5 +1,6 @@
 """Schwab account-related MCP tools using schwab-py library."""
 
+import datetime
 from typing import Any
 
 from schwab.client import Client
@@ -252,6 +253,101 @@ async def get_schwab_account_balances(account_hash: str) -> dict[str, Any]:
 
     except Exception as e:
         logger.error(f"Error getting Schwab account balances: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_check_margin_status(account_hash: str) -> dict[str, Any]:
+    """Derive Schwab margin-call status from account balance fields."""
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"check margin status {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_account() -> Any:
+            response = broker.client.get_account(account_hash)
+            return response.json()
+
+        account_data = await execute_broker_request(_get_account, retry_safe=True)
+        securities_account = account_data.get("securitiesAccount", {})
+        current_balances = securities_account.get("currentBalances", {})
+
+        equity = float(current_balances.get("equity", 0.0) or 0.0)
+        maintenance_requirement = float(
+            current_balances.get("maintenanceRequirement", 0.0) or 0.0
+        )
+        # Schwab has no direct margin-call endpoint, so infer status from equity vs maintenance requirement.
+        margin_call = maintenance_requirement > 0 and equity <= maintenance_requirement
+        deficit = max(0.0, maintenance_requirement - equity)
+
+        return create_success_response(
+            {
+                "account_hash": account_hash,
+                "account_type": securities_account.get("type"),
+                "equity": equity,
+                "maintenance_requirement": maintenance_requirement,
+                "margin_call": margin_call,
+                "deficit": deficit,
+                "status": "success",
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error checking Schwab margin status: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_margin_interest(
+    account_hash: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> dict[str, Any]:
+    """Get Schwab margin-interest transactions from transaction history."""
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get margin interest {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+        parsed_start_date = (
+            datetime.date.fromisoformat(start_date) if start_date else None
+        )
+        parsed_end_date = datetime.date.fromisoformat(end_date) if end_date else None
+
+        def _get_transactions() -> Any:
+            response = broker.client.get_transactions(
+                account_hash,
+                start_date=parsed_start_date,
+                end_date=parsed_end_date,
+                transaction_types=[Client.Transactions.TransactionType.DIVIDEND_OR_INTEREST],
+            )
+            return response.json()
+
+        transactions = await execute_broker_request(_get_transactions, retry_safe=True)
+        margin_interest_transactions = [
+            txn
+            for txn in transactions
+            if "MARGIN INTEREST" in str(txn.get("description", "")).upper()
+        ]
+        total_charges = sum(
+            abs(float(txn.get("netAmount", 0.0) or 0.0))
+            for txn in margin_interest_transactions
+        )
+
+        return create_success_response(
+            {
+                "interest_charges": margin_interest_transactions,
+                "total_charges": total_charges,
+                "charges_count": len(margin_interest_transactions),
+                "status": "success",
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error getting Schwab margin interest: {e}")
         return create_error_response(e)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,6 +284,24 @@ def schwab_balances_payload() -> dict[str, Any]:
 
 
 @pytest.fixture
+def schwab_margin_call_balances_payload() -> dict[str, Any]:
+    """Representative Schwab balances payload with an active margin call."""
+    return broker_payloads.schwab_margin_call_balances_payload()
+
+
+@pytest.fixture
+def schwab_no_margin_call_balances_payload() -> dict[str, Any]:
+    """Representative Schwab balances payload with no margin call."""
+    return broker_payloads.schwab_no_margin_call_balances_payload()
+
+
+@pytest.fixture
+def schwab_margin_interest_transactions_payload() -> list[dict[str, Any]]:
+    """Representative Schwab transactions including margin interest charges."""
+    return broker_payloads.schwab_margin_interest_transactions_payload()
+
+
+@pytest.fixture
 def schwab_user_preferences_payload() -> dict[str, Any]:
     """Representative Schwab user preferences payload."""
     return broker_payloads.schwab_user_preferences_payload()

--- a/tests/fixtures/broker_payloads.py
+++ b/tests/fixtures/broker_payloads.py
@@ -361,6 +361,67 @@ def schwab_balances_payload() -> dict[str, Any]:
     )
 
 
+def schwab_margin_call_balances_payload() -> dict[str, Any]:
+    """Return Schwab balance data that indicates an active margin call."""
+    return _copy(
+        {
+            "securitiesAccount": {
+                "accountNumber": "12345678",
+                "type": "MARGIN",
+                "currentBalances": {
+                    "equity": 25000.0,
+                    "maintenanceRequirement": 30000.0,
+                },
+            }
+        }
+    )
+
+
+def schwab_no_margin_call_balances_payload() -> dict[str, Any]:
+    """Return Schwab balance data that indicates no margin call."""
+    return _copy(
+        {
+            "securitiesAccount": {
+                "accountNumber": "12345678",
+                "type": "MARGIN",
+                "currentBalances": {
+                    "equity": 50000.0,
+                    "maintenanceRequirement": 15000.0,
+                },
+            }
+        }
+    )
+
+
+def schwab_margin_interest_transactions_payload() -> list[dict[str, Any]]:
+    """Return Schwab transactions containing margin interest and non-interest entries."""
+    return _copy_list(
+        [
+            {
+                "transactionId": "1",
+                "type": "DIVIDEND_OR_INTEREST",
+                "description": "MARGIN INTEREST CHARGE",
+                "netAmount": -12.50,
+                "tradeDate": "2026-01-15T00:00:00+0000",
+            },
+            {
+                "transactionId": "2",
+                "type": "DIVIDEND_OR_INTEREST",
+                "description": "MARGIN INTEREST CHARGE",
+                "netAmount": -8.25,
+                "tradeDate": "2026-02-15T00:00:00+0000",
+            },
+            {
+                "transactionId": "3",
+                "type": "DIVIDEND_OR_INTEREST",
+                "description": "QUALIFIED DIVIDEND",
+                "netAmount": 5.00,
+                "tradeDate": "2026-02-20T00:00:00+0000",
+            },
+        ]
+    )
+
+
 def schwab_user_preferences_payload() -> dict[str, Any]:
     """Return representative Schwab user preferences response."""
     return _copy(

--- a/tests/unit/test_schwab_account_tools.py
+++ b/tests/unit/test_schwab_account_tools.py
@@ -14,6 +14,8 @@ from open_stocks_mcp.tools.schwab_account_tools import (
     get_schwab_all_account_data,
     get_schwab_portfolio,
     get_schwab_user_preferences,
+    schwab_check_margin_status,
+    schwab_get_margin_interest,
 )
 
 
@@ -346,3 +348,144 @@ class TestSchwabAccountTools:
         assert profile["account_count"] == 2
         assert "accounts" in profile
         assert "user_preferences" in profile
+
+
+class TestSchwabMarginTools:
+    """Test Schwab margin-status and margin-interest tools."""
+
+    @pytest.mark.journey_notifications
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
+    async def test_check_margin_status_active_call(
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_margin_call_balances_payload: dict[str, Any],
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_to_thread.return_value = schwab_margin_call_balances_payload
+
+        result = await schwab_check_margin_status("abc123")
+
+        assert result["result"]["margin_call"] is True
+        assert result["result"]["equity"] == 25000.0
+        assert result["result"]["maintenance_requirement"] == 30000.0
+        assert result["result"]["deficit"] == 5000.0
+        assert result["result"]["status"] == "success"
+
+    @pytest.mark.journey_notifications
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
+    async def test_check_margin_status_no_call(
+        self,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_no_margin_call_balances_payload: dict[str, Any],
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_to_thread.return_value = schwab_no_margin_call_balances_payload
+
+        result = await schwab_check_margin_status("abc123")
+
+        assert result["result"]["margin_call"] is False
+        assert result["result"]["deficit"] == 0.0
+
+    @pytest.mark.journey_notifications
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    async def test_check_margin_status_auth_error(
+        self,
+        mock_get_broker: AsyncMock,
+        mock_schwab_auth_error: dict[str, Any],
+    ) -> None:
+        mock_get_broker.return_value = (None, mock_schwab_auth_error)
+        result = await schwab_check_margin_status("abc123")
+        assert result == mock_schwab_auth_error
+
+    @pytest.mark.journey_notifications
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.Client")
+    async def test_get_margin_interest_filters_and_sums(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+        schwab_margin_interest_transactions_payload: list[dict[str, Any]],
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Transactions.TransactionType.DIVIDEND_OR_INTEREST = (
+            "DIVIDEND_OR_INTEREST"
+        )
+        mock_to_thread.return_value = schwab_margin_interest_transactions_payload
+
+        result = await schwab_get_margin_interest("abc123")
+
+        assert result["result"]["charges_count"] == 2
+        assert result["result"]["total_charges"] == pytest.approx(20.75)
+        descriptions = [txn["description"] for txn in result["result"]["interest_charges"]]
+        assert "QUALIFIED DIVIDEND" not in descriptions
+        for txn in result["result"]["interest_charges"]:
+            assert "transactionId" in txn
+            assert "description" in txn
+            assert "netAmount" in txn
+            assert "tradeDate" in txn
+
+    @pytest.mark.journey_notifications
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_account_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_account_tools.Client")
+    async def test_get_margin_interest_empty(
+        self,
+        mock_client: MagicMock,
+        mock_to_thread: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Transactions.TransactionType.DIVIDEND_OR_INTEREST = (
+            "DIVIDEND_OR_INTEREST"
+        )
+        mock_to_thread.return_value = []
+
+        result = await schwab_get_margin_interest("abc123")
+        assert result["result"]["charges_count"] == 0
+        assert result["result"]["total_charges"] == 0.0
+        assert result["result"]["interest_charges"] == []
+
+    @pytest.mark.journey_notifications
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_account_tools.get_authenticated_broker_or_error"
+    )
+    async def test_get_margin_interest_auth_error(
+        self,
+        mock_get_broker: AsyncMock,
+        mock_schwab_auth_error: dict[str, Any],
+    ) -> None:
+        mock_get_broker.return_value = (None, mock_schwab_auth_error)
+        result = await schwab_get_margin_interest("abc123")
+        assert result == mock_schwab_auth_error


### PR DESCRIPTION
Closes #198

## Changes
- add schwab_check_margin_status and schwab_get_margin_interest to Schwab account tools
- register both new tools in MCP server app
- add unit tests for margin-call derivation and margin-interest filtering/summing
- add fixture payloads for margin call/no-call balances and margin interest transactions

## Test plan
- uv run pytest tests/unit/test_schwab_account_tools.py -q
- uv run pytest tests/unit/ -k "schwab" -m "journey_notifications or journey_account" -q
- uv run mypy src/open_stocks_mcp/tools/schwab_account_tools.py src/open_stocks_mcp/server/app.py
- uv run ruff check src/open_stocks_mcp/tools/schwab_account_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_schwab_account_tools.py tests/fixtures/broker_payloads.py tests/conftest.py