### PR TITLE
fix: use Docker-managed named volumes for token storage

### DIFF
--- a/examples/open-stocks-mcp-docker/Dockerfile
+++ b/examples/open-stocks-mcp-docker/Dockerfile
@@ -30,6 +30,10 @@ RUN pip check && \
 # Change ownership of the working directory to the mcp user
 RUN chown -R mcp:mcp /usr/src/app
 
+# Pre-create the token directory with owner-only permissions so the
+# Docker-managed named volume is writable by the non-root mcp user.
+RUN install -d -m 700 -o mcp -g mcp /home/mcp/.tokens
+
 # Switch to the non-root user
 USER mcp
 

--- a/examples/open-stocks-mcp-docker/Dockerfile.dev
+++ b/examples/open-stocks-mcp-docker/Dockerfile.dev
@@ -36,6 +36,10 @@ RUN pip check && \
 # Change ownership of the working directory to the mcp user
 RUN chown -R mcp:mcp /usr/src/app
 
+# Pre-create the token directory with owner-only permissions so the
+# Docker-managed named volume is writable by the non-root mcp user.
+RUN install -d -m 700 -o mcp -g mcp /home/mcp/.tokens
+
 # Switch to the non-root user
 USER mcp
 

--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -93,7 +93,7 @@ INFO -   - Health Check: http://0.0.0.0:3001/health
 - ✅ Container status shows `healthy`
 - ✅ Logs show "Login successful with device verification"
 - ✅ Logs show "Starting HTTP MCP server on 0.0.0.0:3001"
-- ✅ Session file created at `./data/tokens/robinhood.pickle` (persistent)
+- ✅ Session token persisted in the Docker-managed `mcp_tokens` volume
 - ✅ Log file created at `./data/logs/open_stocks_mcp.log` (persistent)
 - ✅ Health check responds: `curl http://localhost:3001/health`
 
@@ -278,20 +278,22 @@ docker-compose logs --since="1h"
 
 ### Persistent Storage
 
-The Docker setup includes persistent volumes to preserve data across container restarts:
+The Docker setup uses two persistent volumes:
 
-```
-data/
-├── tokens/     # Robinhood session tokens (robinhood.pickle)
-└── logs/       # Application logs (open_stocks_mcp.log)
-```
+| Volume | Location | Type | Contents |
+|--------|----------|------|----------|
+| `mcp_tokens` | `/home/mcp/.tokens` | Docker-managed named volume | Robinhood session tokens |
+| `mcp_logs` | `/home/mcp/.local/state/mcp-servers/logs` | Host bind mount (`./data/logs/`) | Application logs |
 
 **Benefits:**
 - **Session persistence**: Avoid re-authentication after container restarts
+- **Secure token storage**: Tokens live in a Docker-managed volume with owner-only permissions, not on the host filesystem
 - **Log retention**: Keep application logs for debugging and monitoring
-- **Data safety**: Protect against data loss during updates
 
-**Security Note**: The `data/` directory contains sensitive authentication tokens and should never be committed to version control.
+To force re-authentication (e.g. after a credential change), remove the token volume:
+```bash
+docker-compose down -v
+```
 
 ### Resource Limits
 

--- a/examples/open-stocks-mcp-docker/data/README.md
+++ b/examples/open-stocks-mcp-docker/data/README.md
@@ -1,14 +1,13 @@
 # Persistent Data Storage
 
-This directory contains persistent data for the Open Stocks MCP server:
+This directory contains host-backed persistent data for the Open Stocks MCP server:
 
-- **tokens/**: Robinhood session tokens and authentication data
 - **logs/**: Application logs and debugging information
 
-These directories are automatically mounted as Docker volumes to preserve
-data across container restarts and updates.
+Robinhood session tokens are stored in the Docker-managed `mcp_tokens` named
+volume (not on the host filesystem). Run `docker-compose down -v` to remove
+all volumes and force re-authentication.
 
 ## Security Note
 Never commit the contents of these directories to version control.
 The .gitignore file should exclude these paths.
-

--- a/examples/open-stocks-mcp-docker/docker-compose.dev.yml
+++ b/examples/open-stocks-mcp-docker/docker-compose.dev.yml
@@ -58,11 +58,6 @@ services:
 # Named volumes for persistent data
 volumes:
   mcp_tokens:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ./data/tokens
   mcp_logs:
     driver: local
     driver_opts:
@@ -78,6 +73,7 @@ volumes:
 # to 0.0.0.0 without it. Clients must send `Authorization: Bearer $MCP_API_KEY`
 # on /mcp requests.
 #
-# Persistent data will be stored in:
-# - ./data/tokens/ (Robinhood session tokens)
+# Persistent data:
+# - mcp_tokens volume (Robinhood session tokens, Docker-managed)
 # - ./data/logs/ (Application logs)
+# Run `docker-compose down -v` to remove volumes and force re-authentication.

--- a/examples/open-stocks-mcp-docker/docker-compose.yml
+++ b/examples/open-stocks-mcp-docker/docker-compose.yml
@@ -56,11 +56,6 @@ services:
 # Named volumes for persistent data
 volumes:
   mcp_tokens:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ./data/tokens
   mcp_logs:
     driver: local
     driver_opts:
@@ -80,6 +75,7 @@ volumes:
 #   python -c "import secrets; print(secrets.token_urlsafe(32))"
 # Clients must send `Authorization: Bearer $MCP_API_KEY` on /mcp requests.
 #
-# Persistent data will be stored in:
-# - ./data/tokens/ (Robinhood session tokens)
+# Persistent data:
+# - mcp_tokens volume (Robinhood session tokens, Docker-managed)
 # - ./data/logs/ (Application logs)
+# Run `docker-compose down -v` to remove volumes and force re-authentication.

--- a/tests/unit/test_docker_compose_security.py
+++ b/tests/unit/test_docker_compose_security.py
@@ -1,0 +1,42 @@
+"""Regression tests: Docker compose token volumes must not use host bind mounts."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+DOCKER_DIR = Path(__file__).resolve().parents[2] / "examples" / "open-stocks-mcp-docker"
+
+COMPOSE_FILES = [
+    DOCKER_DIR / "docker-compose.yml",
+    DOCKER_DIR / "docker-compose.dev.yml",
+]
+
+
+@pytest.fixture(params=COMPOSE_FILES, ids=lambda p: p.name)
+def compose_config(request: pytest.FixtureRequest) -> dict:
+    return yaml.safe_load(request.param.read_text())
+
+
+def test_mcp_tokens_volume_is_not_bind_backed(compose_config: dict) -> None:
+    vol = compose_config.get("volumes", {}).get("mcp_tokens", {})
+    if vol is None:
+        return
+    driver_opts = vol.get("driver_opts", {})
+    assert "device" not in driver_opts, "mcp_tokens must not bind-mount a host path"
+    assert driver_opts.get("o") != "bind", "mcp_tokens must not use 'o: bind'"
+    assert driver_opts.get("type") != "none", "mcp_tokens must not use 'type: none'"
+
+
+def test_service_mounts_mcp_tokens(compose_config: dict) -> None:
+    for svc_name, svc in compose_config.get("services", {}).items():
+        vols = svc.get("volumes", [])
+        token_mounts = [
+            v
+            for v in vols
+            if isinstance(v, str) and v.startswith("mcp_tokens:")
+        ]
+        assert token_mounts, f"service '{svc_name}' must mount mcp_tokens"
+        assert any(
+            v == "mcp_tokens:/home/mcp/.tokens" for v in token_mounts
+        ), f"service '{svc_name}' must mount mcp_tokens at /home/mcp/.tokens"


### PR DESCRIPTION
Closes #39

## Changes
- Removed `driver_opts` (bind-mount config) from the `mcp_tokens` volume in both `docker-compose.yml` and `docker-compose.dev.yml`, converting it to a true Docker-managed named volume
- Added `RUN install -d -m 700 -o mcp -g mcp /home/mcp/.tokens` to both `Dockerfile` and `Dockerfile.dev` so the volume mount point has correct ownership and owner-only permissions
- Updated `README.md` persistent storage docs to explain token storage uses a Docker-managed volume, not `./data/tokens/`
- Updated `data/README.md` to clarify that only logs are host-backed
- Added `tests/unit/test_docker_compose_security.py` regression tests that parse both compose files and assert `mcp_tokens` is not bind-backed

## Test plan
- [x] `uv run pytest tests/unit/test_docker_compose_security.py -v` — 4 passed (bind-mount assertions + service mount checks)
- [x] `uv run ruff check tests/unit/test_docker_compose_security.py` — all checks passed
- [x] YAML structure validated programmatically (Docker CLI not available in CI worktree)
- [x] `git diff --check` — no whitespace errors
- [ ] Manually verify `docker-compose up` starts correctly with the named volume (requires Docker)

> **Migration note**: Existing users with sessions in `./data/tokens/` will need to re-authenticate after this change, as tokens move to the Docker-managed volume. The updated README explains this.