### PR TITLE
docs: align README Current Status with package version v0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An MCP (Model Context Protocol) server providing access to stock market data and
 
 ## Features
 
-**🚀 Current Status: v0.7.0-dev - Multi-Broker Support (Robinhood + Schwab)**
+**🚀 Current Status: v0.6.5 - Multi-Broker Support (Robinhood + Schwab)**
 - ✅ **MCP tools** across Robinhood + Schwab (see [Tool Reference](docs/MCP_TOOLS_REFERENCE.md) for current breakdown)
 - ✅ **Multi-broker architecture** - Support for Robinhood and Charles Schwab
 - ✅ **Complete trading functionality** - stocks, options, order management

--- a/tests/unit/test_docs_version_alignment.py
+++ b/tests/unit/test_docs_version_alignment.py
@@ -1,0 +1,42 @@
+"""Verify the README Current Status version matches the canonical package version."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _readme_status_version() -> str:
+    text = (ROOT / "README.md").read_text()
+    m = re.search(r"Current Status:\s*v([\d.]+[^\s]*)", text)
+    assert m, "Could not find 'Current Status: v...' line in README.md"
+    return m.group(1).rstrip(" -")
+
+
+def _pyproject_version() -> str:
+    with (ROOT / "pyproject.toml").open("rb") as f:
+        data = tomllib.load(f)
+    return data["project"]["version"]
+
+
+def _package_version() -> str:
+    import open_stocks_mcp
+
+    return open_stocks_mcp.__version__
+
+
+@pytest.mark.journey_system
+class TestDocsVersionAlignment:
+    def test_readme_matches_pyproject(self) -> None:
+        assert _readme_status_version() == _pyproject_version()
+
+    def test_readme_matches_package(self) -> None:
+        assert _readme_status_version() == _package_version()
+
+    def test_pyproject_matches_package(self) -> None:
+        assert _pyproject_version() == _package_version()


### PR DESCRIPTION
Closes #46

## Changes
- Updated README.md Current Status line from `v0.7.0-dev` to `v0.6.5` to match `pyproject.toml` and `src/open_stocks_mcp/__init__.py`
- Added `tests/unit/test_docs_version_alignment.py` with 3 tests asserting README, pyproject.toml, and package `__version__` all match

## Test plan
- `uv run pytest tests/unit/test_docs_version_alignment.py -q` — 3 passed
- `uv run ruff check tests/unit/test_docs_version_alignment.py` — all checks passed
- `git diff --check` — no whitespace errors