### PR TITLE
docs: correct HTTP transport default port from 3001 to 3000

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Project guidance for Claude Code when working with the Open Stocks MCP server.
 - **Current Version**: v0.6.5 with enhanced authentication and session management
 - **Framework**: FastMCP for simplified MCP development
 - **API**: Robin Stocks for market data and trading
-- **Transport**: HTTP with Server-Sent Events (SSE) on port 3001
+- **Transport**: HTTP with Server-Sent Events (SSE), configurable via `--port` (default 3000)
 - **Docker**: Production-ready with persistent session/log storage
 
 ## Quick Reference
@@ -150,7 +150,7 @@ ROBINHOOD_PASSWORD="password"
 - ✅ **Phases 0-7**: 122 MCP tools with complete trading functionality (4 deprecated)
 - ✅ **Enhanced Options Tools**: New `get_open_option_positions_with_details()` with call/put enrichment
 - ✅ **Journey Testing**: 11 user journey categories for organized testing
-- ✅ **HTTP Transport**: Server-Sent Events (SSE) on port 3001
+- ✅ **HTTP Transport**: Server-Sent Events (SSE), default port 3000
 - ✅ **Docker Infrastructure**: Persistent volumes for sessions and logs
 - ✅ **Test Coverage**: Comprehensive test suite with journey-based markers
 - ✅ **Type Safety**: Zero MyPy errors maintained across codebase
@@ -231,7 +231,7 @@ if isinstance(order_result, dict) and 'non_field_errors' in order_result:
 ## Important Notes
 
 - **Use UV for dependencies** - Project uses UV package manager  
-- **HTTP transport default** - Server runs on port 3001 (not 3000)
+- **HTTP transport default** - Server defaults to port 3000; use `--port 3001` to override
 - **Docker persistent volumes** - Session tokens and logs survive restarts
 - **Async patterns required** - Robin Stocks is sync, tools are async
 - **JSON responses mandatory** - All tools return `{"result": data}` format


### PR DESCRIPTION
Closes #44

## Changes
- Updated CLAUDE.md project overview to state HTTP transport is configurable via `--port` (default 3000) instead of claiming port 3001
- Updated completed status entry to reflect default port 3000
- Updated Important Notes to clarify server defaults to port 3000 with `--port 3001` as an explicit override
- Preserved all intentional `--port 3001` examples (dev server command, Docker, ADK) since those are opt-in overrides

## Test plan
- `rg "default.*3001|3001 \(not 3000\)|Transport.*port 3001|HTTP Transport.*port 3001" CLAUDE.md` returns no stale default-port claims
- `rg "default.*3000|defaults? to 3000|--port 3001" CLAUDE.md` confirms corrected default and explicit opt-in examples are documented
- `git diff --check` confirms no whitespace errors