### PR TITLE
test: add unit/journey_system markers and tighten crypto placeholder assertion

### DIFF
--- a/tests/unit/test_robinhood_crypto_tools.py
+++ b/tests/unit/test_robinhood_crypto_tools.py
@@ -8,11 +8,15 @@ from open_stocks_mcp.tools.robinhood_crypto_tools import get_crypto_positions
 class TestCryptoPositionsStub:
     """get_crypto_positions must raise NotImplementedError, not return not_implemented."""
 
+    @pytest.mark.unit
+    @pytest.mark.journey_system
     @pytest.mark.asyncio
     async def test_raises_not_implemented(self) -> None:
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match="Crypto positions are not yet implemented"):
             await get_crypto_positions()
 
+    @pytest.mark.unit
+    @pytest.mark.journey_system
     @pytest.mark.asyncio
     async def test_is_not_registered_as_mcp_tool(self) -> None:
         """Confirm crypto_tools is not imported by the server module."""


### PR DESCRIPTION
Closes #29

## Changes
- Added `@pytest.mark.unit` and `@pytest.mark.journey_system` markers to both crypto placeholder tests so they participate in standard focused test selections
- Tightened `test_raises_not_implemented` to use `pytest.raises(NotImplementedError, match="Crypto positions are not yet implemented")` to pin the placeholder contract message

## Test plan
- `uv run pytest -m "unit and journey_system" tests/unit/test_robinhood_crypto_tools.py --collect-only -q` — both tests collected (was 0 before)
- `uv run pytest tests/unit/test_robinhood_crypto_tools.py -q` — 2 passed
- `uv run pytest tests/unit/test_robinhood_crypto_tools.py --cov=open_stocks_mcp.tools.robinhood_crypto_tools --cov-report=term-missing -q` — 100% coverage
- `uv run ruff check tests/unit/test_robinhood_crypto_tools.py src/open_stocks_mcp/tools/robinhood_crypto_tools.py` — all checks passed
- `uv run mypy src/open_stocks_mcp/tools/robinhood_crypto_tools.py` — no issues found