### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,4 +379,3 @@ examples/kubernetes/secret.yaml
 .foreman/
 .agents/
 .beads/
-foreman.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,4 @@ examples/kubernetes/secret.yaml
 .foreman/
 .agents/
 .beads/
+foreman.yaml

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1896,6 +1896,8 @@ async def schwab_open_option_orders(
         max_results: Maximum orders to fetch before filtering (default 50)
     """
     return await _schwab_get_open_option_orders_impl(account_hash, max_results)
+
+
 # Schwab Streaming Tools
 @mcp.tool()
 async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:

--- a/src/open_stocks_mcp/tools/market/movers.py
+++ b/src/open_stocks_mcp/tools/market/movers.py
@@ -268,14 +268,9 @@ async def get_stocks_by_tag(tag: str) -> dict[str, Any]:
     stocks_data = await execute_with_retry(rh.get_all_stocks_from_market_tag, tag)
 
     if not stocks_data or stocks_data == [None]:
-        return create_no_data_response(
-            f"No stocks found for tag: {tag}", {"tag": tag}
-        )
+        return create_no_data_response(f"No stocks found for tag: {tag}", {"tag": tag})
 
     # Filter out None values and ensure we have valid data
     stocks = [stock for stock in stocks_data if stock is not None]
 
-    return create_success_response(
-        {"tag": tag, "stocks": stocks, "count": len(stocks)}
-    )
-
+    return create_success_response({"tag": tag, "stocks": stocks, "count": len(stocks)})

--- a/src/open_stocks_mcp/tools/options/chains.py
+++ b/src/open_stocks_mcp/tools/options/chains.py
@@ -243,5 +243,3 @@ async def find_tradable_options(
             "status": "success",
         }
     }
-
-

--- a/src/open_stocks_mcp/tools/options/market_data.py
+++ b/src/open_stocks_mcp/tools/options/market_data.py
@@ -228,5 +228,3 @@ async def get_option_historicals(
             "status": "success",
         }
     }
-
-

--- a/tests/unit/test_market_tools.py
+++ b/tests/unit/test_market_tools.py
@@ -48,9 +48,7 @@ class TestMarketTools:
 
     @pytest.mark.journey_market_data
     @pytest.mark.unit
-    @patch(
-        "open_stocks_mcp.tools.market.movers.rh.get_all_stocks_from_market_tag"
-    )
+    @patch("open_stocks_mcp.tools.market.movers.rh.get_all_stocks_from_market_tag")
     @pytest.mark.asyncio
     async def test_get_stocks_by_tag_success(
         self, mock_stocks: Any, mock_robinhood_market_tag: list[dict[str, Any]]

--- a/tests/unit/test_options_tools.py
+++ b/tests/unit/test_options_tools.py
@@ -92,9 +92,7 @@ class TestOptionsChains:
 class TestFindOptions:
     """Test find tradable options functionality."""
 
-    @patch(
-        "open_stocks_mcp.tools.options.chains.rh.find_options_by_expiration"
-    )
+    @patch("open_stocks_mcp.tools.options.chains.rh.find_options_by_expiration")
     @pytest.mark.journey_options
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -125,9 +123,7 @@ class TestFindOptions:
         assert len(result["result"]["options"]) == 2
         assert result["result"]["status"] == "success"
 
-    @patch(
-        "open_stocks_mcp.tools.options.chains.rh.find_options_by_expiration"
-    )
+    @patch("open_stocks_mcp.tools.options.chains.rh.find_options_by_expiration")
     @pytest.mark.journey_options
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -316,9 +312,7 @@ class TestOptionHistoricals:
 class TestOptionPositions:
     """Test option positions retrieval."""
 
-    @patch(
-        "open_stocks_mcp.tools.options.positions.rh.options.get_aggregate_positions"
-    )
+    @patch("open_stocks_mcp.tools.options.positions.rh.options.get_aggregate_positions")
     @pytest.mark.journey_options
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -354,9 +348,7 @@ class TestOptionPositions:
         assert result["result"]["total_contracts"] == 2
         assert result["result"]["status"] == "success"
 
-    @patch(
-        "open_stocks_mcp.tools.options.positions.rh.options.get_aggregate_positions"
-    )
+    @patch("open_stocks_mcp.tools.options.positions.rh.options.get_aggregate_positions")
     @pytest.mark.journey_options
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/unit/test_session_security.py
+++ b/tests/unit/test_session_security.py
@@ -71,9 +71,7 @@ class TestFernetKeyManagement:
         key2 = manager._get_or_create_fernet_key()
         assert key1 == key2
 
-    def test_valid_fernet_key_generated(
-        self, manager: SessionPickleManager
-    ) -> None:
+    def test_valid_fernet_key_generated(self, manager: SessionPickleManager) -> None:
         key = manager._get_or_create_fernet_key()
         # Fernet key must be usable — if it's invalid Fernet() raises ValueError
         fernet = Fernet(key)
@@ -206,8 +204,7 @@ class TestLoginPickleReencryption:
             session_manager._pickle = manager
 
             assert (
-                session_manager._login_with_device_verification("user", "pass")
-                is False
+                session_manager._login_with_device_verification("user", "pass") is False
             )
 
         assert not pickle_path.exists()


### PR DESCRIPTION
## Summary

Automated code-quality cleanup run by Foreman.

**Tools applied:** `ruff check --fix`, `ruff format`

### Files changed (7)

| File | Change |
|------|--------|
| `src/open_stocks_mcp/server/app.py` | Format: added trailing newlines |
| `src/open_stocks_mcp/tools/market/movers.py` | Format: collapsed multi-line dict to single line |
| `src/open_stocks_mcp/tools/options/chains.py` | Format: removed unnecessary blank lines |
| `src/open_stocks_mcp/tools/options/market_data.py` | Format: removed unnecessary blank lines |
| `tests/unit/test_market_tools.py` | Format: collapsed multi-line expression |
| `tests/unit/test_options_tools.py` | Format: collapsed multi-line expressions |
| `tests/unit/test_session_security.py` | Format: collapsed multi-line expressions |

### Validation

- **mypy**: ✅ 0 errors
- **pytest**: ✅ 843 passed, 69 skipped, 0 failed (21s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)