### PR TITLE
fix: replace deprecated asyncio.get_event_loop usage

### DIFF
--- a/src/open_stocks_mcp/brokers/session_state.py
+++ b/src/open_stocks_mcp/brokers/session_state.py
@@ -135,12 +135,9 @@ class SessionManager:
         try:
             logger.info(f"Attempting to authenticate user: {self.username}")
 
-            loop = asyncio.get_event_loop()
-
             try:
                 login_result = await asyncio.wait_for(
-                    loop.run_in_executor(
-                        None,
+                    asyncio.to_thread(
                         self._login_with_device_verification,
                         self.username,
                         self.password,
@@ -162,7 +159,7 @@ class SessionManager:
                 self._increment_failed_attempts()
                 return False
 
-            user_profile = await loop.run_in_executor(None, rh.load_user_profile)
+            user_profile = await asyncio.to_thread(rh.load_user_profile)
 
             if user_profile:
                 self.login_time = datetime.now()
@@ -223,8 +220,7 @@ class SessionManager:
         """
         async with self._lock:
             try:
-                loop = asyncio.get_event_loop()
-                await loop.run_in_executor(None, rh.logout)
+                await asyncio.to_thread(rh.logout)
                 logger.info("Successfully logged out")
             except Exception as e:
                 logger.error(f"Error during logout: {e}")

--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -409,5 +409,4 @@ async def rate_limited_call(
     if asyncio.iscoroutinefunction(func):
         return await func(*args, **kwargs)
     else:
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(None, func, *args, **kwargs)
+        return await asyncio.to_thread(func, *args, **kwargs)

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -97,9 +97,8 @@ async def execute_with_retry(
             if asyncio.iscoroutinefunction(func):
                 result = await func(*args, **kwargs)
             else:
-                loop = asyncio.get_event_loop()
                 bound_func = functools.partial(func, *args, **kwargs)
-                result = await loop.run_in_executor(None, bound_func)
+                result = await asyncio.to_thread(bound_func)
 
             session_manager.update_last_successful_call()
             await circuit_breaker.record_success()

--- a/src/open_stocks_mcp/tools/robinhood_dividend_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_dividend_tools.py
@@ -55,8 +55,7 @@ async def get_dividends() -> dict[str, Any]:
         await rate_limiter.acquire()
 
         # Get dividend data
-        loop = asyncio.get_event_loop()
-        dividends = await loop.run_in_executor(None, rh.account.get_dividends)
+        dividends = await asyncio.to_thread(rh.account.get_dividends)
 
         # Validate response
         if not dividends or not isinstance(dividends, list):
@@ -86,8 +85,8 @@ async def get_dividends() -> dict[str, Any]:
             instrument_url = dividend.get("instrument")
             if instrument_url:
                 try:
-                    instrument_data = await loop.run_in_executor(
-                        None, rh.stocks.get_instrument_by_url, instrument_url
+                    instrument_data = await asyncio.to_thread(
+                        rh.stocks.get_instrument_by_url, instrument_url
                     )
                     if instrument_data and isinstance(instrument_data, dict):
                         processed["symbol"] = instrument_data.get("symbol")
@@ -151,11 +150,10 @@ async def get_total_dividends() -> dict[str, Any]:
         await rate_limiter.acquire()
 
         # Use robin_stocks built-in function
-        loop = asyncio.get_event_loop()
-        total = await loop.run_in_executor(None, rh.account.get_total_dividends)
+        total = await asyncio.to_thread(rh.account.get_total_dividends)
 
         # Also get detailed dividends for additional stats
-        dividends = await loop.run_in_executor(None, rh.account.get_dividends)
+        dividends = await asyncio.to_thread(rh.account.get_dividends)
 
         # Calculate additional statistics
         by_year: dict[str, float] = {}
@@ -246,9 +244,8 @@ async def get_dividends_by_instrument(symbol: str) -> dict[str, Any]:
         await rate_limiter.acquire()
 
         # Get dividends by instrument
-        loop = asyncio.get_event_loop()
-        dividends = await loop.run_in_executor(
-            None, rh.account.get_dividends_by_instrument, symbol
+        dividends = await asyncio.to_thread(
+            rh.account.get_dividends_by_instrument, symbol
         )
 
         # Process dividend data
@@ -328,10 +325,7 @@ async def get_interest_payments() -> dict[str, Any]:
         await rate_limiter.acquire()
 
         # Get interest payments
-        loop = asyncio.get_event_loop()
-        interest_payments = await loop.run_in_executor(
-            None, rh.account.get_interest_payments
-        )
+        interest_payments = await asyncio.to_thread(rh.account.get_interest_payments)
 
         # Process interest payment data
         processed_payments = []
@@ -405,10 +399,7 @@ async def get_stock_loan_payments() -> dict[str, Any]:
         await rate_limiter.acquire()
 
         # Get stock loan payments
-        loop = asyncio.get_event_loop()
-        loan_payments = await loop.run_in_executor(
-            None, rh.account.get_stock_loan_payments
-        )
+        loan_payments = await asyncio.to_thread(rh.account.get_stock_loan_payments)
 
         # Process loan payment data
         processed_payments = []
@@ -431,8 +422,8 @@ async def get_stock_loan_payments() -> dict[str, Any]:
                 instrument_url = payment.get("instrument")
                 if instrument_url:
                     try:
-                        instrument_data = await loop.run_in_executor(
-                            None, rh.stocks.get_instrument_by_url, instrument_url
+                        instrument_data = await asyncio.to_thread(
+                            rh.stocks.get_instrument_by_url, instrument_url
                         )
                         if instrument_data and isinstance(instrument_data, dict):
                             processed["symbol"] = instrument_data.get("symbol")

--- a/tests/integration/test_live_market_entrypoint.py
+++ b/tests/integration/test_live_market_entrypoint.py
@@ -24,7 +24,7 @@ def test_get_stock_price_aapl(live_robinhood_session: object) -> None:
 
     from open_stocks_mcp.tools.stocks.quote import get_stock_price
 
-    result = asyncio.get_event_loop().run_until_complete(get_stock_price("AAPL"))
+    result = asyncio.run(get_stock_price("AAPL"))
     assert isinstance(result, dict), "Response must be a dict"
     assert "result" in result, "Response must contain a 'result' key"
     assert isinstance(result["result"], dict), "'result' value must be a dict"

--- a/tests/unit/test_dev_tooling.py
+++ b/tests/unit/test_dev_tooling.py
@@ -126,3 +126,16 @@ def test_dependency_floors_and_pre_commit_revisions() -> None:
     repo_revs = {repo["repo"]: repo["rev"] for repo in pre_commit["repos"]}
     assert repo_revs["https://github.com/astral-sh/ruff-pre-commit"] == "v0.15.14"
     assert repo_revs["https://github.com/pre-commit/pre-commit-hooks"] == "v6.0.0"
+
+
+@pytest.mark.unit
+def test_production_code_avoids_deprecated_asyncio_get_event_loop() -> None:
+    offenders: list[str] = []
+    for path in (ROOT / "src").rglob("*.py"):
+        if "asyncio.get_event_loop(" in path.read_text(encoding="utf-8"):
+            offenders.append(str(path.relative_to(ROOT)))
+
+    assert offenders == [], (
+        "Deprecated asyncio.get_event_loop() found in production code: "
+        + ", ".join(offenders)
+    )

--- a/tests/unit/test_dividend_tools.py
+++ b/tests/unit/test_dividend_tools.py
@@ -1,7 +1,8 @@
 """Unit tests for dividend tools."""
 
+from unittest.mock import AsyncMock
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -15,75 +16,122 @@ from open_stocks_mcp.tools.robinhood_dividend_tools import (
 class TestDividendTools:
     """Test dividend tools with mocked responses."""
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.get_event_loop")
+    @staticmethod
+    def _configure_authenticated_session(
+        mock_get_rate_limiter: Any, mock_get_session_manager: Any
+    ) -> None:
+        session = mock_get_session_manager.return_value
+        session.ensure_authenticated = AsyncMock(return_value=True)
+        mock_get_rate_limiter.return_value.acquire = AsyncMock(return_value=None)
+
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.to_thread")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_get_dividends_success(self, mock_loop: Any) -> None:
+    async def test_get_dividends_success(
+        self, mock_to_thread: Any, mock_get_session_manager: Any, mock_get_rate_limiter: Any
+    ) -> None:
         """Test successful dividends retrieval."""
-        # Mock the event loop and run_in_executor
-        mock_executor = AsyncMock()
-        mock_executor.return_value = [
-            {"amount": "10.00", "payable_date": "2023-01-15"},
-            {"amount": "5.00", "payable_date": "2023-02-15"},
+        self._configure_authenticated_session(
+            mock_get_rate_limiter, mock_get_session_manager
+        )
+        mock_to_thread.side_effect = [
+            [
+                {
+                    "amount": "10.00",
+                    "payable_date": "2023-01-15",
+                    "state": "paid",
+                    "instrument": "instrument://aapl",
+                },
+                {
+                    "amount": "5.00",
+                    "payable_date": "2023-02-15",
+                    "state": "paid",
+                    "instrument": "instrument://msft",
+                },
+            ],
+            {"symbol": "AAPL", "simple_name": "Apple"},
+            {"symbol": "MSFT", "simple_name": "Microsoft"},
         ]
-
-        mock_loop.return_value.run_in_executor = mock_executor
 
         result = await get_dividends()
 
         assert "result" in result
         assert isinstance(result["result"], dict)
+        assert mock_to_thread.await_args_list[0].args[0].__name__ == "get_dividends"
+        assert (
+            mock_to_thread.await_args_list[1].args[0].__name__
+            == "get_instrument_by_url"
+        )
+        assert (
+            mock_to_thread.await_args_list[2].args[0].__name__
+            == "get_instrument_by_url"
+        )
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.get_event_loop")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.to_thread")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_get_total_dividends_success(self, mock_loop: Any) -> None:
+    async def test_get_total_dividends_success(
+        self, mock_to_thread: Any, mock_get_session_manager: Any, mock_get_rate_limiter: Any
+    ) -> None:
         """Test successful total dividends calculation."""
-        # Mock the event loop and run_in_executor
-        mock_executor = AsyncMock()
-        mock_executor.return_value = "100.50"  # Total dividends as string
-
-        mock_loop.return_value.run_in_executor = mock_executor
+        self._configure_authenticated_session(
+            mock_get_rate_limiter, mock_get_session_manager
+        )
+        mock_to_thread.side_effect = [
+            "100.50",
+            [{"state": "paid", "paid_at": "2024-01-15T00:00:00Z", "amount": "10.00"}],
+        ]
 
         result = await get_total_dividends()
 
         assert "result" in result
         assert isinstance(result["result"], dict)
+        assert (
+            mock_to_thread.await_args_list[0].args[0].__name__ == "get_total_dividends"
+        )
+        assert mock_to_thread.await_args_list[1].args[0].__name__ == "get_dividends"
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.get_event_loop")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.to_thread")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_get_dividends_by_instrument_success(self, mock_loop: Any) -> None:
+    async def test_get_dividends_by_instrument_success(
+        self, mock_to_thread: Any, mock_get_session_manager: Any, mock_get_rate_limiter: Any
+    ) -> None:
         """Test successful dividends by instrument retrieval."""
-        # Mock the event loop and run_in_executor
-        mock_executor = AsyncMock()
-        mock_executor.return_value = [
+        self._configure_authenticated_session(
+            mock_get_rate_limiter, mock_get_session_manager
+        )
+        mock_to_thread.return_value = [
             {"amount": "10.00", "symbol": "AAPL"},
         ]
-
-        mock_loop.return_value.run_in_executor = mock_executor
 
         result = await get_dividends_by_instrument("AAPL")
 
         assert "result" in result
         assert isinstance(result["result"], dict)
+        assert (
+            mock_to_thread.await_args.args[0].__name__ == "get_dividends_by_instrument"
+        )
+        assert mock_to_thread.await_args.args[1] == "AAPL"
 
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.get_event_loop")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.to_thread")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_get_dividends_error(self, mock_loop: Any) -> None:
+    async def test_get_dividends_error(self, mock_to_thread: Any) -> None:
         """Test error handling."""
-        # Mock the event loop and run_in_executor to raise an exception
-        mock_executor = AsyncMock()
-        mock_executor.side_effect = Exception("API Error")
-
-        mock_loop.return_value.run_in_executor = mock_executor
+        mock_to_thread.side_effect = Exception("API Error")
 
         result = await get_dividends()
 

--- a/tests/unit/test_simple_rate_limiter.py
+++ b/tests/unit/test_simple_rate_limiter.py
@@ -6,7 +6,11 @@ from unittest.mock import patch
 
 import pytest
 
-from open_stocks_mcp.tools.rate_limiter import RateLimiter, get_rate_limiter
+from open_stocks_mcp.tools.rate_limiter import (
+    RateLimiter,
+    get_rate_limiter,
+    rate_limited_call,
+)
 
 
 class TestSimpleRateLimiter:
@@ -395,3 +399,25 @@ class TestRequestCoordinator:
         c1 = get_request_coordinator()
         c2 = get_request_coordinator()
         assert c1 is c2
+
+
+@pytest.mark.journey_system
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rate_limited_call_runs_sync_function_without_deprecated_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_acquire(_endpoint: str | None = None) -> None:
+        return None
+
+    monkeypatch.setattr(get_rate_limiter(), "acquire", fake_acquire)
+    monkeypatch.setattr(
+        "open_stocks_mcp.tools.rate_limiter.asyncio.get_event_loop",
+        lambda: (_ for _ in ()).throw(AssertionError("deprecated loop lookup")),
+    )
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    result = await rate_limited_call(add, 2, 3)
+    assert result == 5


### PR DESCRIPTION
Closes #58

## Changes
- replaced deprecated `asyncio.get_event_loop()` + `run_in_executor` patterns with `asyncio.to_thread(...)` in retry, rate limiter, and dividend tools
- updated real session manager implementation in `src/open_stocks_mcp/brokers/session_state.py` (the `tools/session_manager.py` module is a re-export shim)
- updated dividend tests to patch/assert `asyncio.to_thread` behavior
- replaced live integration entrypoint loop usage with `asyncio.run(...)`
- added a static regression test that fails if production code reintroduces `asyncio.get_event_loop(` under `src/`

## Test plan
- `uv run pytest tests/unit/test_error_handling.py::test_execute_with_retry_runs_sync_in_executor tests/unit/test_simple_rate_limiter.py::test_rate_limited_call_runs_sync_function_without_deprecated_loop tests/unit/test_session_manager.py::test_authenticate_success_with_login_and_profile tests/unit/test_session_manager.py::test_authenticate_false_when_login_returns_false tests/unit/test_session_manager.py::test_logout_clears_session_state tests/unit/test_session_manager.py::test_logout_reraises_exception_and_still_clears_state -q`
- `uv run pytest tests/unit/test_dev_tooling.py::test_production_code_avoids_deprecated_asyncio_get_event_loop tests/unit/test_dividend_tools.py tests/integration/test_live_market_entrypoint.py --collect-only -q`
- `uv run ruff check src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/brokers/session_state.py src/open_stocks_mcp/tools/robinhood_dividend_tools.py tests/unit/test_error_handling.py tests/unit/test_simple_rate_limiter.py tests/unit/test_session_manager.py tests/unit/test_dividend_tools.py tests/unit/test_dev_tooling.py tests/integration/test_live_market_entrypoint.py`
- `uv run mypy src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/brokers/session_state.py src/open_stocks_mcp/tools/robinhood_dividend_tools.py`
- `rg -n "asyncio\.get_event_loop\(" src tests/integration tests/unit --glob '!tests/unit/test_dev_tooling.py'`
