### PR TITLE
refactor: centralize default options retry count

### DIFF
--- a/src/open_stocks_mcp/tools/error_handling.py
+++ b/src/open_stocks_mcp/tools/error_handling.py
@@ -23,13 +23,14 @@ from open_stocks_mcp.tools.responses import (
     log_api_call,
     sanitize_api_response,
 )
-from open_stocks_mcp.tools.retry import execute_with_retry
+from open_stocks_mcp.tools.retry import DEFAULT_MAX_RETRIES, execute_with_retry
 from open_stocks_mcp.tools.validation import (
     validate_period,
     validate_symbol,
 )
 
 __all__ = [
+    "DEFAULT_MAX_RETRIES",
     "APIError",
     "AuthenticationError",
     "CircuitBreakerError",

--- a/src/open_stocks_mcp/tools/options/chains.py
+++ b/src/open_stocks_mcp/tools/options/chains.py
@@ -82,7 +82,7 @@ async def get_options_chains(symbol: str) -> dict[str, Any]:
         return {"result": {"error": "Symbol is required", "status": "error"}}
 
     # Get option chains data
-    chains_data = await execute_with_retry(rh.options.get_chains, symbol, max_retries=3)
+    chains_data = await execute_with_retry(rh.options.get_chains, symbol)
 
     if not chains_data:
         logger.warning(f"No option chains found for {symbol}")
@@ -193,7 +193,6 @@ async def find_tradable_options(
             symbol,
             expiration_date,
             option_type,
-            max_retries=3,
         )
     except AttributeError:
         # Fallback: try alternative API function names
@@ -202,7 +201,6 @@ async def find_tradable_options(
                 rh.get_option_contracts_by_ticker,
                 symbol,
                 expiration_date,
-                max_retries=3,
             )
         except AttributeError:
             logger.error("Could not find correct Robin Stocks options API function")

--- a/src/open_stocks_mcp/tools/options/market_data.py
+++ b/src/open_stocks_mcp/tools/options/market_data.py
@@ -79,7 +79,6 @@ async def get_option_market_data(option_id: str) -> dict[str, Any]:
     market_data = await execute_with_retry(
         rh.options.get_option_market_data_by_id,
         option_id,
-        max_retries=3,
     )
 
     if not market_data:
@@ -189,7 +188,6 @@ async def get_option_historicals(
         option_type,
         interval,
         span,
-        max_retries=3,
     )
 
     if not historical_data:

--- a/src/open_stocks_mcp/tools/options/positions.py
+++ b/src/open_stocks_mcp/tools/options/positions.py
@@ -77,7 +77,6 @@ async def get_aggregate_positions() -> dict[str, Any]:
     # Get aggregated positions
     positions_data = await execute_with_retry(
         rh.options.get_aggregate_positions,
-        max_retries=3,
     )
 
     if not positions_data:
@@ -173,7 +172,6 @@ async def get_all_option_positions() -> dict[str, Any]:
     # Get all option positions
     positions_data = await execute_with_retry(
         rh.options.get_all_option_positions,
-        max_retries=3,
     )
 
     if not positions_data:
@@ -278,7 +276,6 @@ async def get_open_option_positions() -> dict[str, Any]:
     # Get open option positions
     positions_data = await execute_with_retry(
         rh.options.get_open_option_positions,
-        max_retries=3,
     )
 
     if not positions_data:
@@ -379,7 +376,6 @@ async def get_open_option_positions_with_details() -> dict[str, Any]:
     # Step 1: Get base open option positions
     positions_data = await execute_with_retry(
         rh.options.get_open_option_positions,
-        max_retries=3,
     )
 
     if not positions_data:

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -14,6 +14,8 @@ from open_stocks_mcp.tools.exceptions import (
     classify_error,
 )
 
+DEFAULT_MAX_RETRIES = 3
+
 
 async def execute_with_retry(
     func: Callable[..., Any],
@@ -69,8 +71,12 @@ async def execute_with_retry(
     if retry_config is None:
         raise RuntimeError("Retry configuration unavailable")
     configured_max_retries = (
-        retry_config.max_retries if max_retries is None else max_retries
+        retry_config.max_retries
+        if max_retries is None
+        else max_retries
     )
+    if configured_max_retries is None:
+        configured_max_retries = DEFAULT_MAX_RETRIES
     retry_delay = retry_config.initial_delay if delay is None else delay
     retry_backoff_factor = (
         retry_config.backoff_factor if backoff_factor is None else backoff_factor

--- a/tests/unit/test_error_handling_module_split.py
+++ b/tests/unit/test_error_handling_module_split.py
@@ -7,6 +7,7 @@ from open_stocks_mcp.tools.validation import validate_symbol
 
 def test_error_handling_reexports_core_symbols() -> None:
     assert error_handling.execute_with_retry is not None
+    assert error_handling.DEFAULT_MAX_RETRIES == 3
     assert error_handling.classify_error is not None
     assert error_handling.create_error_response is not None
     assert error_handling.validate_symbol is not None

--- a/tests/unit/test_options_tools.py
+++ b/tests/unit/test_options_tools.py
@@ -1,10 +1,14 @@
 """Unit tests for options trading tools."""
 
+import inspect
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 
+import open_stocks_mcp.tools.options.chains as options_chains_module
+import open_stocks_mcp.tools.options.market_data as options_market_data_module
+import open_stocks_mcp.tools.options.positions as options_positions_module
 from open_stocks_mcp.tools.options.chains import (
     find_tradable_options,
     get_options_chains,
@@ -19,6 +23,17 @@ from open_stocks_mcp.tools.options.positions import (
     get_open_option_positions,
     get_open_option_positions_with_details,
 )
+
+
+def test_options_modules_do_not_hardcode_default_max_retries() -> None:
+    chains_source = inspect.getsource(options_chains_module)
+    market_data_source = inspect.getsource(options_market_data_module)
+    positions_source = inspect.getsource(options_positions_module)
+
+    combined_source = "\n".join([chains_source, market_data_source, positions_source])
+
+    assert "max_retries=3" not in combined_source
+    assert "max_retries=2" in positions_source
 
 
 class TestOptionsChains:


### PR DESCRIPTION
Closes #61

## Changes
- added DEFAULT_MAX_RETRIES = 3 to retry helpers and used it as the fallback when config retry max is unset
- re-exported DEFAULT_MAX_RETRIES from tools/error_handling.py
- removed explicit max_retries=3 overrides from split options modules so normal calls use the centralized default
- preserved the explicit max_retries=2 detail-enrichment call in options positions
- added regression tests for facade export and for preventing max_retries=3 reintroduction in options modules

## Test plan
- uv run pytest tests/unit/test_error_handling_module_split.py tests/unit/test_options_tools.py -q
- uv run ruff check src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/options/chains.py src/open_stocks_mcp/tools/options/market_data.py src/open_stocks_mcp/tools/options/positions.py tests/unit/test_error_handling_module_split.py tests/unit/test_options_tools.py
- uv run mypy src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/options/chains.py src/open_stocks_mcp/tools/options/market_data.py src/open_stocks_mcp/tools/options/positions.py

## Plan note
- The issue comment plan referenced robinhood_options_tools.py, but the codebase now uses split modules under tools/options/; implementation followed the same intent on the current file layout.