### PR TITLE
test: strengthen weak assertions in account, analytics, and auth tests

### DIFF
--- a/tests/unit/test_account_tools.py
+++ b/tests/unit/test_account_tools.py
@@ -81,9 +81,12 @@ class TestAccountTools:
 
         result = await get_portfolio()
 
-        assert "result" in result
-        # The actual response structure depends on how the tool processes the data
-        assert isinstance(result["result"], dict)
+        assert result["result"] == {
+            "market_value": "2000.00",
+            "equity": "2100.00",
+            "buying_power": "100.00",
+            "status": "success",
+        }
 
     @pytest.mark.journey_portfolio
     @pytest.mark.unit
@@ -153,12 +156,24 @@ class TestAccountTools:
 
         result = await get_positions()
 
-        assert "result" in result
-        # The result contains structured data with positions, count, status
-        assert isinstance(result["result"], dict)
-        assert "positions" in result["result"]
-        assert "count" in result["result"]
-        assert result["result"]["count"] == 2
+        assert result["result"] == {
+            "positions": [
+                {
+                    "symbol": "AAPL",
+                    "quantity": "10.0000",
+                    "average_buy_price": "150.00",
+                    "updated_at": "2023-01-01T00:00:00Z",
+                },
+                {
+                    "symbol": "GOOGL",
+                    "quantity": "5.0000",
+                    "average_buy_price": "2500.00",
+                    "updated_at": "2023-01-01T00:00:00Z",
+                },
+            ],
+            "count": 2,
+            "status": "success",
+        }
 
     @pytest.mark.journey_account
     @pytest.mark.unit
@@ -172,8 +187,19 @@ class TestAccountTools:
 
         result = await get_account_details()
 
-        assert "result" in result
-        assert isinstance(result["result"], dict)
+        assert result["result"] == {
+            "portfolio_equity": "2100.00",
+            "total_equity": "2100.00",
+            "account_buying_power": "1000.00",
+            "options_buying_power": "1000.00",
+            "crypto_buying_power": "1000.00",
+            "uninvested_cash": "100.00",
+            "withdrawable_cash": "100.00",
+            "cash_available_from_instant_deposits": "0.00",
+            "cash_held_for_orders": "0.00",
+            "near_margin_call": False,
+            "status": "success",
+        }
 
     @pytest.mark.journey_portfolio
     @pytest.mark.unit

--- a/tests/unit/test_analytics_tools.py
+++ b/tests/unit/test_analytics_tools.py
@@ -76,11 +76,12 @@ class TestBuildHoldings:
 
         result = await get_build_holdings()
 
-        assert "result" in result
-        assert result["result"]["status"] == "no_data"
-        assert result["result"]["total_positions"] == 0
-        assert result["result"]["holdings"] == {}
-        assert "No holdings found" in result["result"]["message"]
+        assert result["result"] == {
+            "holdings": {},
+            "total_positions": 0,
+            "message": "No holdings found",
+            "status": "no_data",
+        }
 
     @patch("open_stocks_mcp.tools.robinhood_advanced_portfolio_tools.rh.build_holdings")
     @pytest.mark.journey_research
@@ -92,11 +93,12 @@ class TestBuildHoldings:
 
         result = await get_build_holdings()
 
-        assert "result" in result
-        assert result["result"]["total_positions"] == 0
-        assert result["result"]["holdings"] == {}
-        # Empty dict is treated as no_data by the function
-        assert result["result"]["status"] == "no_data"
+        assert result["result"] == {
+            "holdings": {},
+            "total_positions": 0,
+            "message": "No holdings found",
+            "status": "no_data",
+        }
 
 
 class TestBuildUserProfile:

--- a/tests/unit/test_auth_coordinator.py
+++ b/tests/unit/test_auth_coordinator.py
@@ -327,9 +327,13 @@ class TestGetAuthenticatedBrokerOrError:
             result_broker, error = await get_authenticated_broker_or_error("test")
 
         assert result_broker is None
-        assert error is not None
-        assert "result" in error
-        assert "error" in error["result"]
+        assert error["result"] == {
+            "error": "Test authentication failed: Mock authentication failed",
+            "status": "broker_unavailable",
+            "broker": "test",
+            "auth_status": "auth_failed",
+            "requires_setup": False,
+        }
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_broker(self, fresh_registry):
@@ -343,7 +347,12 @@ class TestGetAuthenticatedBrokerOrError:
             )
 
         assert result_broker is None
-        assert error is not None
+        assert error == {
+            "result": {
+                "error": "Broker not found: nonexistent",
+                "status": "broker_not_found",
+            }
+        }
 
     @pytest.mark.asyncio
     async def test_operation_parameter_in_error(self, fresh_registry):


### PR DESCRIPTION
Closes #26

## Changes
- Hardened assertions in `tests/unit/test_account_tools.py` to verify exact portfolio, positions, and account detail values.
- Strengthened no-data assertions in `tests/unit/test_analytics_tools.py` to check the complete response payload.
- Replaced non-null error checks in `tests/unit/test_auth_coordinator.py` with exact structured error response assertions.

## Test plan
- Run `uv run pytest tests/unit/test_account_tools.py tests/unit/test_analytics_tools.py tests/unit/test_auth_coordinator.py -m "not slow and not exception_test" -q`
- Verified that hardened tests pass and accurately catch regressions in response values.