### PR TITLE
docs: add v0.6.5 entry to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Open Stocks MCP project will be documented in this file.
 
+## [0.6.5] - 2026-05-18
+
+### Changed
+- Bumped version to 0.6.5
+- Code cleanup for release (release cleanup)
+- Updated all dependencies to latest versions
+- Added open source community infrastructure
+- Code quality improvements and QA documentation
+
 ## [0.6.4] - 2025-09-10
 
 ### Enhanced


### PR DESCRIPTION
Closes #48

## Changes
- Added missing v0.6.5 release entry to `CHANGELOG.md`

## Test plan
- Validated text content according to issue requirements
- Verified correct placement chronologically
- Ran `git diff --check`