### PR TITLE
test: extend RobinhoodBroker coverage for auth, session, and trading

### DIFF
--- a/tests/unit/test_robinhood_broker.py
+++ b/tests/unit/test_robinhood_broker.py
@@ -26,6 +26,280 @@ def unavailable_broker() -> RobinhoodBroker:
     return rb
 
 
+class TestRobinhoodBrokerConstructor:
+    """Constructor sets auth state based on credentials provided."""
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    def test_both_credentials_sets_not_authenticated(self) -> None:
+        session_mgr = MagicMock()
+        rb = RobinhoodBroker(
+            username="user@example.com",
+            password="secret",
+            session_manager=session_mgr,
+        )
+        session_mgr.set_credentials.assert_called_once_with("user@example.com", "secret")
+        assert rb._auth_info.status == BrokerAuthStatus.NOT_AUTHENTICATED
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    def test_only_username_sets_not_configured(self) -> None:
+        session_mgr = MagicMock()
+        rb = RobinhoodBroker(username="user@example.com", session_manager=session_mgr)
+        assert rb._auth_info.status == BrokerAuthStatus.NOT_CONFIGURED
+        assert rb._auth_info.error_message is not None
+        assert "password" in rb._auth_info.error_message.lower()
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    def test_only_password_sets_not_configured(self) -> None:
+        session_mgr = MagicMock()
+        rb = RobinhoodBroker(password="secret", session_manager=session_mgr)
+        assert rb._auth_info.status == BrokerAuthStatus.NOT_CONFIGURED
+        assert rb._auth_info.error_message is not None
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    def test_no_credentials_sets_not_configured_with_instructions(self) -> None:
+        session_mgr = MagicMock()
+        rb = RobinhoodBroker(session_manager=session_mgr)
+        assert rb._auth_info.status == BrokerAuthStatus.NOT_CONFIGURED
+        assert rb._auth_info.setup_instructions is not None
+        assert "ROBINHOOD_USERNAME" in rb._auth_info.setup_instructions
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    def test_broker_name_is_robinhood(self) -> None:
+        session_mgr = MagicMock()
+        rb = RobinhoodBroker(session_manager=session_mgr)
+        assert rb.name == "robinhood"
+
+
+class TestRobinhoodAuthenticate:
+    """authenticate() delegates to session_manager.ensure_authenticated()."""
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.asyncio
+    async def test_authenticate_success(self) -> None:
+        session_mgr = MagicMock()
+        session_mgr.ensure_authenticated = AsyncMock(return_value=True)
+        rb = RobinhoodBroker(session_manager=session_mgr)
+
+        result = await rb.authenticate()
+
+        assert result is True
+        assert rb._auth_info.status == BrokerAuthStatus.AUTHENTICATED
+        assert rb._auth_info.last_auth_attempt is not None
+        assert rb._auth_info.last_successful_auth is not None
+        assert rb._auth_info.error_message is None
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.asyncio
+    async def test_authenticate_failure(self) -> None:
+        session_mgr = MagicMock()
+        session_mgr.ensure_authenticated = AsyncMock(return_value=False)
+        rb = RobinhoodBroker(session_manager=session_mgr)
+
+        result = await rb.authenticate()
+
+        assert result is False
+        assert rb._auth_info.status == BrokerAuthStatus.AUTH_FAILED
+        assert rb._auth_info.last_auth_attempt is not None
+        assert rb._auth_info.error_message is not None
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.asyncio
+    async def test_authenticate_exception(self) -> None:
+        session_mgr = MagicMock()
+        session_mgr.ensure_authenticated = AsyncMock(side_effect=Exception("boom"))
+        rb = RobinhoodBroker(session_manager=session_mgr)
+
+        result = await rb.authenticate()
+
+        assert result is False
+        assert rb._auth_info.status == BrokerAuthStatus.AUTH_FAILED
+        assert rb._auth_info.error_message == "boom"
+        assert rb._auth_info.last_auth_attempt is not None
+
+
+class TestRobinhoodIsAuthenticated:
+    """is_authenticated() reflects session validity and updates TOKEN_EXPIRED."""
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.asyncio
+    async def test_valid_session_returns_true(self) -> None:
+        session_mgr = MagicMock()
+        session_mgr.is_session_valid.return_value = True
+        rb = RobinhoodBroker(session_manager=session_mgr)
+        rb._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+
+        result = await rb.is_authenticated()
+
+        assert result is True
+        assert rb._auth_info.status == BrokerAuthStatus.AUTHENTICATED
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.asyncio
+    async def test_expired_session_transitions_to_token_expired(self) -> None:
+        session_mgr = MagicMock()
+        session_mgr.is_session_valid.return_value = False
+        rb = RobinhoodBroker(session_manager=session_mgr)
+        rb._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+
+        result = await rb.is_authenticated()
+
+        assert result is False
+        assert rb._auth_info.status == BrokerAuthStatus.TOKEN_EXPIRED
+        assert rb._auth_info.error_message == "Session expired"
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.asyncio
+    async def test_unauthenticated_invalid_session_stays_not_authenticated(
+        self,
+    ) -> None:
+        session_mgr = MagicMock()
+        session_mgr.is_session_valid.return_value = False
+        rb = RobinhoodBroker(session_manager=session_mgr)
+        rb._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
+
+        result = await rb.is_authenticated()
+
+        assert result is False
+        assert rb._auth_info.status == BrokerAuthStatus.NOT_AUTHENTICATED
+
+
+class TestRobinhoodLogout:
+    """logout() clears session state and swallows exceptions."""
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.asyncio
+    async def test_logout_success_clears_status(self) -> None:
+        session_mgr = MagicMock()
+        session_mgr.logout = AsyncMock()
+        rb = RobinhoodBroker(session_manager=session_mgr)
+        rb._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+        rb._auth_info.error_message = "some prior error"
+
+        await rb.logout()
+
+        session_mgr.logout.assert_awaited_once()
+        assert rb._auth_info.status == BrokerAuthStatus.NOT_AUTHENTICATED
+        assert rb._auth_info.error_message is None
+
+    @pytest.mark.unit
+    @pytest.mark.journey_account
+    @pytest.mark.asyncio
+    async def test_logout_exception_is_swallowed(self) -> None:
+        session_mgr = MagicMock()
+        session_mgr.logout = AsyncMock(side_effect=Exception("logout error"))
+        rb = RobinhoodBroker(session_manager=session_mgr)
+        rb._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+
+        # Must not raise
+        await rb.logout()
+
+
+class TestRobinhoodTradingDelegation:
+    """order_buy_market / order_sell_market delegate with int(quantity)."""
+
+    @pytest.mark.unit
+    @pytest.mark.journey_trading
+    @pytest.mark.asyncio
+    async def test_order_buy_market_delegates_with_int_quantity(
+        self, broker: RobinhoodBroker
+    ) -> None:
+        expected = {"result": {"order_id": "abc123", "status": "queued"}}
+        with patch(
+            "open_stocks_mcp.tools.robinhood_trading_tools.order_buy_market",
+            new=AsyncMock(return_value=expected),
+        ) as mock_tool:
+            result = await broker.order_buy_market("AAPL", 3.9)
+
+        mock_tool.assert_awaited_once_with("AAPL", 3)
+        assert result == expected
+
+    @pytest.mark.unit
+    @pytest.mark.journey_trading
+    @pytest.mark.asyncio
+    async def test_order_sell_market_delegates_with_int_quantity(
+        self, broker: RobinhoodBroker
+    ) -> None:
+        expected = {"result": {"order_id": "xyz789", "status": "queued"}}
+        with patch(
+            "open_stocks_mcp.tools.robinhood_trading_tools.order_sell_market",
+            new=AsyncMock(return_value=expected),
+        ) as mock_tool:
+            result = await broker.order_sell_market("TSLA", 2.7)
+
+        mock_tool.assert_awaited_once_with("TSLA", 2)
+        assert result == expected
+
+    @pytest.mark.unit
+    @pytest.mark.journey_trading
+    @pytest.mark.asyncio
+    async def test_order_buy_market_returns_delegated_error(
+        self, broker: RobinhoodBroker
+    ) -> None:
+        delegated_error = {"result": {"status": "error", "error": "Insufficient funds"}}
+        with patch(
+            "open_stocks_mcp.tools.robinhood_trading_tools.order_buy_market",
+            new=AsyncMock(return_value=delegated_error),
+        ):
+            result = await broker.order_buy_market("AAPL", 1)
+        assert result == delegated_error
+
+    @pytest.mark.unit
+    @pytest.mark.journey_trading
+    @pytest.mark.asyncio
+    async def test_order_sell_market_returns_delegated_error(
+        self, broker: RobinhoodBroker
+    ) -> None:
+        delegated_error = {"result": {"status": "error", "error": "Position not found"}}
+        with patch(
+            "open_stocks_mcp.tools.robinhood_trading_tools.order_sell_market",
+            new=AsyncMock(return_value=delegated_error),
+        ):
+            result = await broker.order_sell_market("TSLA", 1)
+        assert result == delegated_error
+
+    @pytest.mark.unit
+    @pytest.mark.journey_trading
+    @pytest.mark.asyncio
+    async def test_order_buy_market_unavailable_returns_broker_unavailable(
+        self, unavailable_broker: RobinhoodBroker
+    ) -> None:
+        with patch(
+            "open_stocks_mcp.tools.robinhood_trading_tools.order_buy_market",
+            new=AsyncMock(),
+        ) as mock_tool:
+            result = await unavailable_broker.order_buy_market("AAPL", 1)
+
+        mock_tool.assert_not_awaited()
+        assert result["result"]["status"] == "broker_unavailable"
+
+    @pytest.mark.unit
+    @pytest.mark.journey_trading
+    @pytest.mark.asyncio
+    async def test_order_sell_market_unavailable_returns_broker_unavailable(
+        self, unavailable_broker: RobinhoodBroker
+    ) -> None:
+        with patch(
+            "open_stocks_mcp.tools.robinhood_trading_tools.order_sell_market",
+            new=AsyncMock(),
+        ) as mock_tool:
+            result = await unavailable_broker.order_sell_market("TSLA", 1)
+
+        mock_tool.assert_not_awaited()
+        assert result["result"]["status"] == "broker_unavailable"
+
+
 class TestGetStockQuoteDelegation:
     """get_stock_quote must delegate to get_stock_price tool, not return a stub."""
 


### PR DESCRIPTION
Closes #24

## Changes
- Added `TestRobinhoodBrokerConstructor`: covers both-credentials, one-credential, and no-credentials initialization paths including `set_credentials()` call assertion and `setup_instructions` presence.
- Added `TestRobinhoodAuthenticate`: covers `ensure_authenticated()` returning `True`, returning `False`, and raising an exception; asserts `BrokerAuthStatus`, `last_auth_attempt`, `last_successful_auth`, and `error_message` for each path.
- Added `TestRobinhoodIsAuthenticated`: covers valid session → `True`, authenticated broker with invalid session → `TOKEN_EXPIRED` + `"Session expired"`, and non-authenticated broker with invalid session → status unchanged.
- Added `TestRobinhoodLogout`: covers success path (status cleared to `NOT_AUTHENTICATED`, `error_message` cleared) and exception-swallowing path (no raise).
- Added `TestRobinhoodTradingDelegation`: covers `order_buy_market` and `order_sell_market` with `int(quantity)` assertion, delegated error passthrough, and `broker_unavailable` response when broker is not available.

## Test plan
- `uv run pytest tests/unit/test_robinhood_broker.py -q` → 27 passed
- `uv run pytest tests/unit/test_robinhood_broker.py tests/unit/test_broker_registry.py tests/unit/test_broker_base.py -q` → 72 passed
- `uv run ruff check tests/unit/test_robinhood_broker.py src/open_stocks_mcp/brokers/robinhood.py` → All checks passed