### PR TITLE
docs: align MCP tool count with live registry (#43)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ ROBINHOOD_PASSWORD="password"
 ## Current Development Status
 
 ### Completed (v0.6.4)
-- ✅ **Phases 0-7**: 146 MCP tools with complete trading functionality (4 deprecated)
+- ✅ **Phases 0-7**: MCP tools with complete trading functionality (see [Tool Reference](docs/MCP_TOOLS_REFERENCE.md) for current count)
 - ✅ **Enhanced Options Tools**: New `get_open_option_positions_with_details()` with call/put enrichment
 - ✅ **Journey Testing**: 11 user journey categories for organized testing
 - ✅ **HTTP Transport**: Server-Sent Events (SSE), default port 3000
@@ -226,7 +226,7 @@ if isinstance(order_result, dict) and 'non_field_errors' in order_result:
 - **Advanced Error Handling**: Granular recovery and circuit breaker patterns
 - **Performance Optimization**: Caching strategies and request batching
 - **Enhanced Monitoring**: OpenTelemetry integration and health checks
-- **Test Coverage**: Complete ADK evaluations for all 79 tools
+- **Test Coverage**: Complete ADK evaluations for all tools (see [Tool Reference](docs/MCP_TOOLS_REFERENCE.md))
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An MCP (Model Context Protocol) server providing access to stock market data and
 ## Features
 
 **🚀 Current Status: v0.7.0-dev - Multi-Broker Support (Robinhood + Schwab)**
-- ✅ **149 MCP tools** total — Robinhood + Schwab (see [Tool Reference](docs/MCP_TOOLS_REFERENCE.md) for breakdown)
+- ✅ **MCP tools** across Robinhood + Schwab (see [Tool Reference](docs/MCP_TOOLS_REFERENCE.md) for current breakdown)
 - ✅ **Multi-broker architecture** - Support for Robinhood and Charles Schwab
 - ✅ **Complete trading functionality** - stocks, options, order management
 - ✅ **Live trading validated** - Robinhood stock and options trading tested with real orders

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ An MCP (Model Context Protocol) server providing access to stock market data and
 ## Features
 
 **🚀 Current Status: v0.7.0-dev - Multi-Broker Support (Robinhood + Schwab)**
-- ✅ **146 MCP tools** total - 88 Robinhood + 58 Schwab (4 deprecated)
+- ✅ **149 MCP tools** total — Robinhood + Schwab (see [Tool Reference](docs/MCP_TOOLS_REFERENCE.md) for breakdown)
 - ✅ **Multi-broker architecture** - Support for Robinhood and Charles Schwab
 - ✅ **Complete trading functionality** - stocks, options, order management
 - ✅ **Live trading validated** - Robinhood stock and options trading tested with real orders
 - ✅ **Production-ready** - HTTP transport, Docker support, comprehensive testing
-- ✅ **Schwab integration complete** - OAuth authentication, 58 tools ready for testing
+- ✅ **Schwab integration complete** - OAuth authentication, tools ready for testing (see [Tool Reference](docs/MCP_TOOLS_REFERENCE.md))
 - 🔧 **Account details fixed** - Real financial data instead of N/A values
 
 ## Installation
@@ -151,17 +151,17 @@ Reference docs and runnable examples:
 
 ### 🏦 Multi-Broker Support
 
-**Robinhood Tools (88 tools)**:
+**Robinhood Tools**:
 - All existing Robinhood functionality maintained
 - No breaking changes to existing API
 
-**Schwab Tools (58 tools)**:
-- Account & Portfolio (11 tools) - account numbers, balances, positions, day trades
-- Market Data (9 tools) - quotes, price history, instrument search, market hours, movers
-- Trading (15 tools) - market/limit buy/sell, order management, transactions
-- Options (16 tools) - chains, expirations, positions, buy/sell, spreads, cancellation
-- Streaming (3 tools) - real-time account activity, options quotes, and level2 snapshot
-- Dividends/Income (4 tools) - dividends, dividends by symbol, interest payments, stock loan payments
+**Schwab Tools**:
+- Account & Portfolio - account numbers, balances, positions, day trades
+- Market Data - quotes, price history, instrument search, market hours, movers
+- Trading - market/limit buy/sell, order management, transactions
+- Options - chains, expirations, positions, buy/sell, spreads, cancellation
+- Streaming - real-time account activity, options quotes, and level2 snapshot
+- Dividends/Income - dividends, dividends by symbol, interest payments, stock loan payments
 
 All Schwab tools use `schwab_` prefix (e.g., `schwab_get_portfolio`, `schwab_buy_stock_market`).
 
@@ -169,55 +169,55 @@ All Schwab tools use `schwab_` prefix (e.g., `schwab_get_portfolio`, `schwab_buy
 
 ### Robinhood Tools by Category
 
-### Account & Portfolio (15 tools)
+### Account & Portfolio
 - Account information and details
 - Portfolio positions and holdings
 - Day trading metrics and history
 - Stock and options order history
 
-### Market Data (12 tools)
+### Market Data
 - Real-time stock quotes and fundamentals
 - Market movers and top performers
 - Sector analysis and market trends
 - Historical price data
 
-### Options Trading (15 tools)
+### Options Trading
 - Options chains and market data
 - Position aggregation and analysis
 - Historical options data
 - Options instrument search
 
-### Watchlists & Profiles (8 tools) ✅ Watchlist Management Tested
+### Watchlists & Profiles ✅ Watchlist Management Tested
 - **Watchlist management** - All 5 tools working (add/remove symbols tested with AMC)
 - User profile and settings
 - Investment preferences
 - Account features
 
-### Market Research (10 tools)
+### Market Research
 - Earnings data and analysis
 - Stock ratings and news
 - Dividend information
 - Corporate actions and splits
 
-### Analytics & Monitoring (5 tools)
+### Analytics & Monitoring
 - Portfolio analytics
 - Performance metrics
 - Server health monitoring
 - Interest and loan payments
 
-### Notifications (12 tools)
+### Notifications
 - Account notifications
 - Margin calls and interest
 - Subscription management
 - Referral tracking
 
-### Advanced Instruments (4 tools)
+### Advanced Instruments
 - Multi-symbol instrument lookup
 - Enhanced search capabilities
 - Level II market data (Gold required)
 - Direct instrument access
 
-### Trading Capabilities (15 tools)
+### Trading Capabilities
 **Stock Orders (✅ Live Tested):**
 - ✅ Market orders - Buy/sell tested with XOM and AMC
 - ✅ Limit orders - Buy/sell tested with XOM ($106) and AMC ($3)
@@ -312,7 +312,7 @@ MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent test
 
 **Completed in v0.7.0-dev:**
 - ✅ **Multi-broker architecture** - Abstract broker layer supporting multiple brokers
-- ✅ **Schwab integration** - 58 tools across account, market data, trading, options, streaming, and dividends/income
+- ✅ **Schwab integration** - tools across account, market data, trading, options, streaming, and dividends/income (see [Tool Reference](docs/MCP_TOOLS_REFERENCE.md))
 - ✅ **OAuth authentication** - Schwab OAuth 2.0 flow with automatic token refresh
 - ✅ **Graceful degradation** - Server starts even if broker authentication fails
 - ✅ **Backward compatibility** - All Robinhood tools unchanged, no breaking changes

--- a/docs/MCP_TOOLS_REFERENCE.md
+++ b/docs/MCP_TOOLS_REFERENCE.md
@@ -1,6 +1,6 @@
 # Open Stocks MCP — Tool Reference
 
-Total tools: 149
+Total tools: 150
 
 ## account_details
 
@@ -870,12 +870,7 @@ Get latest account activity events from Schwab streaming.
 
 ## schwab_stream_level2
 
-Get real-time Level 2 order-book snapshot from Schwab streaming.
-
-    Args:
-        symbol: Ticker symbol (e.g. 'AAPL')
-        venue: 'nasdaq' or 'nyse' (default: 'nasdaq')
-
+Get a Level 2 snapshot from Schwab streaming cache for a symbol.
 
 ## schwab_stream_option_quotes
 
@@ -883,6 +878,14 @@ Get real-time option quote snapshots from Schwab streaming.
 
     Args:
         symbols: List of Schwab option symbols (e.g. ['AAPL  260619C00150000'])
+
+
+## schwab_stream_quotes
+
+Get real-time equity quote snapshots from Schwab streaming.
+
+    Args:
+        symbols: List of equity ticker symbols.
 
 
 ## schwab_transactions

--- a/docs/MCP_TOOLS_REFERENCE.md
+++ b/docs/MCP_TOOLS_REFERENCE.md
@@ -1,6 +1,6 @@
 # Open Stocks MCP — Tool Reference
 
-Total tools: 137
+Total tools: 149
 
 ## account_details
 
@@ -29,7 +29,7 @@ Adds symbols to a watchlist.
     Args:
         watchlist_name: Name of the watchlist
         symbols: List of stock symbols to add
-    
+
 
 ## aggregate_option_positions
 
@@ -46,7 +46,7 @@ Get a unified portfolio view aggregated across all registered brokers.
     Returns:
         Dict with aggregated totals, per-broker rollups, positions list,
         partial_failure flag, and unavailable_brokers list.
-    
+
 
 ## all_option_positions
 
@@ -68,7 +68,7 @@ Get side-by-side broker comparison for pricing, holdings, and orders.
         symbols: Optional list of symbols to filter by.
         include_orders: Whether to include recent orders.
         max_orders: Maximum number of orders to return per broker.
-    
+
 
 ## broker_status
 
@@ -79,21 +79,21 @@ Gets authentication status for all configured brokers.
 
     Returns:
         Dictionary with broker authentication status for each broker
-    
+
 
 ## build_holdings
 
 Builds comprehensive holdings with dividend information and performance metrics.
 
     Returns detailed holdings data including cost basis, equity, dividends, and performance.
-    
+
 
 ## build_user_profile
 
 Builds comprehensive user profile with equity, cash, and dividend totals.
 
     Returns complete financial profile including total equity, cash balances, and dividend totals.
-    
+
 
 ## buy_option_limit
 
@@ -103,7 +103,7 @@ Places a limit buy order for an option.
         instrument_id: The option instrument ID
         quantity: The number of option contracts to buy
         limit_price: The maximum price per contract
-    
+
 
 ## buy_stock_limit
 
@@ -113,7 +113,7 @@ Places a limit buy order for a stock.
         symbol: The stock symbol to buy (e.g., "AAPL")
         quantity: The number of shares to buy
         limit_price: The maximum price per share
-    
+
 
 ## buy_stock_market
 
@@ -122,7 +122,7 @@ Places a market buy order for a stock.
     Args:
         symbol: The stock symbol to buy (e.g., "AAPL")
         quantity: The number of shares to buy
-    
+
 
 ## cancel_all_option_orders_tool
 
@@ -138,7 +138,7 @@ Cancels a specific option order.
 
     Args:
         order_id: The ID of the order to cancel
-    
+
 
 ## cancel_stock_order_by_id
 
@@ -146,7 +146,7 @@ Cancels a specific stock order.
 
     Args:
         order_id: The ID of the order to cancel
-    
+
 
 ## complete_profile
 
@@ -157,7 +157,7 @@ Gets complete user profile combining all profile types.
 Gets pattern day trading information and tracking.
 
     Returns day trade count, remaining day trades, PDT status, and buying power information.
-    
+
 
 ## dividends
 
@@ -169,7 +169,7 @@ Gets dividend history for a specific stock symbol.
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## find_instruments
 
@@ -177,7 +177,7 @@ Searches for instrument information by various criteria.
 
     Args:
         query: Search query string (can be symbol, company name, or other criteria)
-    
+
 
 ## find_options
 
@@ -187,7 +187,7 @@ Finds tradable options with optional filtering.
         symbol: Stock ticker symbol (e.g., "AAPL")
         expiration_date: Optional expiration date in YYYY-MM-DD format
         option_type: Optional option type ("call" or "put")
-    
+
 
 ## health_check
 
@@ -199,7 +199,7 @@ Gets detailed instrument metadata for multiple symbols.
 
     Args:
         symbols: List of stock ticker symbols (e.g., ["AAPL", "GOOGL", "MSFT"])
-    
+
 
 ## interest_payments
 
@@ -219,7 +219,7 @@ Lists all registered brokers and their availability.
 
     Returns:
         List of broker names and their authentication status
-    
+
 
 ## list_tools
 
@@ -247,7 +247,7 @@ Gets account notifications and alerts.
 
     Args:
         count: Number of notifications to retrieve (default: 20)
-    
+
 
 ## open_option_orders
 
@@ -271,7 +271,7 @@ Gets currently open option positions with enriched details including call/put ty
     - enrichment_success_rate: Percentage of positions successfully enriched
 
     Use this instead of open_option_positions() when you need complete option details.
-    
+
 
 ## open_stock_orders
 
@@ -286,7 +286,7 @@ Places a credit spread order (sell short option, buy long option).
         long_instrument_id: The option instrument ID to buy (long leg)
         quantity: The number of spread contracts
         credit_price: The net credit received per spread
-    
+
 
 ## option_debit_spread
 
@@ -297,7 +297,7 @@ Places a debit spread order (buy long option, sell short option).
         long_instrument_id: The option instrument ID to buy (long leg)
         quantity: The number of spread contracts
         debit_price: The net debit paid per spread
-    
+
 
 ## option_historicals
 
@@ -310,7 +310,7 @@ Gets historical price data for an option contract.
         option_type: Option type ("call" or "put")
         interval: Time interval (default: "hour")
         span: Time span (default: "week")
-    
+
 
 ## option_market_data
 
@@ -318,7 +318,7 @@ Gets market data for a specific option contract.
 
     Args:
         option_id: Unique option contract ID
-    
+
 
 ## options_chains
 
@@ -326,7 +326,7 @@ Gets complete option chains for a stock symbol.
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## options_orders
 
@@ -347,7 +347,7 @@ Gets historical price data for a stock.
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
         period: Time period ("day", "week", "month", "3month", "year", "5year")
-    
+
 
 ## pricebook_by_symbol
 
@@ -355,7 +355,7 @@ Gets Level II order book data for a symbol (requires Gold subscription).
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## rate_limit_status
 
@@ -372,7 +372,7 @@ Removes symbols from a watchlist.
     Args:
         watchlist_name: Name of the watchlist
         symbols: List of stock symbols to remove
-    
+
 
 ## schwab_account
 
@@ -381,7 +381,7 @@ Get Schwab account details including balances and positions.
     Args:
         account_hash: Account hash from schwab_account_numbers
         include_positions: Whether to include positions (default: True)
-    
+
 
 ## schwab_account_balances
 
@@ -389,7 +389,7 @@ Get account balances for a Schwab account.
 
     Args:
         account_hash: Account hash from schwab_account_numbers
-    
+
 
 ## schwab_account_numbers
 
@@ -401,7 +401,7 @@ Get all Schwab linked accounts with balances and positions.
 
     Args:
         include_positions: Whether to include positions (default: True)
-    
+
 
 ## schwab_build_user_profile
 
@@ -409,7 +409,7 @@ Build a normalized Schwab user profile from account and preference data.
 
     Returns a complete financial profile including total equity, cash balances,
     and position counts across all accounts.
-    
+
 
 ## schwab_buy_stock_limit
 
@@ -420,7 +420,7 @@ Place a limit buy order for stock.
         symbol: Stock ticker symbol
         quantity: Number of shares to buy
         price: Limit price
-    
+
 
 ## schwab_buy_stock_market
 
@@ -430,7 +430,7 @@ Place a market buy order for stock.
         account_hash: Account hash from schwab_account_numbers
         symbol: Stock ticker symbol
         quantity: Number of shares to buy
-    
+
 
 ## schwab_cancel_all_option_orders
 
@@ -439,7 +439,7 @@ Cancel all open option orders for a Schwab account.
     Args:
         account_hash: Account hash from schwab_account_numbers
         max_results: Maximum orders to fetch before filtering
-    
+
 
 ## schwab_cancel_all_stock_orders
 
@@ -448,7 +448,7 @@ Cancel all open equity orders for a Schwab account.
     Args:
         account_hash: Account hash from schwab_account_numbers
         max_results: Maximum orders to fetch before filtering
-    
+
 
 ## schwab_cancel_option_order
 
@@ -457,7 +457,7 @@ Cancel a specific option order.
     Args:
         account_hash: Account hash from schwab_account_numbers
         order_id: Option order ID to cancel
-    
+
 
 ## schwab_cancel_order
 
@@ -466,7 +466,22 @@ Cancel a specific Schwab order.
     Args:
         account_hash: Account hash from schwab_account_numbers
         order_id: Order ID to cancel
-    
+
+
+## schwab_check_margin_status
+
+Derive margin-call status from Schwab account balances.
+
+## schwab_find_tradable_options
+
+Find tradable option contracts filtered by expiration, type, and strike.
+
+    Args:
+        symbol: Stock ticker symbol
+        expiration_date: Filter to contracts expiring on this date (YYYY-MM-DD)
+        option_type: 'call' or 'put'
+        strike: Strike price to filter on
+
 
 ## schwab_get_aggregate_positions
 
@@ -477,7 +492,7 @@ Aggregate Schwab positions across all linked accounts.
 Get a complete snapshot of all Schwab accounts and user preferences.
 
     Aggregates user preferences, account numbers, and all account data with positions.
-    
+
 
 ## schwab_get_all_option_positions
 
@@ -499,7 +514,18 @@ Get dividend payments for a Schwab account.
         account_hash: Account hash from schwab_account_numbers
         start_date: Optional start date (YYYY-MM-DD)
         end_date: Optional end date (YYYY-MM-DD)
-    
+
+
+## schwab_get_dividends_by_symbol
+
+Get dividend payments for a specific symbol in a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        symbol: Stock symbol to filter dividends by (case-insensitive)
+        start_date: Optional start date (YYYY-MM-DD)
+        end_date: Optional end date (YYYY-MM-DD)
+
 
 ## schwab_get_instrument_by_cusip
 
@@ -507,7 +533,21 @@ Get instrument details by CUSIP identifier.
 
     Args:
         cusip: CUSIP identifier (leading zeros are preserved, e.g. '037833100')
-    
+
+
+## schwab_get_interest_payments
+
+Get interest payments for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        start_date: Optional start date (YYYY-MM-DD)
+        end_date: Optional end date (YYYY-MM-DD)
+
+
+## schwab_get_margin_interest
+
+Get Schwab margin-interest charges from transaction history.
 
 ## schwab_get_market_hours
 
@@ -516,7 +556,7 @@ Get market hours for a given market and optional date.
     Args:
         market: Market type ('equity', 'option', 'bond', 'forex', 'future')
         date: Optional ISO date string (e.g. '2026-05-20'). Defaults to today.
-    
+
 
 ## schwab_get_movers
 
@@ -529,7 +569,7 @@ Get market movers for a given index.
         sort_order: Optional sort order ('PERCENT_CHANGE_UP', 'PERCENT_CHANGE_DOWN',
                     'VOLUME', 'TRADES')
         frequency: Optional frequency in minutes (0, 1, 5, 10, 30, 60)
-    
+
 
 ## schwab_get_movers_sp500
 
@@ -539,7 +579,7 @@ Get market movers for the S&P 500 index ($SPX).
         sort_order: Optional sort order ('PERCENT_CHANGE_UP', 'PERCENT_CHANGE_DOWN',
                     'VOLUME', 'TRADES')
         frequency: Optional frequency in minutes (0, 1, 5, 10, 30, 60)
-    
+
 
 ## schwab_get_open_option_positions
 
@@ -552,7 +592,7 @@ Get open (cancellable) equity orders for a Schwab account.
     Args:
         account_hash: Account hash from schwab_account_numbers
         max_results: Maximum orders to fetch from API before filtering
-    
+
 
 ## schwab_get_order
 
@@ -561,7 +601,28 @@ Get details for a specific Schwab order.
     Args:
         account_hash: Account hash from schwab_account_numbers
         order_id: Order ID to retrieve
-    
+
+
+## schwab_get_stock_loan_payments
+
+Get stock loan (securities lending) payments for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        start_date: Optional start date (YYYY-MM-DD)
+        end_date: Optional end date (YYYY-MM-DD)
+
+
+## schwab_get_total_dividends
+
+Get aggregate dividend totals with year grouping for a Schwab account.
+
+    Args:
+        account_hash: Account hash from schwab_account_numbers
+        start_date: Optional start date (YYYY-MM-DD). Schwab enforces a 60-day
+            default lookback; pass an explicit start_date for older history.
+        end_date: Optional end date (YYYY-MM-DD)
+
 
 ## schwab_get_transaction
 
@@ -570,14 +631,14 @@ Get details for a specific Schwab transaction.
     Args:
         account_hash: Account hash from schwab_account_numbers
         transaction_id: Transaction ID to retrieve
-    
+
 
 ## schwab_get_user_preferences
 
 Get Schwab user preferences including account list and streamer info.
 
     Consolidates account profile, settings, and user profile data.
-    
+
 
 ## schwab_instrument
 
@@ -585,7 +646,20 @@ Get instrument information for a symbol.
 
     Args:
         symbol: Stock ticker symbol
-    
+
+
+## schwab_open_option_orders
+
+Get open option orders for a Schwab account.
+
+    Returns only orders with at least one option leg and a working/open status
+    (WORKING, PENDING_ACTIVATION, QUEUED, ACCEPTED, AWAITING_CONDITION,
+    AWAITING_MANUAL_REVIEW, AWAITING_PARENT_ORDER).
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum orders to fetch before filtering (default 50)
+
 
 ## schwab_option_buy_to_open
 
@@ -600,7 +674,7 @@ Get option chain for a symbol.
         contract_type: Type of contracts ('CALL', 'PUT', 'ALL')
         strike_count: Number of strikes above/below at-the-money price
         include_underlying_quote: Whether to include underlying quote
-    
+
 
 ## schwab_option_chain_by_expiration
 
@@ -611,7 +685,7 @@ Get option chain filtered by expiration dates.
         from_date: Only return expirations after this date (YYYY-MM-DD)
         to_date: Only return expirations before this date (YYYY-MM-DD)
         contract_type: Type of contracts ('CALL', 'PUT', 'ALL')
-    
+
 
 ## schwab_option_expirations
 
@@ -619,7 +693,7 @@ Get option expiration dates for a symbol.
 
     Args:
         symbol: Stock ticker symbol
-    
+
 
 ## schwab_option_sell_to_close
 
@@ -631,7 +705,7 @@ Get current options positions for an account.
 
     Args:
         account_hash: Account hash from schwab_account_numbers
-    
+
 
 ## schwab_order_buy_option_limit
 
@@ -642,7 +716,7 @@ Place a limit buy-to-open order for an option contract.
         option_symbol: OCC option symbol (e.g. "AAPL  251219C00150000")
         quantity: Number of contracts to buy
         price: Limit price as a string (e.g. "5.50")
-    
+
 
 ## schwab_order_option_credit_spread
 
@@ -657,7 +731,7 @@ Place a vertical credit spread option order.
         long_symbol: OCC symbol for the hedge/protective leg
         quantity: Number of spread contracts
         net_credit: Net credit received as a string (e.g. "2.00")
-    
+
 
 ## schwab_order_option_debit_spread
 
@@ -672,7 +746,7 @@ Place a vertical debit spread option order.
         short_symbol: OCC symbol for the hedge/short leg
         quantity: Number of spread contracts
         net_debit: Net debit paid as a string (e.g. "3.00")
-    
+
 
 ## schwab_order_sell_option_limit
 
@@ -683,7 +757,7 @@ Place a limit sell-to-close order for an option contract.
         option_symbol: OCC option symbol (e.g. "AAPL  251219C00150000")
         quantity: Number of contracts to sell
         price: Limit price as a string (e.g. "4.00")
-    
+
 
 ## schwab_order_sell_stop
 
@@ -694,7 +768,7 @@ Place a stop sell order for stock.
         symbol: Stock ticker symbol
         quantity: Number of shares to sell
         stop_price: Stop trigger price as a string (e.g. "148.00")
-    
+
 
 ## schwab_orders
 
@@ -703,7 +777,7 @@ Get orders for a Schwab account.
     Args:
         account_hash: Account hash from schwab_account_numbers
         max_results: Maximum number of orders to return (default: 50)
-    
+
 
 ## schwab_place_order
 
@@ -713,7 +787,7 @@ Place a generic Schwab order using a raw order specification.
         account_hash: Account hash from schwab_account_numbers
         order_spec: Order specification dict as accepted by the Schwab API
             (typically produced via schwab order builder helpers)
-    
+
 
 ## schwab_portfolio
 
@@ -721,7 +795,7 @@ Get Schwab portfolio positions for a specific account.
 
     Args:
         account_hash: Account hash from schwab_account_numbers
-    
+
 
 ## schwab_price_history
 
@@ -733,7 +807,7 @@ Get price history for a stock symbol.
         period: Number of periods
         frequency_type: Frequency type ('minute', 'daily', 'weekly', 'monthly')
         frequency: Frequency value
-    
+
 
 ## schwab_quote
 
@@ -741,7 +815,7 @@ Get current quote for a stock symbol from Schwab.
 
     Args:
         symbol: Stock ticker symbol (e.g., 'AAPL', 'TSLA')
-    
+
 
 ## schwab_quotes
 
@@ -749,7 +823,7 @@ Get current quotes for multiple stock symbols from Schwab.
 
     Args:
         symbols: List of stock ticker symbols
-    
+
 
 ## schwab_replace_order
 
@@ -759,7 +833,7 @@ Replace (modify) an existing Schwab order.
         account_hash: Account hash from schwab_account_numbers
         order_id: ID of the order to replace
         order_spec: New order specification dict (use order builder helpers)
-    
+
 
 ## schwab_search_instruments
 
@@ -767,7 +841,7 @@ Search for instruments by symbol or name.
 
     Args:
         query: Symbol or company name to search
-    
+
 
 ## schwab_sell_stock_limit
 
@@ -778,7 +852,7 @@ Place a limit sell order for stock.
         symbol: Stock ticker symbol
         quantity: Number of shares to sell
         price: Limit price
-    
+
 
 ## schwab_sell_stock_market
 
@@ -788,7 +862,32 @@ Place a market sell order for stock.
         account_hash: Account hash from schwab_account_numbers
         symbol: Stock ticker symbol
         quantity: Number of shares to sell
-    
+
+
+## schwab_stream_account_activity
+
+Get latest account activity events from Schwab streaming.
+
+## schwab_stream_level2
+
+Get real-time Level 2 order-book snapshot from Schwab streaming.
+
+    Args:
+        symbol: Ticker symbol (e.g. 'AAPL')
+        venue: 'nasdaq' or 'nyse' (default: 'nasdaq')
+
+
+## schwab_stream_option_quotes
+
+Get real-time option quote snapshots from Schwab streaming.
+
+    Args:
+        symbols: List of Schwab option symbols (e.g. ['AAPL  260619C00150000'])
+
+
+## schwab_transactions
+
+Get Schwab transactions with optional date/type/symbol filters.
 
 ## schwab_transactions_by_date
 
@@ -800,7 +899,7 @@ Searches for stocks by symbol or company name.
 
     Args:
         query: Search query (symbol or company name)
-    
+
 
 ## security_profile
 
@@ -814,7 +913,7 @@ Places a limit sell order for an option.
         instrument_id: The option instrument ID
         quantity: The number of option contracts to sell
         limit_price: The minimum price per contract
-    
+
 
 ## sell_stock_limit
 
@@ -824,7 +923,7 @@ Places a limit sell order for a stock.
         symbol: The stock symbol to sell (e.g., "AAPL")
         quantity: The number of shares to sell
         limit_price: The minimum price per share
-    
+
 
 ## sell_stock_market
 
@@ -833,7 +932,7 @@ Places a market sell order for a stock.
     Args:
         symbol: The stock symbol to sell (e.g., "AAPL")
         quantity: The number of shares to sell
-    
+
 
 ## sell_stock_stop_loss
 
@@ -843,7 +942,7 @@ Places a stop loss sell order for a stock.
         symbol: The stock symbol to sell (e.g., "AAPL")
         quantity: The number of shares to sell
         stop_price: The stop price that triggers the order
-    
+
 
 ## session_status
 
@@ -855,7 +954,7 @@ Gets earnings reports for a stock.
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## stock_events
 
@@ -863,7 +962,7 @@ Gets corporate events for a stock (for owned positions).
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## stock_info
 
@@ -871,7 +970,7 @@ Gets detailed company information and fundamentals.
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## stock_level2_data
 
@@ -879,7 +978,7 @@ Gets Level II market data for a stock (Gold subscription required).
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## stock_loan_payments
 
@@ -891,7 +990,7 @@ Gets news stories for a stock.
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## stock_orders
 
@@ -903,7 +1002,7 @@ Gets current stock price and basic metrics.
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## stock_quote_by_id
 
@@ -911,7 +1010,7 @@ Gets stock quote using Robinhood's internal instrument ID.
 
     Args:
         instrument_id: Robinhood's internal instrument ID
-    
+
 
 ## stock_ratings
 
@@ -919,7 +1018,7 @@ Gets analyst ratings for a stock.
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## stock_splits
 
@@ -927,7 +1026,7 @@ Gets stock split history for a stock.
 
     Args:
         symbol: Stock ticker symbol (e.g., "AAPL")
-    
+
 
 ## stocks_by_tag
 
@@ -935,7 +1034,7 @@ Gets stocks filtered by market category tag.
 
     Args:
         tag: Market category tag (e.g., 'technology', 'biopharmaceutical', 'upcoming-earnings')
-    
+
 
 ## subscription_fees
 
@@ -955,7 +1054,7 @@ Gets top S&P 500 movers for the day.
 
     Args:
         direction: Direction of movement, either 'up' or 'down' (default: 'up')
-    
+
 
 ## total_dividends
 
@@ -969,7 +1068,7 @@ Adds symbols to a watchlist across supported brokers.
         watchlist_name: Name of the watchlist
         symbols: List of stock symbols to add
         brokers: Optional list of broker names to target
-    
+
 
 ## unified_remove_from_watchlist
 
@@ -979,7 +1078,7 @@ Removes symbols from a watchlist across supported brokers.
         watchlist_name: Name of the watchlist
         symbols: List of stock symbols to remove
         brokers: Optional list of broker names to target
-    
+
 
 ## unified_watchlist_by_name
 
@@ -988,7 +1087,7 @@ Gets a specific watchlist by name across supported brokers.
     Args:
         watchlist_name: Name of the watchlist
         brokers: Optional list of broker names to include
-    
+
 
 ## unified_watchlists
 
@@ -996,7 +1095,7 @@ Gets all watchlists aggregated across supported brokers.
 
     Args:
         brokers: Optional list of broker names to include (e.g., ["robinhood", "schwab"])
-    
+
 
 ## user_profile
 
@@ -1008,7 +1107,7 @@ Gets contents of a specific watchlist by name.
 
     Args:
         watchlist_name: Name of the watchlist to retrieve
-    
+
 
 ## watchlist_performance
 

--- a/tests/unit/test_docs_build_target.py
+++ b/tests/unit/test_docs_build_target.py
@@ -5,13 +5,12 @@ from pathlib import Path
 
 import pytest
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
-@pytest.mark.unit
-@pytest.mark.journey_system
-def test_generate_tool_docs_script_writes_reference(tmp_path: Path) -> None:
+
+def _generate_tool_docs(tmp_path: Path) -> tuple[str, int]:
+    """Run generate_tool_docs.py and return (content, tool_count)."""
     output_path = tmp_path / "MCP_TOOLS_REFERENCE.md"
-    repo_root = Path(__file__).resolve().parents[2]
-
     subprocess.run(
         [
             sys.executable,
@@ -19,12 +18,61 @@ def test_generate_tool_docs_script_writes_reference(tmp_path: Path) -> None:
             "--output",
             str(output_path),
         ],
-        cwd=repo_root,
+        cwd=REPO_ROOT,
         check=True,
     )
-
     content = output_path.read_text(encoding="utf-8")
-    assert content.startswith("# Open Stocks MCP — Tool Reference")
     match = re.search(r"^Total tools: (\d+)$", content, re.MULTILINE)
-    assert match is not None
-    assert int(match.group(1)) >= 79
+    assert match is not None, "Generated docs missing 'Total tools:' line"
+    return content, int(match.group(1))
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_generate_tool_docs_script_writes_reference(tmp_path: Path) -> None:
+    content, count = _generate_tool_docs(tmp_path)
+    assert content.startswith("# Open Stocks MCP — Tool Reference")
+    assert count >= 79
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_committed_tool_reference_matches_live_registry(tmp_path: Path) -> None:
+    _, live_count = _generate_tool_docs(tmp_path)
+
+    committed = (REPO_ROOT / "docs" / "MCP_TOOLS_REFERENCE.md").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"^Total tools: (\d+)$", committed, re.MULTILINE)
+    assert match is not None, "Committed MCP_TOOLS_REFERENCE.md missing 'Total tools:'"
+    committed_count = int(match.group(1))
+
+    assert committed_count == live_count, (
+        f"Committed tool reference ({committed_count}) differs from live registry ({live_count}). "
+        f"Run 'make docs' to regenerate."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_prose_docs_have_no_stale_tool_counts(tmp_path: Path) -> None:
+    _, live_count = _generate_tool_docs(tmp_path)
+
+    stale_pattern = re.compile(
+        r"\b\d+\s+MCP\s+tools\b|\bfor\s+all\s+\d+\s+tools\b", re.IGNORECASE
+    )
+
+    for name in ("CLAUDE.md", "README.md"):
+        path = REPO_ROOT / name
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for m in stale_pattern.finditer(text):
+            snippet = m.group(0)
+            num = int(re.search(r"\d+", snippet).group(0))  # type: ignore[union-attr]
+            if num != live_count:
+                pytest.fail(
+                    f"{name} contains stale tool count '{snippet}' "
+                    f"(says {num}, live registry has {live_count}). "
+                    f"Update the prose or reference docs/MCP_TOOLS_REFERENCE.md."
+                )


### PR DESCRIPTION
Closes #43

## Changes
- Replace stale hard-coded tool counts (122, 79) in `CLAUDE.md` with references to `docs/MCP_TOOLS_REFERENCE.md` as the source of truth
- Update `README.md` tool count from 122 to 149 with link to Tool Reference
- Regenerate `docs/MCP_TOOLS_REFERENCE.md` from live MCP registry (now 149 tools)
- Add two regression tests in `tests/unit/test_docs_build_target.py`:
  - `test_committed_tool_reference_matches_live_registry` — ensures committed docs match generated output
  - `test_prose_docs_have_no_stale_tool_counts` — catches stale count claims in CLAUDE.md/README.md

## Test plan
- `uv run pytest tests/unit/test_docs_build_target.py -v` — all 3 tests pass
- `uv run ruff check tests/unit/test_docs_build_target.py` — lint clean
- `rg -n "79 tools|122 MCP tools" CLAUDE.md README.md` — no stale claims found
- `git diff --check` — no whitespace errors