### PR TITLE
feat: add Schwab equity quote streaming tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -175,6 +175,9 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
+    schwab_get_open_option_orders as _schwab_get_open_option_orders_impl,
+)
+from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_option_buy_to_open as _schwab_option_buy_to_open_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
@@ -210,6 +213,9 @@ from open_stocks_mcp.tools.schwab_streaming_tools import (
 )
 from open_stocks_mcp.tools.schwab_streaming_tools import (
     schwab_stream_option_quotes as _schwab_stream_option_quotes_impl,
+)
+from open_stocks_mcp.tools.schwab_streaming_tools import (
+    schwab_stream_quotes as _schwab_stream_quotes_impl,
 )
 from open_stocks_mcp.tools.schwab_trading_tools import (
     cancel_schwab_order,
@@ -1948,17 +1954,6 @@ async def schwab_open_option_orders(
 
 # Schwab Streaming Tools
 @mcp.tool()
-async def schwab_stream_level2(symbol: str, venue: str = "nasdaq") -> dict[str, Any]:
-    """Get real-time Level 2 order-book snapshot from Schwab streaming.
-
-    Args:
-        symbol: Ticker symbol (e.g. 'AAPL')
-        venue: 'nasdaq' or 'nyse' (default: 'nasdaq')
-    """
-    return await _schwab_stream_level2_impl(symbol, venue)
-
-
-@mcp.tool()
 async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
     """Get real-time option quote snapshots from Schwab streaming.
 
@@ -1966,6 +1961,16 @@ async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
         symbols: List of Schwab option symbols (e.g. ['AAPL  260619C00150000'])
     """
     return await _schwab_stream_option_quotes_impl(symbols)
+
+
+@mcp.tool()
+async def schwab_stream_quotes(symbols: list[str]) -> dict[str, Any]:
+    """Get real-time equity quote snapshots from Schwab streaming.
+
+    Args:
+        symbols: List of equity ticker symbols.
+    """
+    return await _schwab_stream_quotes_impl(symbols)
 
 
 @mcp.tool()

--- a/src/open_stocks_mcp/tools/schwab_streaming_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_streaming_tools.py
@@ -10,82 +10,6 @@ from open_stocks_mcp.tools.error_handling import (
 )
 
 
-async def schwab_stream_level2(symbol: str, venue: str = "nasdaq") -> dict[str, Any]:
-    """Get real-time Level 2 order-book snapshot from Schwab streaming.
-
-    Args:
-        symbol: Ticker symbol (e.g. 'AAPL')
-        venue: 'nasdaq' or 'nyse' (default: 'nasdaq')
-    """
-    broker, error = await get_authenticated_broker_or_error(
-        "schwab", f"stream Level 2 book for {symbol}"
-    )
-    if error:
-        return error
-
-    # Check streaming capability
-    health = broker.get_health_status()
-    if not health.get("capabilities", {}).get("streaming_quotes"):
-        return create_success_response(
-            {
-                "status": "stream_unavailable",
-                "symbol": symbol,
-                "reason": "streaming capability disabled",
-            }
-        )
-
-    # Check stream manager readiness
-    manager = getattr(broker, "stream_manager", None)
-    if manager is None:
-        return create_success_response(
-            {
-                "status": "stream_unavailable",
-                "symbol": symbol,
-                "reason": "stream manager unavailable",
-            }
-        )
-
-    if not manager.is_running:
-        return create_success_response(
-            {
-                "status": "stream_unavailable",
-                "symbol": symbol,
-                "reason": "stream manager stopped",
-            }
-        )
-
-    # Subscribe to Level 2
-    sub_success = await manager.subscribe_level2(symbol, venue)
-    if not sub_success:
-        return create_success_response(
-            {
-                "status": "stream_unavailable",
-                "symbol": symbol,
-                "reason": "Level 2 subscription failed",
-            }
-        )
-
-    # Retrieve cached snapshot
-    snapshot = manager.get_latest_level2(symbol)
-    if not snapshot:
-        return create_success_response(
-            {
-                "status": "stream_unavailable",
-                "symbol": symbol,
-                "reason": "no cached Level 2 snapshot",
-            }
-        )
-
-    return create_success_response(
-        {
-            "status": "success",
-            "symbol": symbol.upper(),
-            "venue": venue.lower(),
-            "snapshot": snapshot,
-        }
-    )
-
-
 async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
     """Get real-time option quote snapshots from Schwab streaming.
 
@@ -153,6 +77,81 @@ async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
                 "status": "stream_unavailable",
                 "symbols": symbols,
                 "reason": "no cached option quote snapshot",
+            }
+        )
+
+    return create_success_response(
+        {
+            "status": "success",
+            "quotes": quotes,
+            "count": len(quotes),
+        }
+    )
+
+
+async def schwab_stream_quotes(symbols: list[str]) -> dict[str, Any]:
+    """Get real-time equity quote snapshots from Schwab streaming.
+
+    Args:
+        symbols: List of equity ticker symbols (e.g. ['AAPL', 'MSFT'])
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", "stream equity quotes"
+    )
+    if error:
+        return error
+
+    health = broker.get_health_status()
+    if not health.get("capabilities", {}).get("streaming_quotes"):
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "streaming capability disabled",
+            }
+        )
+
+    manager = getattr(broker, "stream_manager", None)
+    if manager is None:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "stream manager unavailable",
+            }
+        )
+
+    if not manager.is_running:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "stream manager stopped",
+            }
+        )
+
+    sub_success = await manager.subscribe_quotes(symbols)
+    if not sub_success:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "equity quote subscription failed",
+            }
+        )
+
+    quotes = {}
+    for symbol in symbols:
+        quote = manager.get_latest_quote(symbol)
+        if quote:
+            quotes[symbol] = quote
+
+    if not quotes:
+        return create_success_response(
+            {
+                "status": "stream_unavailable",
+                "symbols": symbols,
+                "reason": "no cached equity quote snapshot",
             }
         )
 

--- a/tests/unit/test_schwab_streaming_tools.py
+++ b/tests/unit/test_schwab_streaming_tools.py
@@ -7,75 +7,8 @@ from open_stocks_mcp.tools.schwab_streaming_tools import (
     schwab_stream_account_activity,
     schwab_stream_level2,
     schwab_stream_option_quotes,
+    schwab_stream_quotes,
 )
-
-
-@pytest.mark.journey_market_data
-@pytest.mark.asyncio
-async def test_schwab_stream_level2_success() -> None:
-    mock_broker = MagicMock()
-    mock_broker.get_health_status.return_value = {
-        "capabilities": {"streaming_quotes": True}
-    }
-    mock_broker.stream_manager.is_running = True
-    mock_broker.stream_manager.subscribe_level2 = AsyncMock(return_value=True)
-    mock_broker.stream_manager.get_latest_level2.return_value = {
-        "SYMBOL": "AAPL",
-        "BIDS": [{"PRICE": 150.0}],
-    }
-
-    with patch(
-        "open_stocks_mcp.tools.schwab_streaming_tools.get_authenticated_broker_or_error",
-        AsyncMock(return_value=(mock_broker, None)),
-    ):
-        result = await schwab_stream_level2("AAPL")
-
-    assert result["result"]["status"] == "success"
-    assert result["result"]["snapshot"]["SYMBOL"] == "AAPL"
-    assert result["result"]["snapshot"]["BIDS"][0]["PRICE"] == 150.0
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "capability, manager_exists, is_running, sub_success, cached_book, expected_reason",
-    [
-        (False, True, True, True, {"1": 1.0}, "streaming capability disabled"),
-        (True, False, True, True, {"1": 1.0}, "stream manager unavailable"),
-        (True, True, False, True, {"1": 1.0}, "stream manager stopped"),
-        (True, True, True, False, {"1": 1.0}, "Level 2 subscription failed"),
-        (True, True, True, True, None, "no cached Level 2 snapshot"),
-    ],
-)
-async def test_schwab_stream_level2_unavailable(
-    capability: bool,
-    manager_exists: bool,
-    is_running: bool,
-    sub_success: bool,
-    cached_book: dict[str, Any] | None,
-    expected_reason: str,
-) -> None:
-    mock_broker = MagicMock()
-    mock_broker.get_health_status.return_value = {
-        "capabilities": {"streaming_quotes": capability}
-    }
-    if not manager_exists:
-        mock_broker.stream_manager = None
-    else:
-        mock_broker.stream_manager.is_running = is_running
-        mock_broker.stream_manager.subscribe_level2 = AsyncMock(
-            return_value=sub_success
-        )
-        mock_broker.stream_manager.get_latest_level2.return_value = cached_book
-
-    with patch(
-        "open_stocks_mcp.tools.schwab_streaming_tools.get_authenticated_broker_or_error",
-        AsyncMock(return_value=(mock_broker, None)),
-    ):
-        result = await schwab_stream_level2("AAPL")
-
-    assert result["result"]["status"] == "stream_unavailable"
-    assert result["result"]["reason"] == expected_reason
-    assert result["result"]["symbol"] == "AAPL"
 
 
 @pytest.mark.asyncio
@@ -145,6 +78,73 @@ async def test_schwab_stream_option_quotes_unavailable(
     assert result["result"]["status"] == "stream_unavailable"
     assert result["result"]["reason"] == expected_reason
     assert result["result"]["symbols"] == ["AAPL  260619C00150000"]
+
+
+@pytest.mark.asyncio
+async def test_schwab_stream_quotes_success() -> None:
+    mock_broker = MagicMock()
+    mock_broker.get_health_status.return_value = {
+        "capabilities": {"streaming_quotes": True}
+    }
+    mock_broker.stream_manager.is_running = True
+    mock_broker.stream_manager.subscribe_quotes = AsyncMock(return_value=True)
+    mock_broker.stream_manager.get_latest_quote.return_value = {
+        "key": "AAPL",
+        "1": 150.25,
+        "2": 150.30,
+        "8": 1000,
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.schwab_streaming_tools.get_authenticated_broker_or_error",
+        AsyncMock(return_value=(mock_broker, None)),
+    ):
+        result = await schwab_stream_quotes(["AAPL"])
+
+    assert result["result"]["status"] == "success"
+    assert result["result"]["count"] == 1
+    assert result["result"]["quotes"]["AAPL"]["1"] == 150.25
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "capability, manager_exists, is_running, sub_success, cached_quote, expected_reason",
+    [
+        (False, True, True, True, {"1": 1.0}, "streaming capability disabled"),
+        (True, False, True, True, {"1": 1.0}, "stream manager unavailable"),
+        (True, True, False, True, {"1": 1.0}, "stream manager stopped"),
+        (True, True, True, False, {"1": 1.0}, "equity quote subscription failed"),
+        (True, True, True, True, None, "no cached equity quote snapshot"),
+    ],
+)
+async def test_schwab_stream_quotes_unavailable(
+    capability: bool,
+    manager_exists: bool,
+    is_running: bool,
+    sub_success: bool,
+    cached_quote: dict[str, Any] | None,
+    expected_reason: str,
+) -> None:
+    mock_broker = MagicMock()
+    mock_broker.get_health_status.return_value = {
+        "capabilities": {"streaming_quotes": capability}
+    }
+    if not manager_exists:
+        mock_broker.stream_manager = None
+    else:
+        mock_broker.stream_manager.is_running = is_running
+        mock_broker.stream_manager.subscribe_quotes = AsyncMock(return_value=sub_success)
+        mock_broker.stream_manager.get_latest_quote.return_value = cached_quote
+
+    with patch(
+        "open_stocks_mcp.tools.schwab_streaming_tools.get_authenticated_broker_or_error",
+        AsyncMock(return_value=(mock_broker, None)),
+    ):
+        result = await schwab_stream_quotes(["AAPL"])
+
+    assert result["result"]["status"] == "stream_unavailable"
+    assert result["result"]["reason"] == expected_reason
+    assert result["result"]["symbols"] == ["AAPL"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #630

## Changes
- add `schwab_stream_quotes(symbols: list[str])` in `schwab_streaming_tools.py` using subscribe-then-snapshot via `subscribe_quotes` + `get_latest_quote`
- register `schwab_stream_quotes` in MCP server tool imports and `@mcp.tool()` wrappers
- add unit tests for success and unavailable paths for equity streaming quotes
- remove duplicate shadowed `schwab_stream_level2` definitions and duplicate level2 tests that were causing linter redefinition errors
- add missing `_schwab_get_open_option_orders_impl` import used by existing server tool wrapper

## Test plan
- `uv run pytest tests/unit/test_schwab_streaming_tools.py -q --tb=line`
- `uv run ruff check src/open_stocks_mcp/tools/schwab_streaming_tools.py src/open_stocks_mcp/server/app.py tests/unit/test_schwab_streaming_tools.py`
- `uv run mypy src/open_stocks_mcp/tools/schwab_streaming_tools.py src/open_stocks_mcp/server/app.py --no-error-summary`
- `uv run pytest tests/server/test_server_app.py -q --tb=line`
- `uv run pytest -m "not slow and not exception_test" -q --tb=line` (started but did not complete within this play window; no failure output captured)
