### PR TITLE
docs: align Schwab status version label

### DIFF
--- a/SCHWAB_STATUS.md
+++ b/SCHWAB_STATUS.md
@@ -1,6 +1,6 @@
 # Schwab Integration Status
 
-**Version**: 0.6.5
+**Version**: v0.6.5
 **Branch**: main (merged from feature/schwab-integration)
 **Date**: 2025-10-06
 **Status**: ✅ **IMPLEMENTATION COMPLETE** - 🔒 **BLOCKED BY API CREDENTIALS**

--- a/tests/unit/test_dev_tooling.py
+++ b/tests/unit/test_dev_tooling.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -54,3 +55,16 @@ def test_contributing_guide_exists_and_mentions_debugging_recipes() -> None:
         ".vscode/launch.json",
     ):
         assert expected in content
+
+
+@pytest.mark.unit
+def test_schwab_status_version_matches_pyproject() -> None:
+    pyproject = ROOT / "pyproject.toml"
+    schwab_status = ROOT / "SCHWAB_STATUS.md"
+
+    pyproject_data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    version = pyproject_data["project"]["version"]
+    expected = f"**Version**: v{version}"
+
+    content = schwab_status.read_text(encoding="utf-8")
+    assert expected in content


### PR DESCRIPTION
Closes #47

## Changes
- update `SCHWAB_STATUS.md` version line to match the package version format (`v0.6.5`)
- add a focused regression test in `tests/unit/test_dev_tooling.py` that reads `pyproject.toml` via `tomllib` and asserts the expected status-page version line

## Test plan
- uv run pytest tests/unit/test_dev_tooling.py -k schwab_status_version_matches_pyproject -v
- uv run pytest tests/unit/test_dev_tooling.py -v
- uv run ruff check tests/unit/test_dev_tooling.py
- git diff --check
- rg -n '^\*\*Version\*\*: v0\.6\.5$' SCHWAB_STATUS.md