### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1956,6 +1956,12 @@ async def schwab_open_option_orders(
 
 # Schwab Streaming Tools
 @mcp.tool()
+async def schwab_stream_level2(symbol: str, venue: str = "nasdaq") -> dict[str, Any]:
+    """Get a Level 2 snapshot from Schwab streaming cache for a symbol."""
+    return await _schwab_stream_level2_impl(symbol, venue)
+
+
+@mcp.tool()
 async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
     """Get real-time option quote snapshots from Schwab streaming.
 
@@ -1973,12 +1979,6 @@ async def schwab_stream_quotes(symbols: list[str]) -> dict[str, Any]:
         symbols: List of equity ticker symbols.
     """
     return await _schwab_stream_quotes_impl(symbols)
-
-
-@mcp.tool()
-async def schwab_stream_level2(symbol: str, venue: str = "nasdaq") -> dict[str, Any]:
-    """Get a Level 2 snapshot from Schwab streaming cache for a symbol."""
-    return await _schwab_stream_level2_impl(symbol, venue)
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

Automated code-quality cleanup using ruff check --fix and ruff format.

### Lint fixes (7 errors resolved)
- **schwab_stream.py**: Removed duplicate `get_latest_level2` method (F811) + removed duplicate handler registrations in `start()`
- **server/app.py**: Added missing `schwab_get_open_option_orders` import (F821), removed duplicate `schwab_stream_level2` tool registration (F811)
- **schwab_streaming_tools.py**: Removed duplicate `schwab_stream_level2` function (F811), kept venue-aware version
- **test_schwab_streaming_tools.py**: Removed duplicate test functions (F811)
- **test_capabilities_and_streaming.py**: Removed duplicate `test_schwab_stream_manager_subscribe_level2` (F811), fixed test assertions to match actual API output (lowercase keys, venue-aware cache keys)

### Format fixes (15 files)
Reformatted 15 files for consistent code style via ruff format.

### Pre-existing test fixes
Fixed 2 pre-existing test failures on main:
- `test_schwab_stream_manager_level2_handling`: assertions used uppercase keys (`SYMBOL`, `BIDS`) but `_handle_message` stores lowercase; also missing venue param
- `test_schwab_stream_manager_start_registers_book_handlers`: duplicate handler registrations caused `assert_called_once` to fail

### Validation
- **ruff check**: 0 errors
- **mypy**: 0 errors (69 source files)
- **pytest**: 944 passed, 69 skipped, 0 failed

| Category | Files |
|---|---|
| Source fixes | 5 files |
| Test fixes | 6 files |
| Format-only | 6 files |
| **Total** | **17 files** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)