### PR TITLE
docs: align CLAUDE current version text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Project guidance for Claude Code when working with the Open Stocks MCP server.
 ## Project Overview
 
 **Open Stocks MCP** - Model Context Protocol server providing stock market data through Robin Stocks API.
-- **Current Version**: v0.6.4 with enhanced authentication and session management
+- **Current Version**: v0.6.5 with enhanced authentication and session management
 - **Framework**: FastMCP for simplified MCP development
 - **API**: Robin Stocks for market data and trading
 - **Transport**: HTTP with Server-Sent Events (SSE) on port 3001


### PR DESCRIPTION
Closes #42

## Changes
- Update CLAUDE.md Project Overview current-version line from v0.6.4 to v0.6.5
- Keep scope limited to documentation consistency with existing package/runtime versions

## Test plan
- rg -n '\*\*Current Version\*\*: v0\.6\.5' CLAUDE.md
- uv run python -c "import re,tomllib; from pathlib import Path; py=tomllib.loads(Path('pyproject.toml').read_text())['project']['version']; init=re.search(r'__version__ = \\\"([^\\\"]+)\\\"', Path('src/open_stocks_mcp/__init__.py').read_text()).group(1); claude=Path('CLAUDE.md').read_text(); assert py == init == '0.6.5'; assert f'**Current Version**: v{py}' in claude"
- git diff --check