### PR TITLE
refactor: move Robinhood broker imports to module scope

### DIFF
--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -8,6 +8,16 @@ from open_stocks_mcp.brokers.request_policy import install_robinhood_request_tim
 from open_stocks_mcp.brokers.session_state import SessionManager
 from open_stocks_mcp.config import get_config
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.robinhood_account_tools import (
+    get_account_info,
+    get_portfolio,
+    get_positions,
+)
+from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
+from open_stocks_mcp.tools.robinhood_trading_tools import (
+    order_buy_market,
+    order_sell_market,
+)
 
 
 class RobinhoodBroker(BaseBroker):
@@ -124,16 +134,12 @@ class RobinhoodBroker(BaseBroker):
         if not self.is_available():
             return self.create_unavailable_response("get_account_info")
 
-        from open_stocks_mcp.tools.robinhood_account_tools import get_account_info
-
         return await get_account_info()
 
     async def get_portfolio(self) -> dict[str, Any]:
         """Get portfolio holdings."""
         if not self.is_available():
             return self.create_unavailable_response("get_portfolio")
-
-        from open_stocks_mcp.tools.robinhood_account_tools import get_portfolio
 
         return await get_portfolio()
 
@@ -142,16 +148,12 @@ class RobinhoodBroker(BaseBroker):
         if not self.is_available():
             return self.create_unavailable_response("get_positions")
 
-        from open_stocks_mcp.tools.robinhood_account_tools import get_positions
-
         return await get_positions()
 
     async def get_stock_quote(self, symbol: str) -> dict[str, Any]:
         """Get stock quote by symbol."""
         if not self.is_available():
             return self.create_unavailable_response(f"get stock quote for {symbol}")
-
-        from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
 
         return await get_stock_price(symbol)
 
@@ -160,8 +162,6 @@ class RobinhoodBroker(BaseBroker):
         if not self.is_available():
             return self.create_unavailable_response(f"get stock price for {symbol}")
 
-        from open_stocks_mcp.tools.robinhood_stock_tools import get_stock_price
-
         return await get_stock_price(symbol)
 
     async def order_buy_market(self, symbol: str, quantity: float) -> dict[str, Any]:
@@ -169,15 +169,11 @@ class RobinhoodBroker(BaseBroker):
         if not self.is_available():
             return self.create_unavailable_response(f"place buy order for {symbol}")
 
-        from open_stocks_mcp.tools.robinhood_trading_tools import order_buy_market
-
         return await order_buy_market(symbol, int(quantity))
 
     async def order_sell_market(self, symbol: str, quantity: float) -> dict[str, Any]:
         """Place market sell order."""
         if not self.is_available():
             return self.create_unavailable_response(f"place sell order for {symbol}")
-
-        from open_stocks_mcp.tools.robinhood_trading_tools import order_sell_market
 
         return await order_sell_market(symbol, int(quantity))

--- a/tests/unit/test_robinhood_broker.py
+++ b/tests/unit/test_robinhood_broker.py
@@ -38,7 +38,9 @@ class TestRobinhoodBrokerConstructor:
             password="secret",
             session_manager=session_mgr,
         )
-        session_mgr.set_credentials.assert_called_once_with("user@example.com", "secret")
+        session_mgr.set_credentials.assert_called_once_with(
+            "user@example.com", "secret"
+        )
         assert rb._auth_info.status == BrokerAuthStatus.NOT_AUTHENTICATED
 
     @pytest.mark.unit
@@ -217,7 +219,7 @@ class TestRobinhoodTradingDelegation:
     ) -> None:
         expected = {"result": {"order_id": "abc123", "status": "queued"}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_trading_tools.order_buy_market",
+            "open_stocks_mcp.brokers.robinhood.order_buy_market",
             new=AsyncMock(return_value=expected),
         ) as mock_tool:
             result = await broker.order_buy_market("AAPL", 3.9)
@@ -233,7 +235,7 @@ class TestRobinhoodTradingDelegation:
     ) -> None:
         expected = {"result": {"order_id": "xyz789", "status": "queued"}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_trading_tools.order_sell_market",
+            "open_stocks_mcp.brokers.robinhood.order_sell_market",
             new=AsyncMock(return_value=expected),
         ) as mock_tool:
             result = await broker.order_sell_market("TSLA", 2.7)
@@ -249,7 +251,7 @@ class TestRobinhoodTradingDelegation:
     ) -> None:
         delegated_error = {"result": {"status": "error", "error": "Insufficient funds"}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_trading_tools.order_buy_market",
+            "open_stocks_mcp.brokers.robinhood.order_buy_market",
             new=AsyncMock(return_value=delegated_error),
         ):
             result = await broker.order_buy_market("AAPL", 1)
@@ -263,7 +265,7 @@ class TestRobinhoodTradingDelegation:
     ) -> None:
         delegated_error = {"result": {"status": "error", "error": "Position not found"}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_trading_tools.order_sell_market",
+            "open_stocks_mcp.brokers.robinhood.order_sell_market",
             new=AsyncMock(return_value=delegated_error),
         ):
             result = await broker.order_sell_market("TSLA", 1)
@@ -276,7 +278,7 @@ class TestRobinhoodTradingDelegation:
         self, unavailable_broker: RobinhoodBroker
     ) -> None:
         with patch(
-            "open_stocks_mcp.tools.robinhood_trading_tools.order_buy_market",
+            "open_stocks_mcp.brokers.robinhood.order_buy_market",
             new=AsyncMock(),
         ) as mock_tool:
             result = await unavailable_broker.order_buy_market("AAPL", 1)
@@ -291,7 +293,7 @@ class TestRobinhoodTradingDelegation:
         self, unavailable_broker: RobinhoodBroker
     ) -> None:
         with patch(
-            "open_stocks_mcp.tools.robinhood_trading_tools.order_sell_market",
+            "open_stocks_mcp.brokers.robinhood.order_sell_market",
             new=AsyncMock(),
         ) as mock_tool:
             result = await unavailable_broker.order_sell_market("TSLA", 1)
@@ -309,7 +311,7 @@ class TestGetStockQuoteDelegation:
     async def test_delegates_to_stock_price_tool(self, broker: RobinhoodBroker) -> None:
         expected = {"result": {"symbol": "AAPL", "price": 150.0}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_stock_tools.get_stock_price",
+            "open_stocks_mcp.brokers.robinhood.get_stock_price",
             new=AsyncMock(return_value=expected),
         ) as mock_tool:
             result = await broker.get_stock_quote("AAPL")
@@ -331,7 +333,7 @@ class TestGetStockQuoteDelegation:
     @pytest.mark.asyncio
     async def test_result_is_not_not_implemented(self, broker: RobinhoodBroker) -> None:
         with patch(
-            "open_stocks_mcp.tools.robinhood_stock_tools.get_stock_price",
+            "open_stocks_mcp.brokers.robinhood.get_stock_price",
             new=AsyncMock(return_value={"result": {"price": 1.0}}),
         ):
             result = await broker.get_stock_quote("TSLA")
@@ -353,7 +355,7 @@ class TestGetStockQuoteDelegation:
         }
 
         with patch(
-            "open_stocks_mcp.tools.robinhood_stock_tools.get_stock_price",
+            "open_stocks_mcp.brokers.robinhood.get_stock_price",
             new=AsyncMock(return_value=expected),
         ) as mock_tool:
             result = await broker.get_stock_quote("123INVALID")
@@ -370,7 +372,7 @@ class TestOtherRobinhoodDelegations:
     async def test_get_account_info_delegates(self, broker: RobinhoodBroker) -> None:
         expected = {"result": {"accounts": []}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_account_tools.get_account_info",
+            "open_stocks_mcp.brokers.robinhood.get_account_info",
             new=AsyncMock(return_value=expected),
         ) as mock_tool:
             result = await broker.get_account_info()
@@ -383,7 +385,7 @@ class TestOtherRobinhoodDelegations:
     async def test_get_portfolio_delegates(self, broker: RobinhoodBroker) -> None:
         expected = {"result": {"portfolio": {}}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_account_tools.get_portfolio",
+            "open_stocks_mcp.brokers.robinhood.get_portfolio",
             new=AsyncMock(return_value=expected),
         ) as mock_tool:
             result = await broker.get_portfolio()
@@ -396,7 +398,7 @@ class TestOtherRobinhoodDelegations:
     async def test_get_positions_delegates(self, broker: RobinhoodBroker) -> None:
         expected = {"result": {"positions": []}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_account_tools.get_positions",
+            "open_stocks_mcp.brokers.robinhood.get_positions",
             new=AsyncMock(return_value=expected),
         ) as mock_tool:
             result = await broker.get_positions()
@@ -410,10 +412,36 @@ class TestOtherRobinhoodDelegations:
     async def test_get_stock_price_delegates(self, broker: RobinhoodBroker) -> None:
         expected = {"result": {"price": 99.0}}
         with patch(
-            "open_stocks_mcp.tools.robinhood_stock_tools.get_stock_price",
+            "open_stocks_mcp.brokers.robinhood.get_stock_price",
             new=AsyncMock(return_value=expected),
         ) as mock_tool:
             result = await broker.get_stock_price("GOOGL")
 
         mock_tool.assert_awaited_once_with("GOOGL")
+        assert result == expected
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_order_buy_market_delegates(self, broker: RobinhoodBroker) -> None:
+        expected = {"result": {"status": "success"}}
+        with patch(
+            "open_stocks_mcp.brokers.robinhood.order_buy_market",
+            new=AsyncMock(return_value=expected),
+        ) as mock_tool:
+            result = await broker.order_buy_market("AAPL", 1)
+
+        mock_tool.assert_awaited_once_with("AAPL", 1)
+        assert result == expected
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_order_sell_market_delegates(self, broker: RobinhoodBroker) -> None:
+        expected = {"result": {"status": "success"}}
+        with patch(
+            "open_stocks_mcp.brokers.robinhood.order_sell_market",
+            new=AsyncMock(return_value=expected),
+        ) as mock_tool:
+            result = await broker.order_sell_market("AAPL", 1)
+
+        mock_tool.assert_awaited_once_with("AAPL", 1)
         assert result == expected


### PR DESCRIPTION
Closes #52

## Changes
- Moved 7 local imports in `brokers/robinhood.py` to module scope, consolidating them into 3 import blocks.
- Updated 13 patch targets in `tests/unit/test_robinhood_broker.py` to point to the broker module instead of tool modules.
- Added 2 new trading delegation tests in `TestOtherRobinhoodDelegations` for `order_buy_market` and `order_sell_market`.
- Verified all 29 tests in `test_robinhood_broker.py` pass.
- Verified zero lint and type errors.

## Test plan
- Run `uv run pytest tests/unit/test_robinhood_broker.py -v`
- Run `uv run ruff check src/open_stocks_mcp/brokers/robinhood.py`
- Run `uv run mypy src/open_stocks_mcp/brokers/robinhood.py`