### PR TITLE
chore: remove unused span validator

### DIFF
--- a/src/open_stocks_mcp/tools/error_handling.py
+++ b/src/open_stocks_mcp/tools/error_handling.py
@@ -27,7 +27,6 @@ from open_stocks_mcp.tools.responses import (
 from open_stocks_mcp.tools.retry import execute_with_retry
 from open_stocks_mcp.tools.validation import (
     validate_period,
-    validate_span,
     validate_symbol,
 )
 
@@ -50,6 +49,5 @@ __all__ = [
     "log_api_call",
     "sanitize_api_response",
     "validate_period",
-    "validate_span",
     "validate_symbol",
 ]

--- a/src/open_stocks_mcp/tools/validation.py
+++ b/src/open_stocks_mcp/tools/validation.py
@@ -17,9 +17,3 @@ def validate_period(period: str) -> bool:
     """Validate a time period parameter."""
     valid_periods = ["day", "week", "month", "3month", "year", "5year", "all"]
     return period in valid_periods
-
-
-def validate_span(span: str) -> bool:
-    """Validate a time span parameter."""
-    valid_spans = ["day", "week", "month", "3month", "year", "5year", "all"]
-    return span in valid_spans

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -31,7 +31,6 @@ from open_stocks_mcp.tools.error_handling import (
     log_api_call,
     sanitize_api_response,
     validate_period,
-    validate_span,
     validate_symbol,
 )
 
@@ -759,18 +758,6 @@ def test_validate_period_valid(period: str) -> None:
 @pytest.mark.parametrize("period", ["hour", "decade", "", "DAY"])
 def test_validate_period_invalid(period: str) -> None:
     assert validate_period(period) is False
-
-
-@pytest.mark.parametrize(
-    "span", ["day", "week", "month", "3month", "year", "5year", "all"]
-)
-def test_validate_span_valid(span: str) -> None:
-    assert validate_span(span) is True
-
-
-@pytest.mark.parametrize("span", ["hour", "decade", "", "DAY"])
-def test_validate_span_invalid(span: str) -> None:
-    assert validate_span(span) is False
 
 
 def test_sanitize_api_response_redacts_recursive_values() -> None:

--- a/tests/unit/test_error_handling_module_split.py
+++ b/tests/unit/test_error_handling_module_split.py
@@ -12,6 +12,11 @@ def test_error_handling_reexports_core_symbols() -> None:
     assert error_handling.validate_symbol is not None
 
 
+def test_error_handling_does_not_export_unused_span_validator() -> None:
+    assert "validate_span" not in error_handling.__all__
+    assert not hasattr(error_handling, "validate_span")
+
+
 def test_validation_behavior_preserved() -> None:
     assert validate_symbol("AAPL") is True
     assert validate_symbol("AAPL7") is True


### PR DESCRIPTION
Closes #55

## Changes
- Remove the unused validate_span helper from validation.py.
- Remove validate_span from the error_handling compatibility facade exports.
- Remove direct validate_span tests and add a facade regression that it is not exported.

## Test plan
- uv run pytest tests/unit/test_error_handling.py tests/unit/test_error_handling_module_split.py -q
- uv run ruff check src/open_stocks_mcp/tools/validation.py src/open_stocks_mcp/tools/error_handling.py tests/unit/test_error_handling.py tests/unit/test_error_handling_module_split.py
- uv run mypy src/open_stocks_mcp/tools/validation.py src/open_stocks_mcp/tools/error_handling.py