### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/src/open_stocks_mcp/brokers/schwab_stream.py
+++ b/src/open_stocks_mcp/brokers/schwab_stream.py
@@ -80,8 +80,6 @@ class SchwabStreamManager:
             self.stream_client.add_nasdaq_book_handler(_core_handler)
             self.stream_client.add_nyse_book_handler(_core_handler)
             self.stream_client.add_account_activity_handler(_core_handler)
-            self.stream_client.add_nasdaq_book_handler(_core_handler)
-            self.stream_client.add_nyse_book_handler(_core_handler)
 
             await self.stream_client.login()
             self._is_running = True
@@ -275,7 +273,9 @@ class SchwabStreamManager:
             logger.info(f"Subscribed to Schwab Level 2 ({venue}): {symbol}")
             return True
         except Exception as e:
-            logger.error(f"Failed to subscribe to Schwab Level 2 ({venue}) for {symbol}: {e}")
+            logger.error(
+                f"Failed to subscribe to Schwab Level 2 ({venue}) for {symbol}: {e}"
+            )
             return False
 
     def get_latest_activity(self) -> list[dict[str, Any]]:
@@ -290,9 +290,6 @@ class SchwabStreamManager:
         """Get latest cached option quote for symbol."""
         return self._latest_option_quotes.get(symbol.upper())
 
-    def get_latest_level2(self, symbol: str) -> dict[str, Any] | None:
-        """Get latest cached Level 2 book for symbol."""
-        return self._latest_level2_books.get(symbol.upper())
     def get_latest_level2(
         self, symbol: str, venue: str = "nasdaq"
     ) -> dict[str, Any] | None:

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1571,7 +1571,9 @@ async def schwab_get_stock_loan_payments(
         start_date: Optional start date (YYYY-MM-DD)
         end_date: Optional end date (YYYY-MM-DD)
     """
-    return await _schwab_get_stock_loan_payments_impl(account_hash, start_date, end_date)
+    return await _schwab_get_stock_loan_payments_impl(
+        account_hash, start_date, end_date
+    )
 
 
 @mcp.tool()
@@ -1964,6 +1966,7 @@ async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
 
 
 @mcp.tool()
+<<<<<<< HEAD
 async def schwab_stream_quotes(symbols: list[str]) -> dict[str, Any]:
     """Get real-time equity quote snapshots from Schwab streaming.
 
@@ -1980,10 +1983,11 @@ async def schwab_stream_level2(symbol: str, venue: str = "nasdaq") -> dict[str, 
 
 
 @mcp.tool()
+=======
+>>>>>>> af859be (chore: automated code-quality cleanup)
 async def schwab_stream_account_activity() -> dict[str, Any]:
     """Get latest account activity events from Schwab streaming."""
     return await _schwab_stream_account_activity_impl()
-
 
 
 def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -1966,7 +1966,6 @@ async def schwab_stream_option_quotes(symbols: list[str]) -> dict[str, Any]:
 
 
 @mcp.tool()
-<<<<<<< HEAD
 async def schwab_stream_quotes(symbols: list[str]) -> dict[str, Any]:
     """Get real-time equity quote snapshots from Schwab streaming.
 
@@ -1983,8 +1982,6 @@ async def schwab_stream_level2(symbol: str, venue: str = "nasdaq") -> dict[str, 
 
 
 @mcp.tool()
-=======
->>>>>>> af859be (chore: automated code-quality cleanup)
 async def schwab_stream_account_activity() -> dict[str, Any]:
     """Get latest account activity events from Schwab streaming."""
     return await _schwab_stream_account_activity_impl()

--- a/src/open_stocks_mcp/tools/robinhood_stock_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_stock_tools.py
@@ -87,17 +87,19 @@ async def get_stock_price(symbol: str) -> dict[str, Any]:
     change_percent = (change / previous_close * 100) if previous_close else 0.0
 
     logger.info(f"Successfully retrieved stock price for {symbol}")
-    return create_success_response({
-        "symbol": symbol,
-        "price": current_price,
-        "change": round(change, 2),
-        "change_percent": round(change_percent, 2),
-        "previous_close": previous_close,
-        "volume": int(quote.get("volume", 0)),
-        "ask_price": float(quote.get("ask_price", 0)),
-        "bid_price": float(quote.get("bid_price", 0)),
-        "last_trade_price": float(quote.get("last_trade_price", 0)),
-    })
+    return create_success_response(
+        {
+            "symbol": symbol,
+            "price": current_price,
+            "change": round(change, 2),
+            "change_percent": round(change_percent, 2),
+            "previous_close": previous_close,
+            "volume": int(quote.get("volume", 0)),
+            "ask_price": float(quote.get("ask_price", 0)),
+            "bid_price": float(quote.get("bid_price", 0)),
+            "last_trade_price": float(quote.get("last_trade_price", 0)),
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -145,20 +147,22 @@ async def get_stock_info(symbol: str) -> dict[str, Any]:
     company_name = await execute_with_retry(rh.get_name_by_symbol, symbol)
 
     logger.info(f"Successfully retrieved stock info for {symbol}")
-    return create_success_response({
-        "symbol": symbol,
-        "company_name": company_name or instrument.get("simple_name", "N/A"),
-        "sector": fundamental.get("sector", "N/A"),
-        "industry": fundamental.get("industry", "N/A"),
-        "description": fundamental.get("description", "N/A"),
-        "market_cap": fundamental.get("market_cap", "N/A"),
-        "pe_ratio": fundamental.get("pe_ratio", "N/A"),
-        "dividend_yield": fundamental.get("dividend_yield", "N/A"),
-        "high_52_weeks": fundamental.get("high_52_weeks", "N/A"),
-        "low_52_weeks": fundamental.get("low_52_weeks", "N/A"),
-        "average_volume": fundamental.get("average_volume", "N/A"),
-        "tradeable": instrument.get("tradeable", False),
-    })
+    return create_success_response(
+        {
+            "symbol": symbol,
+            "company_name": company_name or instrument.get("simple_name", "N/A"),
+            "sector": fundamental.get("sector", "N/A"),
+            "industry": fundamental.get("industry", "N/A"),
+            "description": fundamental.get("description", "N/A"),
+            "market_cap": fundamental.get("market_cap", "N/A"),
+            "pe_ratio": fundamental.get("pe_ratio", "N/A"),
+            "dividend_yield": fundamental.get("dividend_yield", "N/A"),
+            "high_52_weeks": fundamental.get("high_52_weeks", "N/A"),
+            "low_52_weeks": fundamental.get("low_52_weeks", "N/A"),
+            "average_volume": fundamental.get("average_volume", "N/A"),
+            "tradeable": instrument.get("tradeable", False),
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -185,32 +189,38 @@ async def search_stocks(query: str) -> dict[str, Any]:
     search_results = await execute_with_retry(rh.find_instrument_data, query)
 
     if not search_results:
-        return create_success_response({
-            "query": query,
-            "results": [],
-            "count": 0,
-            "message": f"No stocks found matching query: {query}",
-        })
+        return create_success_response(
+            {
+                "query": query,
+                "results": [],
+                "count": 0,
+                "message": f"No stocks found matching query: {query}",
+            }
+        )
 
     # Process search results (limit to 10 for performance)
     results = []
     for item in search_results[:10]:
         symbol = item.get("symbol", "")
         if symbol:  # Only include results with valid symbols
-            results.append({
-                "symbol": symbol.upper(),
-                "name": item.get("simple_name", "N/A"),
-                "tradeable": item.get("tradeable", False),
-                "country": item.get("country", "N/A"),
-                "type": item.get("type", "N/A"),
-            })
+            results.append(
+                {
+                    "symbol": symbol.upper(),
+                    "name": item.get("simple_name", "N/A"),
+                    "tradeable": item.get("tradeable", False),
+                    "country": item.get("country", "N/A"),
+                    "type": item.get("type", "N/A"),
+                }
+            )
 
     logger.info(f"Successfully searched stocks for query: {query}")
-    return create_success_response({
-        "query": query,
-        "results": results,
-        "count": len(results),
-    })
+    return create_success_response(
+        {
+            "query": query,
+            "results": results,
+            "count": len(results),
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -232,13 +242,15 @@ async def get_market_hours() -> dict[str, Any]:
     # Process market data - focus on main markets
     market_data = []
     for market in markets[:5]:  # Limit to top 5 markets
-        market_data.append({
-            "name": market.get("name", "N/A"),
-            "mic": market.get("mic", "N/A"),
-            "operating_mic": market.get("operating_mic", "N/A"),
-            "timezone": market.get("timezone", "N/A"),
-            "website": market.get("website", "N/A"),
-        })
+        market_data.append(
+            {
+                "name": market.get("name", "N/A"),
+                "mic": market.get("mic", "N/A"),
+                "operating_mic": market.get("operating_mic", "N/A"),
+                "timezone": market.get("timezone", "N/A"),
+                "website": market.get("website", "N/A"),
+            }
+        )
 
     logger.info("Successfully retrieved market hours information")
     return create_success_response({"markets": market_data, "count": len(market_data)})
@@ -300,23 +312,27 @@ async def get_price_history(symbol: str, period: str = "week") -> dict[str, Any]
     price_points = []
     for data_point in historical_data[-20:]:
         if data_point and data_point.get("close_price"):
-            price_points.append({
-                "date": data_point.get("begins_at", "N/A"),
-                "open": float(data_point.get("open_price", 0)),
-                "high": float(data_point.get("high_price", 0)),
-                "low": float(data_point.get("low_price", 0)),
-                "close": float(data_point.get("close_price", 0)),
-                "volume": int(data_point.get("volume", 0)),
-            })
+            price_points.append(
+                {
+                    "date": data_point.get("begins_at", "N/A"),
+                    "open": float(data_point.get("open_price", 0)),
+                    "high": float(data_point.get("high_price", 0)),
+                    "low": float(data_point.get("low_price", 0)),
+                    "close": float(data_point.get("close_price", 0)),
+                    "volume": int(data_point.get("volume", 0)),
+                }
+            )
 
     logger.info(f"Successfully retrieved price history for {symbol} over {period}")
-    return create_success_response({
-        "symbol": symbol,
-        "period": period,
-        "interval": interval,
-        "data_points": price_points,
-        "count": len(price_points),
-    })
+    return create_success_response(
+        {
+            "symbol": symbol,
+            "period": period,
+            "interval": interval,
+            "data_points": price_points,
+            "count": len(price_points),
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -369,37 +385,43 @@ async def get_instruments_by_symbols(symbols: list[str]) -> dict[str, Any]:
     processed_instruments = []
     for instrument in instruments_data:
         if instrument:
-            processed_instruments.append({
-                "symbol": instrument.get("symbol", "N/A"),
-                "name": instrument.get("name", "N/A"),
-                "instrument_id": instrument.get("id", "N/A"),
-                "url": instrument.get("url", "N/A"),
-                "tradeable": instrument.get("tradeable", False),
-                "market": instrument.get("market", "N/A"),
-                "list_date": instrument.get("list_date", "N/A"),
-                "state": instrument.get("state", "N/A"),
-                "type": instrument.get("type", "N/A"),
-                "tradability": instrument.get("tradability", "N/A"),
-                "simple_name": instrument.get("simple_name", "N/A"),
-                "country": instrument.get("country", "N/A"),
-                "symbol_description": instrument.get("symbol_description", "N/A"),
-                "fractional_tradability": instrument.get(
-                    "fractional_tradability", "N/A"
-                ),
-                "maintenance_ratio": instrument.get("maintenance_ratio", "N/A"),
-                "margin_initial_ratio": instrument.get("margin_initial_ratio", "N/A"),
-                "day_trade_ratio": instrument.get("day_trade_ratio", "N/A"),
-                "bloomberg_unique": instrument.get("bloomberg_unique", "N/A"),
-            })
+            processed_instruments.append(
+                {
+                    "symbol": instrument.get("symbol", "N/A"),
+                    "name": instrument.get("name", "N/A"),
+                    "instrument_id": instrument.get("id", "N/A"),
+                    "url": instrument.get("url", "N/A"),
+                    "tradeable": instrument.get("tradeable", False),
+                    "market": instrument.get("market", "N/A"),
+                    "list_date": instrument.get("list_date", "N/A"),
+                    "state": instrument.get("state", "N/A"),
+                    "type": instrument.get("type", "N/A"),
+                    "tradability": instrument.get("tradability", "N/A"),
+                    "simple_name": instrument.get("simple_name", "N/A"),
+                    "country": instrument.get("country", "N/A"),
+                    "symbol_description": instrument.get("symbol_description", "N/A"),
+                    "fractional_tradability": instrument.get(
+                        "fractional_tradability", "N/A"
+                    ),
+                    "maintenance_ratio": instrument.get("maintenance_ratio", "N/A"),
+                    "margin_initial_ratio": instrument.get(
+                        "margin_initial_ratio", "N/A"
+                    ),
+                    "day_trade_ratio": instrument.get("day_trade_ratio", "N/A"),
+                    "bloomberg_unique": instrument.get("bloomberg_unique", "N/A"),
+                }
+            )
 
     logger.info(
         f"Successfully retrieved instrument data for {len(processed_instruments)} symbols"
     )
-    return create_success_response({
-        "instruments": processed_instruments,
-        "count": len(processed_instruments),
-        "requested_symbols": clean_symbols,
-    })
+    return create_success_response(
+        {
+            "instruments": processed_instruments,
+            "count": len(processed_instruments),
+            "requested_symbols": clean_symbols,
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -434,35 +456,39 @@ async def find_instrument_data(query: str) -> dict[str, Any]:
     processed_instruments = []
     for instrument in instruments_data[:10]:
         if instrument:
-            processed_instruments.append({
-                "symbol": instrument.get("symbol", "N/A"),
-                "name": instrument.get("name", "N/A"),
-                "instrument_id": instrument.get("id", "N/A"),
-                "url": instrument.get("url", "N/A"),
-                "tradeable": instrument.get("tradeable", False),
-                "market": instrument.get("market", "N/A"),
-                "list_date": instrument.get("list_date", "N/A"),
-                "state": instrument.get("state", "N/A"),
-                "type": instrument.get("type", "N/A"),
-                "tradability": instrument.get("tradability", "N/A"),
-                "simple_name": instrument.get("simple_name", "N/A"),
-                "country": instrument.get("country", "N/A"),
-                "symbol_description": instrument.get("symbol_description", "N/A"),
-                "fractional_tradability": instrument.get(
-                    "fractional_tradability", "N/A"
-                ),
-            })
+            processed_instruments.append(
+                {
+                    "symbol": instrument.get("symbol", "N/A"),
+                    "name": instrument.get("name", "N/A"),
+                    "instrument_id": instrument.get("id", "N/A"),
+                    "url": instrument.get("url", "N/A"),
+                    "tradeable": instrument.get("tradeable", False),
+                    "market": instrument.get("market", "N/A"),
+                    "list_date": instrument.get("list_date", "N/A"),
+                    "state": instrument.get("state", "N/A"),
+                    "type": instrument.get("type", "N/A"),
+                    "tradability": instrument.get("tradability", "N/A"),
+                    "simple_name": instrument.get("simple_name", "N/A"),
+                    "country": instrument.get("country", "N/A"),
+                    "symbol_description": instrument.get("symbol_description", "N/A"),
+                    "fractional_tradability": instrument.get(
+                        "fractional_tradability", "N/A"
+                    ),
+                }
+            )
 
     logger.info(
         f"Successfully found {len(processed_instruments)} instruments for query: {query}"
     )
-    return create_success_response({
-        "instruments": processed_instruments,
-        "count": len(processed_instruments),
-        "query": query,
-        "total_results": len(instruments_data),
-        "showing_results": len(processed_instruments),
-    })
+    return create_success_response(
+        {
+            "instruments": processed_instruments,
+            "count": len(processed_instruments),
+            "query": query,
+            "total_results": len(instruments_data),
+            "showing_results": len(processed_instruments),
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -572,21 +598,25 @@ async def get_pricebook_by_symbol(symbol: str) -> dict[str, Any]:
         if pricebook_data.get("asks"):
             for ask in pricebook_data["asks"]:
                 if ask:
-                    processed_asks.append({
-                        "price": float(ask.get("price", 0)),
-                        "quantity": int(ask.get("quantity", 0)),
-                        "side": "ask",
-                    })
+                    processed_asks.append(
+                        {
+                            "price": float(ask.get("price", 0)),
+                            "quantity": int(ask.get("quantity", 0)),
+                            "side": "ask",
+                        }
+                    )
 
         # Process bids (buy orders)
         if pricebook_data.get("bids"):
             for bid in pricebook_data["bids"]:
                 if bid:
-                    processed_bids.append({
-                        "price": float(bid.get("price", 0)),
-                        "quantity": int(bid.get("quantity", 0)),
-                        "side": "bid",
-                    })
+                    processed_bids.append(
+                        {
+                            "price": float(bid.get("price", 0)),
+                            "quantity": int(bid.get("quantity", 0)),
+                            "side": "bid",
+                        }
+                    )
 
         # Sort asks by price (ascending) and bids by price (descending)
         processed_asks.sort(key=lambda x: x["price"])  # type: ignore[arg-type,return-value]

--- a/src/open_stocks_mcp/tools/schwab_account_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_account_tools.py
@@ -323,7 +323,9 @@ async def schwab_get_margin_interest(
                 account_hash,
                 start_date=parsed_start_date,
                 end_date=parsed_end_date,
-                transaction_types=[Client.Transactions.TransactionType.DIVIDEND_OR_INTEREST],
+                transaction_types=[
+                    Client.Transactions.TransactionType.DIVIDEND_OR_INTEREST
+                ],
             )
             return response.json()
 

--- a/src/open_stocks_mcp/tools/schwab_payment_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_payment_tools.py
@@ -173,7 +173,9 @@ async def schwab_get_stock_loan_payments(
         )
 
     except Exception as e:
-        logger.error(f"Error getting Schwab stock loan payments for {account_hash}: {e}")
+        logger.error(
+            f"Error getting Schwab stock loan payments for {account_hash}: {e}"
+        )
         return create_error_response(e)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,7 @@ class MockBroker(BaseBroker):
     async def order_sell_market(self, symbol: str, quantity: float) -> dict[str, Any]:
         return {"result": {"order": "sell"}}
 
+
 try:
     import pytest_asyncio  # noqa: F401
 except ImportError:

--- a/tests/unit/test_capabilities_and_streaming.py
+++ b/tests/unit/test_capabilities_and_streaming.py
@@ -156,26 +156,6 @@ async def test_schwab_stream_manager_handles_level2_by_venue() -> None:
 
 
 @pytest.mark.asyncio
-async def test_schwab_stream_manager_subscribe_level2() -> None:
-    from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
-
-    mock_broker = MagicMock()
-    manager = SchwabStreamManager(mock_broker)
-    manager._is_running = True
-    manager.stream_client = AsyncMock()
-
-    success_nasdaq = await manager.subscribe_level2("AAPL", "nasdaq")
-    success_nyse = await manager.subscribe_level2("AAPL", "nyse")
-    unsupported = await manager.subscribe_level2("AAPL", "arca")
-
-    assert success_nasdaq is True
-    assert success_nyse is True
-    assert unsupported is False
-    manager.stream_client.nasdaq_book_subs.assert_awaited_once_with(["AAPL"])
-    manager.stream_client.nyse_book_subs.assert_awaited_once_with(["AAPL"])
-
-
-@pytest.mark.asyncio
 async def test_schwab_stream_manager_subscribe_quotes_splitting() -> None:
     from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
 
@@ -280,10 +260,10 @@ async def test_schwab_stream_manager_level2_handling() -> None:
     }
 
     manager._handle_message(nasdaq_message)
-    book = manager.get_latest_level2("AAPL")
+    book = manager.get_latest_level2("AAPL", "nasdaq")
     assert book is not None
-    assert book["SYMBOL"] == "AAPL"
-    assert book["BIDS"][0]["PRICE"] == 150.0
+    assert book["symbol"] == "AAPL"
+    assert book["bids"][0]["PRICE"] == 150.0
 
     # Test NYSE_BOOK message handling
     nyse_message = {
@@ -299,10 +279,10 @@ async def test_schwab_stream_manager_level2_handling() -> None:
     }
 
     manager._handle_message(nyse_message)
-    book = manager.get_latest_level2("IBM")
+    book = manager.get_latest_level2("IBM", "nyse")
     assert book is not None
-    assert book["SYMBOL"] == "IBM"
-    assert book["BIDS"][0]["PRICE"] == 130.0
+    assert book["symbol"] == "IBM"
+    assert book["bids"][0]["PRICE"] == 130.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_client_app.py
+++ b/tests/unit/test_client_app.py
@@ -40,7 +40,9 @@ async def test_call_tool_initializes_stdio_session_and_returns_text():
     mock_session_cm.__aexit__ = AsyncMock()
 
     with (
-        patch("open_stocks_mcp.client.app.stdio_client", return_value=mock_stdio_cm) as mock_stdio,
+        patch(
+            "open_stocks_mcp.client.app.stdio_client", return_value=mock_stdio_cm
+        ) as mock_stdio,
         patch("open_stocks_mcp.client.app.ClientSession", return_value=mock_session_cm),
     ):
         result = await call_tool(tool_name, arguments)
@@ -121,7 +123,9 @@ def test_main_parses_message_and_prints_response():
     runner = CliRunner()
     expected_response = "mocked response"
 
-    with patch("open_stocks_mcp.client.app.call_tool", new_callable=AsyncMock) as mock_call:
+    with patch(
+        "open_stocks_mcp.client.app.call_tool", new_callable=AsyncMock
+    ) as mock_call:
         mock_call.return_value = expected_response
 
         result = runner.invoke(main, ["get_stock_orders status=pending symbol=AAPL"])
@@ -137,7 +141,9 @@ def test_main_splits_argument_values_once_and_ignores_non_key_tokens():
     """Test argument parsing edge cases in main."""
     runner = CliRunner()
 
-    with patch("open_stocks_mcp.client.app.call_tool", new_callable=AsyncMock) as mock_call:
+    with patch(
+        "open_stocks_mcp.client.app.call_tool", new_callable=AsyncMock
+    ) as mock_call:
         mock_call.return_value = "ok"
 
         # query=foo=bar should result in key='query', value='foo=bar'

--- a/tests/unit/test_docker_compose_security.py
+++ b/tests/unit/test_docker_compose_security.py
@@ -32,11 +32,9 @@ def test_service_mounts_mcp_tokens(compose_config: dict) -> None:
     for svc_name, svc in compose_config.get("services", {}).items():
         vols = svc.get("volumes", [])
         token_mounts = [
-            v
-            for v in vols
-            if isinstance(v, str) and v.startswith("mcp_tokens:")
+            v for v in vols if isinstance(v, str) and v.startswith("mcp_tokens:")
         ]
         assert token_mounts, f"service '{svc_name}' must mount mcp_tokens"
-        assert any(
-            v == "mcp_tokens:/home/mcp/.tokens" for v in token_mounts
-        ), f"service '{svc_name}' must mount mcp_tokens at /home/mcp/.tokens"
+        assert any(v == "mcp_tokens:/home/mcp/.tokens" for v in token_mounts), (
+            f"service '{svc_name}' must mount mcp_tokens at /home/mcp/.tokens"
+        )

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -243,8 +243,11 @@ async def test_alert_dedup_cleanup_avoids_memory_growth() -> None:
     # Map should be empty since 1s > 0.1s
     assert "test_signal" not in collector._last_alert_at
 
+
 @pytest.mark.asyncio
-async def test_monitored_tool_wraps_exception_with_explicit_cause_and_records_metric() -> None:
+async def test_monitored_tool_wraps_exception_with_explicit_cause_and_records_metric() -> (
+    None
+):
     metrics = MetricsCollector(window_size_minutes=1)
     tool = MonitoredTool("failing_tool")
     tool.metrics = metrics

--- a/tests/unit/test_robinhood_broker.py
+++ b/tests/unit/test_robinhood_broker.py
@@ -38,7 +38,9 @@ class TestRobinhoodBrokerConstructor:
             password="secret",
             session_manager=session_mgr,
         )
-        session_mgr.set_credentials.assert_called_once_with("user@example.com", "secret")
+        session_mgr.set_credentials.assert_called_once_with(
+            "user@example.com", "secret"
+        )
         assert rb._auth_info.status == BrokerAuthStatus.NOT_AUTHENTICATED
 
     @pytest.mark.unit

--- a/tests/unit/test_robinhood_crypto_tools.py
+++ b/tests/unit/test_robinhood_crypto_tools.py
@@ -12,7 +12,9 @@ class TestCryptoPositionsStub:
     @pytest.mark.journey_system
     @pytest.mark.asyncio
     async def test_raises_not_implemented(self) -> None:
-        with pytest.raises(NotImplementedError, match="Crypto positions are not yet implemented"):
+        with pytest.raises(
+            NotImplementedError, match="Crypto positions are not yet implemented"
+        ):
             await get_crypto_positions()
 
     @pytest.mark.unit

--- a/tests/unit/test_schwab_account_tools.py
+++ b/tests/unit/test_schwab_account_tools.py
@@ -441,7 +441,9 @@ class TestSchwabMarginTools:
 
         assert result["result"]["charges_count"] == 2
         assert result["result"]["total_charges"] == pytest.approx(20.75)
-        descriptions = [txn["description"] for txn in result["result"]["interest_charges"]]
+        descriptions = [
+            txn["description"] for txn in result["result"]["interest_charges"]
+        ]
         assert "QUALIFIED DIVIDEND" not in descriptions
         for txn in result["result"]["interest_charges"]:
             assert "transactionId" in txn

--- a/tests/unit/test_schwab_payment_tools.py
+++ b/tests/unit/test_schwab_payment_tools.py
@@ -353,7 +353,9 @@ async def test_schwab_get_total_dividends_aggregates_amounts(
 @pytest.mark.asyncio
 @patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
 @patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
-async def test_schwab_get_total_dividends_groups_by_year(mock_to_thread, mock_get_broker):
+async def test_schwab_get_total_dividends_groups_by_year(
+    mock_to_thread, mock_get_broker
+):
     broker = MagicMock()
     mock_get_broker.return_value = (broker, None)
     mock_to_thread.return_value = [
@@ -540,7 +542,10 @@ async def test_schwab_get_stock_loan_payments_filters_non_loan_journals(
 
     assert result["result"]["status"] == "success"
     assert len(result["result"]["loan_payments"]) == 1
-    assert result["result"]["loan_payments"][0]["description"] == "SECURITIES LENDING REVENUE"
+    assert (
+        result["result"]["loan_payments"][0]["description"]
+        == "SECURITIES LENDING REVENUE"
+    )
     assert result["result"]["total_amount"] == "2.00"
     assert result["result"]["enrolled"] is True
 
@@ -571,7 +576,9 @@ async def test_schwab_get_stock_loan_payments_empty_returns_not_enrolled(
 @pytest.mark.asyncio
 @patch("open_stocks_mcp.tools.schwab_payment_tools.get_authenticated_broker_or_error")
 @patch("open_stocks_mcp.tools.schwab_payment_tools.asyncio.to_thread")
-async def test_schwab_get_stock_loan_payments_auth_error(mock_to_thread, mock_get_broker):
+async def test_schwab_get_stock_loan_payments_auth_error(
+    mock_to_thread, mock_get_broker
+):
     mock_get_broker.return_value = (
         None,
         {"result": {"status": "error", "error": "Auth failed"}},

--- a/tests/unit/test_schwab_streaming_tools.py
+++ b/tests/unit/test_schwab_streaming_tools.py
@@ -249,8 +249,26 @@ async def test_schwab_stream_level2_success() -> None:
     "symbol,venue,capability,manager_exists,is_running,sub_success,snapshot,expected_reason",
     [
         ("AAPL", "arca", True, True, True, True, {"x": 1}, "unsupported venue"),
-        ("AAPL", "nasdaq", False, True, True, True, {"x": 1}, "streaming capability disabled"),
-        ("AAPL", "nasdaq", True, False, True, True, {"x": 1}, "stream manager unavailable"),
+        (
+            "AAPL",
+            "nasdaq",
+            False,
+            True,
+            True,
+            True,
+            {"x": 1},
+            "streaming capability disabled",
+        ),
+        (
+            "AAPL",
+            "nasdaq",
+            True,
+            False,
+            True,
+            True,
+            {"x": 1},
+            "stream manager unavailable",
+        ),
         ("AAPL", "nasdaq", True, True, False, True, {"x": 1}, "stream manager stopped"),
         ("AAPL", "nasdaq", True, True, True, False, {"x": 1}, "subscription failed"),
         ("AAPL", "nasdaq", True, True, True, True, None, "no snapshot available"),
@@ -272,7 +290,9 @@ async def test_schwab_stream_level2_unavailable(
     }
     if manager_exists:
         mock_broker.stream_manager.is_running = is_running
-        mock_broker.stream_manager.subscribe_level2 = AsyncMock(return_value=sub_success)
+        mock_broker.stream_manager.subscribe_level2 = AsyncMock(
+            return_value=sub_success
+        )
         mock_broker.stream_manager.get_latest_level2.return_value = snapshot
     else:
         mock_broker.stream_manager = None


### PR DESCRIPTION
## Summary

Automated code-quality cleanup run with `ruff check --fix` and `ruff format`, plus manual fixes for 7 errors that couldn't be auto-fixed.

### Changes

**Format fixes (15 files):** Reformatted by `ruff format`

**Lint fixes (7 errors resolved):**
- **Duplicate function definitions (F811):** Removed stale/superseded versions of `get_latest_level2`, `schwab_stream_level2`, `test_schwab_stream_manager_subscribe_level2`, `test_schwab_stream_level2_success`, and `test_schwab_stream_level2_unavailable` — kept the more complete venue-aware versions
- **Undefined name (F821):** Added missing import for `schwab_get_open_option_orders` as `_schwab_get_open_option_orders_impl` in `server/app.py`
- **Duplicate handler registrations:** Removed duplicate `add_nasdaq_book_handler` / `add_nyse_book_handler` calls in `SchwabStreamManager.start()` that caused 2 pre-existing test failures
- **Test assertion fixes:** Updated `test_schwab_stream_manager_level2_handling` to match the current normalized cache format (lowercase keys, venue-qualified lookup)

### Validation

- `ruff check .` — 0 errors
- `mypy src/` — 0 errors
- `pytest tests/unit/` — 944 passed, 69 skipped, 0 failed (fixed 2 pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)