### PR TITLE
refactor: centralize MockBroker into tests/conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,84 @@
 
 pytest_plugins = ["tests.integration.live_market_harness"]
 
+import asyncio
 import contextlib
 import copy
 import json
 import os
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
+
+from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
+
+
+class MockBroker(BaseBroker):
+    """Shared mock broker for unit tests. Supports auth_delay and logout count."""
+
+    def __init__(
+        self,
+        name: str,
+        should_auth_succeed: bool = True,
+        auth_delay: float = 0,
+        configured: bool = True,
+    ):
+        super().__init__(name)
+        self._should_auth_succeed = should_auth_succeed
+        self._auth_delay = auth_delay
+        self._auth_call_count = 0
+        self._logout_call_count = 0
+
+        if configured:
+            self._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
+        else:
+            self._auth_info.status = BrokerAuthStatus.NOT_CONFIGURED
+
+    async def authenticate(self) -> bool:
+        self._auth_call_count += 1
+        if self._auth_delay > 0:
+            await asyncio.sleep(self._auth_delay)
+
+        self._auth_info.last_auth_attempt = datetime.now()
+
+        if self._should_auth_succeed:
+            self._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+            self._auth_info.last_successful_auth = datetime.now()
+            return True
+        else:
+            self._auth_info.status = BrokerAuthStatus.AUTH_FAILED
+            self._auth_info.error_message = "Mock authentication failed"
+            return False
+
+    async def is_authenticated(self) -> bool:
+        return self._auth_info.status == BrokerAuthStatus.AUTHENTICATED
+
+    async def logout(self) -> None:
+        self._logout_call_count += 1
+        self._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
+
+    async def get_account_info(self) -> dict[str, Any]:
+        return {"result": {"mock": "account"}}
+
+    async def get_portfolio(self) -> dict[str, Any]:
+        return {"result": {"mock": "portfolio"}}
+
+    async def get_positions(self) -> dict[str, Any]:
+        return {"result": {"mock": "positions"}}
+
+    async def get_stock_quote(self, symbol: str) -> dict[str, Any]:
+        return {"result": {"price": 100}}
+
+    async def get_stock_price(self, symbol: str) -> dict[str, Any]:
+        return {"result": {"price": 100}}
+
+    async def order_buy_market(self, symbol: str, quantity: float) -> dict[str, Any]:
+        return {"result": {"order": "buy"}}
+
+    async def order_sell_market(self, symbol: str, quantity: float) -> dict[str, Any]:
+        return {"result": {"order": "sell"}}
 
 try:
     import pytest_asyncio  # noqa: F401

--- a/tests/unit/test_auth_coordinator.py
+++ b/tests/unit/test_auth_coordinator.py
@@ -1,6 +1,5 @@
 """Unit tests for authentication coordinator."""
 
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -10,77 +9,9 @@ from open_stocks_mcp.brokers.auth_coordinator import (
     create_unauthenticated_tool_response,
     get_authenticated_broker_or_error,
 )
-from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
+from open_stocks_mcp.brokers.base import BrokerAuthStatus
 from open_stocks_mcp.brokers.registry import BrokerRegistry
-
-
-class MockBroker(BaseBroker):
-    """Mock broker for testing coordinator."""
-
-    def __init__(
-        self,
-        name: str,
-        should_auth_succeed: bool = True,
-        auth_delay: float = 0,
-        configured: bool = True,
-    ):
-        super().__init__(name)
-        self._should_auth_succeed = should_auth_succeed
-        self._auth_delay = auth_delay
-        self._auth_call_count = 0
-
-        # Set configured status
-        if configured:
-            self._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
-        else:
-            self._auth_info.status = BrokerAuthStatus.NOT_CONFIGURED
-
-    async def authenticate(self) -> bool:
-        """Mock authentication with optional delay."""
-        import asyncio
-
-        self._auth_call_count += 1
-        if self._auth_delay > 0:
-            await asyncio.sleep(self._auth_delay)
-
-        self._auth_info.last_auth_attempt = datetime.now()
-
-        if self._should_auth_succeed:
-            self._auth_info.status = BrokerAuthStatus.AUTHENTICATED
-            self._auth_info.last_successful_auth = datetime.now()
-            return True
-        else:
-            self._auth_info.status = BrokerAuthStatus.AUTH_FAILED
-            self._auth_info.error_message = "Mock authentication failed"
-            return False
-
-    async def is_authenticated(self) -> bool:
-        return self._auth_info.status == BrokerAuthStatus.AUTHENTICATED
-
-    async def logout(self) -> None:
-        self._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
-
-    # Required abstract method implementations
-    async def get_account_info(self):
-        return {"result": {"mock": "account"}}
-
-    async def get_portfolio(self):
-        return {"result": {"mock": "portfolio"}}
-
-    async def get_positions(self):
-        return {"result": {"mock": "positions"}}
-
-    async def get_stock_quote(self, symbol: str):
-        return {"result": {"price": 100}}
-
-    async def get_stock_price(self, symbol: str):
-        return {"result": {"price": 100}}
-
-    async def order_buy_market(self, symbol: str, quantity: float):
-        return {"result": {"order": "buy"}}
-
-    async def order_sell_market(self, symbol: str, quantity: float):
-        return {"result": {"order": "sell"}}
+from tests.conftest import MockBroker
 
 
 @pytest.fixture

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -1,11 +1,9 @@
 """Unit tests for broker registry management."""
 
 import asyncio
-from datetime import datetime
 
 import pytest
 
-from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
 from open_stocks_mcp.brokers.registry import (
     BrokerRegistry,
     RegistryNotInitializedError,
@@ -13,67 +11,7 @@ from open_stocks_mcp.brokers.registry import (
     get_broker_registry_sync,
 )
 from open_stocks_mcp.monitoring import MetricsCollector
-
-
-class MockBroker(BaseBroker):
-    """Mock broker for testing registry."""
-
-    def __init__(
-        self, name: str, should_auth_succeed: bool = True, configured: bool = True
-    ):
-        super().__init__(name)
-        self._should_auth_succeed = should_auth_succeed
-        self._auth_call_count = 0
-        self._logout_call_count = 0
-
-        # Set configured status
-        if configured:
-            self._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
-        else:
-            self._auth_info.status = BrokerAuthStatus.NOT_CONFIGURED
-
-    async def authenticate(self) -> bool:
-        """Mock authentication."""
-        self._auth_call_count += 1
-        self._auth_info.last_auth_attempt = datetime.now()
-
-        if self._should_auth_succeed:
-            self._auth_info.status = BrokerAuthStatus.AUTHENTICATED
-            self._auth_info.last_successful_auth = datetime.now()
-            return True
-        else:
-            self._auth_info.status = BrokerAuthStatus.AUTH_FAILED
-            self._auth_info.error_message = "Mock auth failed"
-            return False
-
-    async def is_authenticated(self) -> bool:
-        return self._auth_info.status == BrokerAuthStatus.AUTHENTICATED
-
-    async def logout(self) -> None:
-        self._logout_call_count += 1
-        self._auth_info.status = BrokerAuthStatus.NOT_AUTHENTICATED
-
-    # Required abstract method implementations
-    async def get_account_info(self):
-        return {"result": {"mock": "account"}}
-
-    async def get_portfolio(self):
-        return {"result": {"mock": "portfolio"}}
-
-    async def get_positions(self):
-        return {"result": {"mock": "positions"}}
-
-    async def get_stock_quote(self, symbol: str):
-        return {"result": {"price": 100}}
-
-    async def get_stock_price(self, symbol: str):
-        return {"result": {"price": 100}}
-
-    async def order_buy_market(self, symbol: str, quantity: float):
-        return {"result": {"order": "buy"}}
-
-    async def order_sell_market(self, symbol: str, quantity: float):
-        return {"result": {"order": "sell"}}
+from tests.conftest import MockBroker
 
 
 class TestBrokerRegistry:

--- a/tests/unit/test_shared_mock_broker.py
+++ b/tests/unit/test_shared_mock_broker.py
@@ -1,0 +1,115 @@
+"""Tests for the shared MockBroker helper in tests.conftest."""
+
+import pytest
+
+from open_stocks_mcp.brokers.base import BrokerAuthStatus
+from tests.conftest import MockBroker
+
+
+class TestMockBrokerSuccessfulAuth:
+    """MockBroker correctly handles successful authentication."""
+
+    @pytest.mark.asyncio
+    async def test_successful_auth_sets_authenticated_status(self):
+        broker = MockBroker("test", should_auth_succeed=True)
+        result = await broker.authenticate()
+        assert result is True
+        assert broker._auth_info.status == BrokerAuthStatus.AUTHENTICATED
+
+    @pytest.mark.asyncio
+    async def test_successful_auth_sets_timestamps(self):
+        broker = MockBroker("test", should_auth_succeed=True)
+        await broker.authenticate()
+        assert broker._auth_info.last_auth_attempt is not None
+        assert broker._auth_info.last_successful_auth is not None
+
+    @pytest.mark.asyncio
+    async def test_successful_auth_increments_call_count(self):
+        broker = MockBroker("test", should_auth_succeed=True)
+        await broker.authenticate()
+        await broker.authenticate()
+        assert broker._auth_call_count == 2
+
+
+class TestMockBrokerFailedAuth:
+    """MockBroker correctly handles authentication failure."""
+
+    @pytest.mark.asyncio
+    async def test_failed_auth_returns_false(self):
+        broker = MockBroker("test", should_auth_succeed=False)
+        result = await broker.authenticate()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_failed_auth_sets_auth_failed_status(self):
+        broker = MockBroker("test", should_auth_succeed=False)
+        await broker.authenticate()
+        assert broker._auth_info.status == BrokerAuthStatus.AUTH_FAILED
+
+    @pytest.mark.asyncio
+    async def test_failed_auth_sets_error_message(self):
+        broker = MockBroker("test", should_auth_succeed=False)
+        await broker.authenticate()
+        assert broker._auth_info.error_message is not None
+        assert len(broker._auth_info.error_message) > 0
+
+    @pytest.mark.asyncio
+    async def test_failed_auth_sets_attempt_timestamp(self):
+        broker = MockBroker("test", should_auth_succeed=False)
+        await broker.authenticate()
+        assert broker._auth_info.last_auth_attempt is not None
+
+
+class TestMockBrokerUnconfigured:
+    """MockBroker initializes to NOT_CONFIGURED when configured=False."""
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_starts_not_configured(self):
+        broker = MockBroker("test", configured=False)
+        assert broker._auth_info.status == BrokerAuthStatus.NOT_CONFIGURED
+
+    @pytest.mark.asyncio
+    async def test_configured_starts_not_authenticated(self):
+        broker = MockBroker("test", configured=True)
+        assert broker._auth_info.status == BrokerAuthStatus.NOT_AUTHENTICATED
+
+
+class TestMockBrokerAuthDelay:
+    """MockBroker respects auth_delay parameter."""
+
+    @pytest.mark.asyncio
+    async def test_auth_delay_completes(self):
+        broker = MockBroker("test", should_auth_succeed=True, auth_delay=0.01)
+        result = await broker.authenticate()
+        assert result is True
+        assert broker._auth_info.status == BrokerAuthStatus.AUTHENTICATED
+
+    @pytest.mark.asyncio
+    async def test_zero_delay_still_authenticates(self):
+        broker = MockBroker("test", should_auth_succeed=True, auth_delay=0)
+        result = await broker.authenticate()
+        assert result is True
+
+
+class TestMockBrokerLogout:
+    """MockBroker logout resets status and tracks count."""
+
+    @pytest.mark.asyncio
+    async def test_logout_resets_status_to_not_authenticated(self):
+        broker = MockBroker("test", should_auth_succeed=True)
+        await broker.authenticate()
+        assert broker._auth_info.status == BrokerAuthStatus.AUTHENTICATED
+        await broker.logout()
+        assert broker._auth_info.status == BrokerAuthStatus.NOT_AUTHENTICATED
+
+    @pytest.mark.asyncio
+    async def test_logout_increments_count(self):
+        broker = MockBroker("test")
+        await broker.logout()
+        await broker.logout()
+        assert broker._logout_call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_logout_count_starts_at_zero(self):
+        broker = MockBroker("test")
+        assert broker._logout_call_count == 0


### PR DESCRIPTION
Closes #27

## Changes
- Added shared `MockBroker` class to `tests/conftest.py` — a superset combining `auth_delay` (from auth coordinator tests) and `_logout_call_count` (from broker registry tests) with all required `BaseBroker` abstract method stubs
- Removed local `class MockBroker` from `tests/unit/test_auth_coordinator.py`; now imports from `tests.conftest`
- Removed local `class MockBroker` from `tests/unit/test_broker_registry.py`; now imports from `tests.conftest`; removed now-unused `BrokerAuthStatus` import
- Added `tests/unit/test_shared_mock_broker.py` to directly cover the shared helper contract (successful auth, failed auth, unconfigured status, auth_delay, logout count/status)

## Test plan
- `uv run pytest tests/unit/test_shared_mock_broker.py -q -o addopts=''` → 14 passed
- `uv run pytest tests/unit/test_shared_mock_broker.py tests/unit/test_auth_coordinator.py tests/unit/test_broker_registry.py -q -o addopts=''` → 65 passed
- `rg -n "^class MockBroker" tests/conftest.py tests/unit/test_auth_coordinator.py tests/unit/test_broker_registry.py` → only `tests/conftest.py:19` remains
- `uv run ruff check tests/conftest.py tests/unit/test_shared_mock_broker.py tests/unit/test_auth_coordinator.py tests/unit/test_broker_registry.py` → All checks passed