### PR TITLE
chore: pin open-stocks-mcp version in Dockerfile (#35)

### DIFF
--- a/examples/open-stocks-mcp-docker/Dockerfile
+++ b/examples/open-stocks-mcp-docker/Dockerfile
@@ -20,8 +20,9 @@ RUN groupadd --gid 1001 mcp && \
 WORKDIR /usr/src/app
 
 # Install the open-stocks-mcp package from PyPI
-# Use the latest version with HTTP transport support
-RUN pip install --no-cache-dir --upgrade open-stocks-mcp
+# Use a pinned version matching the current project release
+ARG OPEN_STOCKS_MCP_VERSION=0.6.5
+RUN pip install --no-cache-dir --upgrade open-stocks-mcp==${OPEN_STOCKS_MCP_VERSION}
 
 # Verify that the package and its dependencies are installed correctly
 RUN pip check && \

--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -21,7 +21,7 @@ This setup uses a production-ready approach:
 ### 1. Choose Your Setup
 
 **Production (Recommended):**
-Uses the published PyPI package (v0.5.5 with full trading support):
+Uses the published PyPI package (v0.6.5 with full trading support):
 ```bash
 docker-compose up
 ```
@@ -101,7 +101,7 @@ INFO -   - Health Check: http://0.0.0.0:3001/health
 
 Run the server using Docker Compose:
 
-**Production (Recommended - v0.5.5 with trading support):**
+**Production (Recommended - v0.6.5 with trading support):**
 ```bash
 # Foreground (see logs)
 docker-compose up
@@ -182,7 +182,7 @@ This script automatically:
 ```bash
 # Health check endpoint
 curl http://localhost:3001/health
-# Returns: {"status":"healthy","version":"0.5.5","transport":"http"}
+# Returns: {"status":"healthy","version":"0.6.5","transport":"http"}
 
 # Server information
 curl http://localhost:3001/
@@ -303,7 +303,7 @@ Adjust these in `docker-compose.yml` based on your needs.
 
 ## Version Information
 
-**Current Release: v0.5.5**
+**Current Release: v0.6.5**
 - ✅ HTTP transport with Server-Sent Events (SSE)
 - ✅ FastAPI-based server with comprehensive middleware
 - ✅ Security headers and CORS support
@@ -314,7 +314,7 @@ Adjust these in `docker-compose.yml` based on your needs.
 - ✅ Full backward compatibility with STDIO transport
 
 **Container Image:**
-- **Production**: Uses PyPI package `open-stocks-mcp==0.5.5`
+- **Production**: Uses PyPI package `open-stocks-mcp==0.6.5`
 - **Development**: Built from source with latest features
 - **Base**: Python 3.11-slim for security and performance
 
@@ -322,7 +322,7 @@ Adjust these in `docker-compose.yml` based on your needs.
 - ✅ **Market Orders**: `buy_stock_market` tested with XOM
 - ✅ **Limit Orders**: `buy_stock_limit` tested with XOM at $95
 - ✅ **Order Cancellation**: Both individual and bulk cancellation tested
-- ✅ **API Reliability**: Fixed critical trading API bugs in v0.5.5
+- ✅ **API Reliability**: Fixed critical trading API bugs in v0.6.5
 - ✅ **Safety Features**: Robinhood safety mechanisms working (market → limit conversion)
 
 ## Security Features

--- a/tests/unit/test_docker_example.py
+++ b/tests/unit/test_docker_example.py
@@ -1,0 +1,59 @@
+import pathlib
+import tomllib
+
+import pytest
+
+# Paths relative to the project root
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
+PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
+DOCKERFILE_PATH = PROJECT_ROOT / "examples" / "open-stocks-mcp-docker" / "Dockerfile"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_dockerfile_version_matches_pyproject():
+    """
+    Verify that the Dockerfile defines a package version build arg
+    that matches the current version in pyproject.toml.
+    """
+    # Read version from pyproject.toml
+    with open(PYPROJECT_PATH, "rb") as f:
+        pyproject_data = tomllib.load(f)
+    expected_version = pyproject_data["project"]["version"]
+
+    # Read Dockerfile content
+    dockerfile_content = DOCKERFILE_PATH.read_text()
+
+    # Assert ARG OPEN_STOCKS_MCP_VERSION=x.y.z exists and matches
+    arg_line = f"ARG OPEN_STOCKS_MCP_VERSION={expected_version}"
+    assert arg_line in dockerfile_content, (
+        f"Dockerfile must contain '{arg_line}' to match project version."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_dockerfile_uses_versioned_install():
+    """
+    Verify that the Dockerfile uses the OPEN_STOCKS_MCP_VERSION build arg
+    to install the package from PyPI.
+    """
+    # Read Dockerfile content
+    dockerfile_content = DOCKERFILE_PATH.read_text()
+
+    # The Dockerfile should define the ARG
+    assert "ARG OPEN_STOCKS_MCP_VERSION=" in dockerfile_content
+
+    # The install command should use the variable
+    # Expected: RUN pip install --no-cache-dir --upgrade open-stocks-mcp==${OPEN_STOCKS_MCP_VERSION}
+    install_command = "RUN pip install --no-cache-dir --upgrade open-stocks-mcp==${OPEN_STOCKS_MCP_VERSION}"
+    assert install_command in dockerfile_content, (
+        "Dockerfile install command must use the pinned version: open-stocks-mcp==${OPEN_STOCKS_MCP_VERSION}"
+    )
+
+    # Ensure the unversioned command is NOT present as a standalone line
+    # (We check for the line ending to avoid substring matches with the versioned command)
+    unversioned_command = "RUN pip install --no-cache-dir --upgrade open-stocks-mcp"
+    assert unversioned_command + "\n" not in dockerfile_content, (
+        "Dockerfile contains an unversioned install command; it must be replaced with the versioned one."
+    )


### PR DESCRIPTION
Closes #35

## Changes
- Added `ARG OPEN_STOCKS_MCP_VERSION=0.6.5` to `examples/open-stocks-mcp-docker/Dockerfile` to ensure deterministic builds.
- Updated `pip install` command in Dockerfile to use the pinned version.
- Updated `examples/open-stocks-mcp-docker/README.md` to reflect the current release version (v0.6.5) across all sections.
- Added `tests/unit/test_docker_example.py` to verify that the Dockerfile version matches `pyproject.toml` and is correctly used in the install command.

## Test plan
- Run `uv run pytest tests/unit/test_docker_example.py -v` to verify the version pin and installation command logic.
- Verify `ruff` check and format pass on the new test file.