### PR TITLE
refactor: centralize trading tool errors

### DIFF
--- a/src/open_stocks_mcp/tools/robinhood_trading_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_trading_tools.py
@@ -42,75 +42,59 @@ async def order_buy_market(symbol: str, quantity: int) -> dict[str, Any]:
         )
 
     # Check if symbol exists and get quote
-    try:
-        quote_data = await execute_with_retry(rh.get_quotes, symbol)
-        if not quote_data or not quote_data[0].get("last_trade_price"):
-            return create_success_response(
-                {"error": f"Symbol {symbol} not found", "status": "error"}
-            )
-        quote = quote_data[0]
-    except Exception as e:
+    quote_data = await execute_with_retry(rh.get_quotes, symbol)
+    if not quote_data or not quote_data[0].get("last_trade_price"):
         return create_success_response(
-            {"error": f"Failed to validate symbol: {e!s}", "status": "error"}
+            {"error": f"Symbol {symbol} not found", "status": "error"}
         )
+    quote = quote_data[0]
 
     # Check buying power
-    try:
-        account = await execute_with_retry(rh.load_account_profile)
-        buying_power = float(account.get("buying_power", 0))
-        estimated_cost = float(quote["last_trade_price"]) * quantity
+    account = await execute_with_retry(rh.load_account_profile)
+    buying_power = float(account.get("buying_power", 0))
+    estimated_cost = float(quote["last_trade_price"]) * quantity
 
-        if buying_power < estimated_cost:
-            return create_success_response(
-                {
-                    "error": f"Insufficient buying power. Need ${estimated_cost:.2f}, have ${buying_power:.2f}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Failed to check buying power: {e!s}", "status": "error"}
-        )
-
-    # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_buy_market, symbol, quantity, timeInForce="gfd"
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        # Check for Robin Stocks API errors
-        if isinstance(order_result, dict) and "non_field_errors" in order_result:
-            error_msgs = order_result["non_field_errors"]
-            return create_success_response(
-                {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(f"Market buy order placed for {quantity} shares of {symbol}")
+    if buying_power < estimated_cost:
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "quantity": quantity,
-                "price": None,  # Market orders have no set price
-                "order_type": "market",
-                "side": "buy",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": f"Insufficient buying power. Need ${estimated_cost:.2f}, have ${buying_power:.2f}",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    # Place order
+    order_result = await execute_with_retry(
+        rh.order_buy_market, symbol, quantity, timeInForce="gfd"
+    )
+
+    if not order_result:
         return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
+            {"error": "Order placement failed", "status": "error"}
         )
+
+    # Check for Robin Stocks API errors
+    if isinstance(order_result, dict) and "non_field_errors" in order_result:
+        error_msgs = order_result["non_field_errors"]
+        return create_success_response(
+            {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
+        )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(f"Market buy order placed for {quantity} shares of {symbol}")
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "quantity": quantity,
+            "price": None,  # Market orders have no set price
+            "order_type": "market",
+            "side": "buy",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -139,71 +123,60 @@ async def order_sell_market(symbol: str, quantity: int) -> dict[str, Any]:
         )
 
     # Check position
-    try:
-        positions = await execute_with_retry(rh.get_open_stock_positions)
-        position = None
-        for pos in positions:
-            if pos.get("symbol") == symbol:
-                position = pos
-                break
+    positions = await execute_with_retry(rh.get_open_stock_positions)
+    position = None
+    for pos in positions:
+        if pos.get("symbol") == symbol:
+            position = pos
+            break
 
-        if not position:
-            return create_success_response(
-                {"error": f"No position found for {symbol}", "status": "error"}
-            )
-
-        shares_owned = float(position.get("quantity", 0))
-        if shares_owned < quantity:
-            return create_success_response(
-                {
-                    "error": f"Insufficient shares. Own {shares_owned}, trying to sell {quantity}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
+    if not position:
         return create_success_response(
-            {"error": f"Failed to check position: {e!s}", "status": "error"}
+            {"error": f"No position found for {symbol}", "status": "error"}
         )
 
-    # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_sell_market, symbol, quantity, timeInForce="gfd"
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        # Check for Robin Stocks API errors
-        if isinstance(order_result, dict) and "non_field_errors" in order_result:
-            error_msgs = order_result["non_field_errors"]
-            return create_success_response(
-                {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(f"Market sell order placed for {quantity} shares of {symbol}")
+    shares_owned = float(position.get("quantity", 0))
+    if shares_owned < quantity:
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "quantity": quantity,
-                "price": None,  # Market orders have no set price
-                "order_type": "market",
-                "side": "sell",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": f"Insufficient shares. Own {shares_owned}, trying to sell {quantity}",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    # Place order
+    order_result = await execute_with_retry(
+        rh.order_sell_market, symbol, quantity, timeInForce="gfd"
+    )
+
+    if not order_result:
         return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
+            {"error": "Order placement failed", "status": "error"}
         )
+
+    # Check for Robin Stocks API errors
+    if isinstance(order_result, dict) and "non_field_errors" in order_result:
+        error_msgs = order_result["non_field_errors"]
+        return create_success_response(
+            {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
+        )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(f"Market sell order placed for {quantity} shares of {symbol}")
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "quantity": quantity,
+            "price": None,  # Market orders have no set price
+            "order_type": "market",
+            "side": "sell",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -240,87 +213,71 @@ async def order_buy_limit(
         )
 
     # Check if symbol exists and validate limit price
-    try:
-        quote_data = await execute_with_retry(rh.get_quotes, symbol)
-        if not quote_data or not quote_data[0].get("last_trade_price"):
-            return create_success_response(
-                {"error": f"Symbol {symbol} not found", "status": "error"}
-            )
-        quote = quote_data[0]
-        current_price = float(quote["last_trade_price"])
-        if (
-            limit_price > current_price * 1.5
-        ):  # Sanity check: limit price shouldn't be >50% above current
-            return create_success_response(
-                {
-                    "error": f"Limit price ${limit_price:.2f} too high compared to current price ${current_price:.2f}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
+    quote_data = await execute_with_retry(rh.get_quotes, symbol)
+    if not quote_data or not quote_data[0].get("last_trade_price"):
         return create_success_response(
-            {"error": f"Failed to validate symbol: {e!s}", "status": "error"}
+            {"error": f"Symbol {symbol} not found", "status": "error"}
         )
-
-    # Check buying power
-    try:
-        account = await execute_with_retry(rh.load_account_profile)
-        buying_power = float(account.get("buying_power", 0))
-        estimated_cost = limit_price * quantity
-
-        if buying_power < estimated_cost:
-            return create_success_response(
-                {
-                    "error": f"Insufficient buying power. Need ${estimated_cost:.2f}, have ${buying_power:.2f}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Failed to check buying power: {e!s}", "status": "error"}
-        )
-
-    # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_buy_limit, symbol, quantity, limit_price
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        # Check for Robin Stocks API errors
-        if isinstance(order_result, dict) and "non_field_errors" in order_result:
-            error_msgs = order_result["non_field_errors"]
-            return create_success_response(
-                {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Limit buy order placed for {quantity} shares of {symbol} at ${limit_price}"
-        )
+    quote = quote_data[0]
+    current_price = float(quote["last_trade_price"])
+    if (
+        limit_price > current_price * 1.5
+    ):  # Sanity check: limit price shouldn't be >50% above current
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "quantity": quantity,
-                "price": limit_price,  # Limit orders have set price
-                "order_type": "limit",
-                "side": "buy",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": f"Limit price ${limit_price:.2f} too high compared to current price ${current_price:.2f}",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    # Check buying power
+    account = await execute_with_retry(rh.load_account_profile)
+    buying_power = float(account.get("buying_power", 0))
+    estimated_cost = limit_price * quantity
+
+    if buying_power < estimated_cost:
         return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
+            {
+                "error": f"Insufficient buying power. Need ${estimated_cost:.2f}, have ${buying_power:.2f}",
+                "status": "error",
+            }
         )
+
+    # Place order
+    order_result = await execute_with_retry(
+        rh.order_buy_limit, symbol, quantity, limit_price
+    )
+
+    if not order_result:
+        return create_success_response(
+            {"error": "Order placement failed", "status": "error"}
+        )
+
+    # Check for Robin Stocks API errors
+    if isinstance(order_result, dict) and "non_field_errors" in order_result:
+        error_msgs = order_result["non_field_errors"]
+        return create_success_response(
+            {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
+        )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Limit buy order placed for {quantity} shares of {symbol} at ${limit_price}"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "quantity": quantity,
+            "price": limit_price,  # Limit orders have set price
+            "order_type": "limit",
+            "side": "buy",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -357,78 +314,67 @@ async def order_sell_limit(
         )
 
     # Check position
-    try:
-        positions = await execute_with_retry(rh.get_open_stock_positions)
-        position = None
-        for pos in positions:
-            if pos.get("symbol") == symbol:
-                position = pos
-                break
+    positions = await execute_with_retry(rh.get_open_stock_positions)
+    position = None
+    for pos in positions:
+        if pos.get("symbol") == symbol:
+            position = pos
+            break
 
-        if not position:
-            return create_success_response(
-                {"error": f"No position found for {symbol}", "status": "error"}
-            )
-
-        shares_owned = float(position.get("quantity", 0))
-        if shares_owned < quantity:
-            return create_success_response(
-                {
-                    "error": f"Insufficient shares. Own {shares_owned}, trying to sell {quantity}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
+    if not position:
         return create_success_response(
-            {"error": f"Failed to check position: {e!s}", "status": "error"}
+            {"error": f"No position found for {symbol}", "status": "error"}
         )
 
-    # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_sell_limit, symbol, quantity, limit_price
-        )
-
-        # Debug: Log the actual response
-        logger.info(f"DEBUG: Raw limit sell order_result = {order_result}")
-        logger.info(f"DEBUG: order_result type = {type(order_result)}")
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        # Check for Robin Stocks API errors
-        if isinstance(order_result, dict) and "non_field_errors" in order_result:
-            error_msgs = order_result["non_field_errors"]
-            return create_success_response(
-                {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-        logger.info(f"DEBUG: Sanitized limit sell order_result = {order_result}")
-
-        logger.info(
-            f"Limit sell order placed for {quantity} shares of {symbol} at ${limit_price}"
-        )
+    shares_owned = float(position.get("quantity", 0))
+    if shares_owned < quantity:
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "quantity": quantity,
-                "price": limit_price,  # Limit orders have set price
-                "order_type": "limit",
-                "side": "sell",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": f"Insufficient shares. Own {shares_owned}, trying to sell {quantity}",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    # Place order
+    order_result = await execute_with_retry(
+        rh.order_sell_limit, symbol, quantity, limit_price
+    )
+
+    # Debug: Log the actual response
+    logger.info(f"DEBUG: Raw limit sell order_result = {order_result}")
+    logger.info(f"DEBUG: order_result type = {type(order_result)}")
+
+    if not order_result:
         return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
+            {"error": "Order placement failed", "status": "error"}
         )
+
+    # Check for Robin Stocks API errors
+    if isinstance(order_result, dict) and "non_field_errors" in order_result:
+        error_msgs = order_result["non_field_errors"]
+        return create_success_response(
+            {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
+        )
+
+    order_result = sanitize_api_response(order_result)
+    logger.info(f"DEBUG: Sanitized limit sell order_result = {order_result}")
+
+    logger.info(
+        f"Limit sell order placed for {quantity} shares of {symbol} at ${limit_price}"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "quantity": quantity,
+            "price": limit_price,  # Limit orders have set price
+            "order_type": "limit",
+            "side": "sell",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -467,60 +413,49 @@ async def order_buy_stop_loss(
         )
 
     # Check if symbol exists and validate stop price
-    try:
-        quote_data = await execute_with_retry(rh.get_quotes, symbol)
-        if not quote_data or not quote_data[0].get("last_trade_price"):
-            return create_success_response(
-                {"error": f"Symbol {symbol} not found", "status": "error"}
-            )
-        quote = quote_data[0]
-        current_price = float(quote["last_trade_price"])
-        if stop_price <= current_price:
-            return create_success_response(
-                {
-                    "error": f"Stop price ${stop_price:.2f} must be above current price ${current_price:.2f} for buy orders",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
+    quote_data = await execute_with_retry(rh.get_quotes, symbol)
+    if not quote_data or not quote_data[0].get("last_trade_price"):
         return create_success_response(
-            {"error": f"Failed to validate symbol: {e!s}", "status": "error"}
+            {"error": f"Symbol {symbol} not found", "status": "error"}
         )
-
-    # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_buy_stop_loss, symbol, quantity, stop_price
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Stop loss buy order placed for {quantity} shares of {symbol} at stop ${stop_price}"
-        )
+    quote = quote_data[0]
+    current_price = float(quote["last_trade_price"])
+    if stop_price <= current_price:
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "quantity": quantity,
-                "stop_price": stop_price,
-                "order_type": "stop_loss",
-                "side": "buy",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": f"Stop price ${stop_price:.2f} must be above current price ${current_price:.2f} for buy orders",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    # Place order
+    order_result = await execute_with_retry(
+        rh.order_buy_stop_loss, symbol, quantity, stop_price
+    )
+
+    if not order_result:
         return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
+            {"error": "Order placement failed", "status": "error"}
         )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Stop loss buy order placed for {quantity} shares of {symbol} at stop ${stop_price}"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "quantity": quantity,
+            "stop_price": stop_price,
+            "order_type": "stop_loss",
+            "side": "buy",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -559,78 +494,67 @@ async def order_sell_stop_loss(
         )
 
     # Check position and validate stop price
-    try:
-        positions = await execute_with_retry(rh.get_open_stock_positions)
-        position = None
-        for pos in positions:
-            if pos.get("symbol") == symbol:
-                position = pos
-                break
+    positions = await execute_with_retry(rh.get_open_stock_positions)
+    position = None
+    for pos in positions:
+        if pos.get("symbol") == symbol:
+            position = pos
+            break
 
-        if not position:
-            return create_success_response(
-                {"error": f"No position found for {symbol}", "status": "error"}
-            )
-
-        shares_owned = float(position.get("quantity", 0))
-        if shares_owned < quantity:
-            return create_success_response(
-                {
-                    "error": f"Insufficient shares. Own {shares_owned}, trying to sell {quantity}",
-                    "status": "error",
-                }
-            )
-
-        # Validate stop price
-        quote_data = await execute_with_retry(rh.get_quotes, symbol)
-        quote = quote_data[0]
-        current_price = float(quote["last_trade_price"])
-        if stop_price >= current_price:
-            return create_success_response(
-                {
-                    "error": f"Stop price ${stop_price:.2f} must be below current price ${current_price:.2f} for sell orders",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
+    if not position:
         return create_success_response(
-            {"error": f"Failed to validate order: {e!s}", "status": "error"}
+            {"error": f"No position found for {symbol}", "status": "error"}
         )
 
-    # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_sell_stop_loss, symbol, quantity, stop_price
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Stop loss sell order placed for {quantity} shares of {symbol} at stop ${stop_price}"
-        )
+    shares_owned = float(position.get("quantity", 0))
+    if shares_owned < quantity:
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "quantity": quantity,
-                "stop_price": stop_price,
-                "order_type": "stop_loss",
-                "side": "sell",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": f"Insufficient shares. Own {shares_owned}, trying to sell {quantity}",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    # Validate stop price
+    quote_data = await execute_with_retry(rh.get_quotes, symbol)
+    quote = quote_data[0]
+    current_price = float(quote["last_trade_price"])
+    if stop_price >= current_price:
         return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
+            {
+                "error": f"Stop price ${stop_price:.2f} must be below current price ${current_price:.2f} for sell orders",
+                "status": "error",
+            }
         )
+
+    # Place order
+    order_result = await execute_with_retry(
+        rh.order_sell_stop_loss, symbol, quantity, stop_price
+    )
+
+    if not order_result:
+        return create_success_response(
+            {"error": "Order placement failed", "status": "error"}
+        )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Stop loss sell order placed for {quantity} shares of {symbol} at stop ${stop_price}"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "quantity": quantity,
+            "stop_price": stop_price,
+            "order_type": "stop_loss",
+            "side": "sell",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -674,51 +598,40 @@ async def order_buy_trailing_stop(
         )
 
     # Check if symbol exists
-    try:
-        quote_data = await execute_with_retry(rh.get_quotes, symbol)
-        if not quote_data or not quote_data[0].get("last_trade_price"):
-            return create_success_response(
-                {"error": f"Symbol {symbol} not found", "status": "error"}
-            )
-    except Exception as e:
+    quote_data = await execute_with_retry(rh.get_quotes, symbol)
+    if not quote_data or not quote_data[0].get("last_trade_price"):
         return create_success_response(
-            {"error": f"Failed to validate symbol: {e!s}", "status": "error"}
+            {"error": f"Symbol {symbol} not found", "status": "error"}
         )
 
     # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_buy_trailing_stop, symbol, quantity, trail_amount
-        )
+    order_result = await execute_with_retry(
+        rh.order_buy_trailing_stop, symbol, quantity, trail_amount
+    )
 
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Trailing stop buy order placed for {quantity} shares of {symbol} with trail ${trail_amount}"
-        )
+    if not order_result:
         return create_success_response(
-            {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "quantity": quantity,
-                "trail_amount": trail_amount,
-                "order_type": "trailing_stop",
-                "side": "buy",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
-            }
+            {"error": "Order placement failed", "status": "error"}
         )
 
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
-        )
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Trailing stop buy order placed for {quantity} shares of {symbol} with trail ${trail_amount}"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "quantity": quantity,
+            "trail_amount": trail_amount,
+            "order_type": "trailing_stop",
+            "side": "buy",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -762,66 +675,55 @@ async def order_sell_trailing_stop(
         )
 
     # Check position
-    try:
-        positions = await execute_with_retry(rh.get_open_stock_positions)
-        position = None
-        for pos in positions:
-            if pos.get("symbol") == symbol:
-                position = pos
-                break
+    positions = await execute_with_retry(rh.get_open_stock_positions)
+    position = None
+    for pos in positions:
+        if pos.get("symbol") == symbol:
+            position = pos
+            break
 
-        if not position:
-            return create_success_response(
-                {"error": f"No position found for {symbol}", "status": "error"}
-            )
-
-        shares_owned = float(position.get("quantity", 0))
-        if shares_owned < quantity:
-            return create_success_response(
-                {
-                    "error": f"Insufficient shares. Own {shares_owned}, trying to sell {quantity}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
+    if not position:
         return create_success_response(
-            {"error": f"Failed to check position: {e!s}", "status": "error"}
+            {"error": f"No position found for {symbol}", "status": "error"}
         )
 
-    # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_sell_trailing_stop, symbol, quantity, trail_amount
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Trailing stop sell order placed for {quantity} shares of {symbol} with trail ${trail_amount}"
-        )
+    shares_owned = float(position.get("quantity", 0))
+    if shares_owned < quantity:
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "quantity": quantity,
-                "trail_amount": trail_amount,
-                "order_type": "trailing_stop",
-                "side": "sell",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": f"Insufficient shares. Own {shares_owned}, trying to sell {quantity}",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    # Place order
+    order_result = await execute_with_retry(
+        rh.order_sell_trailing_stop, symbol, quantity, trail_amount
+    )
+
+    if not order_result:
         return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
+            {"error": "Order placement failed", "status": "error"}
         )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Trailing stop sell order placed for {quantity} shares of {symbol} with trail ${trail_amount}"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "quantity": quantity,
+            "trail_amount": trail_amount,
+            "order_type": "trailing_stop",
+            "side": "sell",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -854,65 +756,49 @@ async def order_buy_fractional_by_price(
         )
 
     # Check if symbol exists
-    try:
-        quote_data = await execute_with_retry(rh.get_quotes, symbol)
-        if not quote_data or not quote_data[0].get("last_trade_price"):
-            return create_success_response(
-                {"error": f"Symbol {symbol} not found", "status": "error"}
-            )
-    except Exception as e:
+    quote_data = await execute_with_retry(rh.get_quotes, symbol)
+    if not quote_data or not quote_data[0].get("last_trade_price"):
         return create_success_response(
-            {"error": f"Failed to validate symbol: {e!s}", "status": "error"}
+            {"error": f"Symbol {symbol} not found", "status": "error"}
         )
 
     # Check buying power
-    try:
-        account = await execute_with_retry(rh.load_account_profile)
-        buying_power = float(account.get("buying_power", 0))
+    account = await execute_with_retry(rh.load_account_profile)
+    buying_power = float(account.get("buying_power", 0))
 
-        if buying_power < amount_in_dollars:
-            return create_success_response(
-                {
-                    "error": f"Insufficient buying power. Need ${amount_in_dollars:.2f}, have ${buying_power:.2f}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Failed to check buying power: {e!s}", "status": "error"}
-        )
-
-    # Place order
-    try:
-        order_result = await execute_with_retry(
-            rh.order_buy_fractional_by_price, symbol, amount_in_dollars
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(f"Fractional buy order placed for ${amount_in_dollars} of {symbol}")
+    if buying_power < amount_in_dollars:
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "symbol": symbol,
-                "amount_in_dollars": amount_in_dollars,
-                "order_type": "fractional",
-                "side": "buy",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": f"Insufficient buying power. Need ${amount_in_dollars:.2f}, have ${buying_power:.2f}",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    # Place order
+    order_result = await execute_with_retry(
+        rh.order_buy_fractional_by_price, symbol, amount_in_dollars
+    )
+
+    if not order_result:
         return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
+            {"error": "Order placement failed", "status": "error"}
         )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(f"Fractional buy order placed for ${amount_in_dollars} of {symbol}")
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "symbol": symbol,
+            "amount_in_dollars": amount_in_dollars,
+            "order_type": "fractional",
+            "side": "buy",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 # Options Order Placement Tools
@@ -952,43 +838,33 @@ async def order_buy_option_limit(
         )
 
     # Validate instrument exists and is tradeable
-    try:
-        instrument = await execute_with_retry(
-            rh.get_option_instrument_data_by_id, instrument_id
-        )
-        if not instrument:
-            return create_success_response(
-                {
-                    "error": f"Option instrument {instrument_id} not found",
-                    "status": "error",
-                }
-            )
-
-        if not instrument.get("tradeable", True):
-            return create_success_response(
-                {"error": "Option instrument is not tradeable", "status": "error"}
-            )
-    except Exception as e:
+    instrument = await execute_with_retry(
+        rh.get_option_instrument_data_by_id, instrument_id
+    )
+    if not instrument:
         return create_success_response(
-            {"error": f"Failed to validate instrument: {e!s}", "status": "error"}
+            {
+                "error": f"Option instrument {instrument_id} not found",
+                "status": "error",
+            }
+        )
+
+    if not instrument.get("tradeable", True):
+        return create_success_response(
+            {"error": "Option instrument is not tradeable", "status": "error"}
         )
 
     # Check buying power
-    try:
-        account = await execute_with_retry(rh.load_account_profile)
-        buying_power = float(account.get("buying_power", 0))
-        estimated_cost = limit_price * quantity * 100  # Options are in contracts of 100
+    account = await execute_with_retry(rh.load_account_profile)
+    buying_power = float(account.get("buying_power", 0))
+    estimated_cost = limit_price * quantity * 100  # Options are in contracts of 100
 
-        if buying_power < estimated_cost:
-            return create_success_response(
-                {
-                    "error": f"Insufficient buying power. Need ${estimated_cost:.2f}, have ${buying_power:.2f}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
+    if buying_power < estimated_cost:
         return create_success_response(
-            {"error": f"Failed to check buying power: {e!s}", "status": "error"}
+            {
+                "error": f"Insufficient buying power. Need ${estimated_cost:.2f}, have ${buying_power:.2f}",
+                "status": "error",
+            }
         )
 
     # Extract parameters needed for Robin Stocks API
@@ -1010,48 +886,42 @@ async def order_buy_option_limit(
 
     # Place order using correct Robin Stocks API parameters
     # Signature: order_buy_option_limit(positionEffect, creditOrDebit, price, symbol, quantity, expirationDate, strike, optionType)
-    try:
-        order_result = await execute_with_retry(
-            rh.order_buy_option_limit,
-            "open",  # positionEffect
-            "debit",  # creditOrDebit - buying = paying debit
-            limit_price,  # price
-            symbol,  # symbol (e.g., 'F')
-            quantity,  # quantity
-            expiration_date,  # expirationDate (YYYY-MM-DD)
-            strike_price,  # strike
-            option_type,  # optionType ('call' or 'put')
-        )
+    order_result = await execute_with_retry(
+        rh.order_buy_option_limit,
+        "open",  # positionEffect
+        "debit",  # creditOrDebit - buying = paying debit
+        limit_price,  # price
+        symbol,  # symbol (e.g., 'F')
+        quantity,  # quantity
+        expiration_date,  # expirationDate (YYYY-MM-DD)
+        strike_price,  # strike
+        option_type,  # optionType ('call' or 'put')
+    )
 
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Option buy limit order placed for {quantity} contracts of {symbol} ${strike_price} {option_type} at ${limit_price}"
-        )
+    if not order_result:
         return create_success_response(
-            {
-                "order_id": order_result.get("id"),
-                "instrument_id": instrument_id,
-                "quantity": quantity,
-                "limit_price": limit_price,
-                "order_type": "limit",
-                "side": "buy",
-                "position_effect": "open",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
-            }
+            {"error": "Order placement failed", "status": "error"}
         )
 
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
-        )
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Option buy limit order placed for {quantity} contracts of {symbol} ${strike_price} {option_type} at ${limit_price}"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "instrument_id": instrument_id,
+            "quantity": quantity,
+            "limit_price": limit_price,
+            "order_type": "limit",
+            "side": "buy",
+            "position_effect": "open",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -1088,25 +958,20 @@ async def order_sell_option_limit(
         )
 
     # Validate instrument exists and is tradeable
-    try:
-        instrument = await execute_with_retry(
-            rh.get_option_instrument_data_by_id, instrument_id
-        )
-        if not instrument:
-            return create_success_response(
-                {
-                    "error": f"Option instrument {instrument_id} not found",
-                    "status": "error",
-                }
-            )
-
-        if not instrument.get("tradeable", True):
-            return create_success_response(
-                {"error": "Option instrument is not tradeable", "status": "error"}
-            )
-    except Exception as e:
+    instrument = await execute_with_retry(
+        rh.get_option_instrument_data_by_id, instrument_id
+    )
+    if not instrument:
         return create_success_response(
-            {"error": f"Failed to validate instrument: {e!s}", "status": "error"}
+            {
+                "error": f"Option instrument {instrument_id} not found",
+                "status": "error",
+            }
+        )
+
+    if not instrument.get("tradeable", True):
+        return create_success_response(
+            {"error": "Option instrument is not tradeable", "status": "error"}
         )
 
     # Check if we have position (for closing) or allow naked selling with margin
@@ -1152,48 +1017,42 @@ async def order_sell_option_limit(
 
     # Place order using correct Robin Stocks API parameters
     # Signature: order_sell_option_limit(positionEffect, creditOrDebit, price, symbol, quantity, expirationDate, strike, optionType)
-    try:
-        order_result = await execute_with_retry(
-            rh.order_sell_option_limit,
-            position_effect,  # 'open' or 'close'
-            "credit",  # creditOrDebit - selling = receiving credit
-            limit_price,  # price
-            symbol,  # symbol (e.g., 'F')
-            quantity,  # quantity
-            expiration_date,  # expirationDate (YYYY-MM-DD)
-            strike_price,  # strike
-            option_type,  # optionType ('call' or 'put')
-        )
+    order_result = await execute_with_retry(
+        rh.order_sell_option_limit,
+        position_effect,  # 'open' or 'close'
+        "credit",  # creditOrDebit - selling = receiving credit
+        limit_price,  # price
+        symbol,  # symbol (e.g., 'F')
+        quantity,  # quantity
+        expiration_date,  # expirationDate (YYYY-MM-DD)
+        strike_price,  # strike
+        option_type,  # optionType ('call' or 'put')
+    )
 
-        if not order_result:
-            return create_success_response(
-                {"error": "Order placement failed", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Option sell limit order placed for {quantity} contracts of {symbol} ${strike_price} {option_type} at ${limit_price}"
-        )
+    if not order_result:
         return create_success_response(
-            {
-                "order_id": order_result.get("id"),
-                "instrument_id": instrument_id,
-                "quantity": quantity,
-                "limit_price": limit_price,
-                "order_type": "limit",
-                "side": "sell",
-                "position_effect": position_effect,
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
-            }
+            {"error": "Order placement failed", "status": "error"}
         )
 
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Order placement failed: {e!s}", "status": "error"}
-        )
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Option sell limit order placed for {quantity} contracts of {symbol} ${strike_price} {option_type} at ${limit_price}"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "instrument_id": instrument_id,
+            "quantity": quantity,
+            "limit_price": limit_price,
+            "order_type": "limit",
+            "side": "sell",
+            "position_effect": position_effect,
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -1245,131 +1104,113 @@ async def order_option_credit_spread(
         )
 
     # Validate both instruments exist and form a valid spread
-    try:
-        short_instrument = await execute_with_retry(
-            rh.get_option_instrument_data_by_id, short_instrument_id
-        )
-        long_instrument = await execute_with_retry(
-            rh.get_option_instrument_data_by_id, long_instrument_id
-        )
+    short_instrument = await execute_with_retry(
+        rh.get_option_instrument_data_by_id, short_instrument_id
+    )
+    long_instrument = await execute_with_retry(
+        rh.get_option_instrument_data_by_id, long_instrument_id
+    )
 
-        if not short_instrument or not long_instrument:
-            return create_success_response(
-                {"error": "One or both option instruments not found", "status": "error"}
-            )
-
-        # Basic validation - both should be same underlying and type
-        if short_instrument.get("chain_symbol") != long_instrument.get("chain_symbol"):
-            return create_success_response(
-                {
-                    "error": "Options must be on the same underlying symbol",
-                    "status": "error",
-                }
-            )
-
-        if short_instrument.get("type") != long_instrument.get("type"):
-            return create_success_response(
-                {"error": "Options must be same type (call or put)", "status": "error"}
-            )
-
-    except Exception as e:
+    if not short_instrument or not long_instrument:
         return create_success_response(
-            {"error": f"Failed to validate instruments: {e!s}", "status": "error"}
+            {"error": "One or both option instruments not found", "status": "error"}
         )
 
-    # Calculate margin requirements (simplified)
-    try:
-        account = await execute_with_retry(rh.load_account_profile)
-        buying_power = float(account.get("buying_power", 0))
-
-        # For credit spreads, margin requirement is typically the width of strikes minus credit received
-        # This is a simplified calculation
-        estimated_margin = credit_price * quantity * 100  # Minimum margin estimate
-
-        if buying_power < estimated_margin:
-            return create_success_response(
-                {
-                    "error": f"Insufficient buying power for margin requirements. Need ~${estimated_margin:.2f}, have ${buying_power:.2f}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Failed to check margin requirements: {e!s}", "status": "error"}
-        )
-
-    # Place spread order
-    try:
-        # Extract symbol from instrument data
-        symbol = short_instrument.get("chain_symbol")
-        if not symbol:
-            return create_success_response(
-                {"error": "Could not extract symbol from instrument", "status": "error"}
-            )
-
-        # Create spread array with correct Robin Stocks format
-        spread = [
-            {
-                "expirationDate": short_instrument.get("expiration_date"),
-                "strike": short_instrument.get("strike_price"),
-                "optionType": short_instrument.get("type"),
-                "effect": "open",
-                "action": "sell",  # Short leg = sell
-            },
-            {
-                "expirationDate": long_instrument.get("expiration_date"),
-                "strike": long_instrument.get("strike_price"),
-                "optionType": long_instrument.get("type"),
-                "effect": "open",
-                "action": "buy",  # Long leg = buy
-            },
-        ]
-
-        # Use correct Robin Stocks API: order_option_credit_spread(price, symbol, quantity, spread, timeInForce='gtc')
-        order_result = await execute_with_retry(
-            rh.order_option_credit_spread,
-            credit_price,
-            symbol,
-            quantity,
-            spread,
-            timeInForce="gfd",
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Spread order placement failed", "status": "error"}
-            )
-
-        # Check for API error responses
-        if isinstance(order_result, dict) and "non_field_errors" in order_result:
-            error_msgs = order_result["non_field_errors"]
-            return create_success_response(
-                {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Credit spread order placed for {quantity} contracts at ${credit_price} credit"
-        )
+    # Basic validation - both should be same underlying and type
+    if short_instrument.get("chain_symbol") != long_instrument.get("chain_symbol"):
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "short_instrument_id": short_instrument_id,
-                "long_instrument_id": long_instrument_id,
-                "quantity": quantity,
-                "credit_price": credit_price,
-                "order_type": "credit_spread",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": "Options must be on the same underlying symbol",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    if short_instrument.get("type") != long_instrument.get("type"):
         return create_success_response(
-            {"error": f"Spread order placement failed: {e!s}", "status": "error"}
+            {"error": "Options must be same type (call or put)", "status": "error"}
         )
+
+    # Calculate margin requirements (simplified)
+    account = await execute_with_retry(rh.load_account_profile)
+    buying_power = float(account.get("buying_power", 0))
+
+    # For credit spreads, margin requirement is typically the width of strikes minus credit received
+    # This is a simplified calculation
+    estimated_margin = credit_price * quantity * 100  # Minimum margin estimate
+
+    if buying_power < estimated_margin:
+        return create_success_response(
+            {
+                "error": f"Insufficient buying power for margin requirements. Need ~${estimated_margin:.2f}, have ${buying_power:.2f}",
+                "status": "error",
+            }
+        )
+
+    # Place spread order
+    symbol = short_instrument.get("chain_symbol")
+    if not symbol:
+        return create_success_response(
+            {"error": "Could not extract symbol from instrument", "status": "error"}
+        )
+
+    # Create spread array with correct Robin Stocks format
+    spread = [
+        {
+            "expirationDate": short_instrument.get("expiration_date"),
+            "strike": short_instrument.get("strike_price"),
+            "optionType": short_instrument.get("type"),
+            "effect": "open",
+            "action": "sell",  # Short leg = sell
+        },
+        {
+            "expirationDate": long_instrument.get("expiration_date"),
+            "strike": long_instrument.get("strike_price"),
+            "optionType": long_instrument.get("type"),
+            "effect": "open",
+            "action": "buy",  # Long leg = buy
+        },
+    ]
+
+    # Use correct Robin Stocks API: order_option_credit_spread(price, symbol, quantity, spread, timeInForce='gtc')
+    order_result = await execute_with_retry(
+        rh.order_option_credit_spread,
+        credit_price,
+        symbol,
+        quantity,
+        spread,
+        timeInForce="gfd",
+    )
+
+    if not order_result:
+        return create_success_response(
+            {"error": "Spread order placement failed", "status": "error"}
+        )
+
+    # Check for API error responses
+    if isinstance(order_result, dict) and "non_field_errors" in order_result:
+        error_msgs = order_result["non_field_errors"]
+        return create_success_response(
+            {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
+        )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Credit spread order placed for {quantity} contracts at ${credit_price} credit"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "short_instrument_id": short_instrument_id,
+            "long_instrument_id": long_instrument_id,
+            "quantity": quantity,
+            "credit_price": credit_price,
+            "order_type": "credit_spread",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -1418,128 +1259,110 @@ async def order_option_debit_spread(
         )
 
     # Validate both instruments exist and form a valid spread
-    try:
-        short_instrument = await execute_with_retry(
-            rh.get_option_instrument_data_by_id, short_instrument_id
-        )
-        long_instrument = await execute_with_retry(
-            rh.get_option_instrument_data_by_id, long_instrument_id
-        )
+    short_instrument = await execute_with_retry(
+        rh.get_option_instrument_data_by_id, short_instrument_id
+    )
+    long_instrument = await execute_with_retry(
+        rh.get_option_instrument_data_by_id, long_instrument_id
+    )
 
-        if not short_instrument or not long_instrument:
-            return create_success_response(
-                {"error": "One or both option instruments not found", "status": "error"}
-            )
-
-        # Basic validation - both should be same underlying and type
-        if short_instrument.get("chain_symbol") != long_instrument.get("chain_symbol"):
-            return create_success_response(
-                {
-                    "error": "Options must be on the same underlying symbol",
-                    "status": "error",
-                }
-            )
-
-        if short_instrument.get("type") != long_instrument.get("type"):
-            return create_success_response(
-                {"error": "Options must be same type (call or put)", "status": "error"}
-            )
-
-    except Exception as e:
+    if not short_instrument or not long_instrument:
         return create_success_response(
-            {"error": f"Failed to validate instruments: {e!s}", "status": "error"}
+            {"error": "One or both option instruments not found", "status": "error"}
         )
 
-    # Check buying power for net debit
-    try:
-        account = await execute_with_retry(rh.load_account_profile)
-        buying_power = float(account.get("buying_power", 0))
-        total_debit = debit_price * quantity * 100  # Total cost
-
-        if buying_power < total_debit:
-            return create_success_response(
-                {
-                    "error": f"Insufficient buying power. Need ${total_debit:.2f}, have ${buying_power:.2f}",
-                    "status": "error",
-                }
-            )
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Failed to check buying power: {e!s}", "status": "error"}
-        )
-
-    # Place spread order
-    try:
-        # Extract symbol from instrument data
-        symbol = short_instrument.get("chain_symbol")
-        if not symbol:
-            return create_success_response(
-                {"error": "Could not extract symbol from instrument", "status": "error"}
-            )
-
-        # Create spread array with correct Robin Stocks format
-        spread = [
-            {
-                "expirationDate": short_instrument.get("expiration_date"),
-                "strike": short_instrument.get("strike_price"),
-                "optionType": short_instrument.get("type"),
-                "effect": "open",
-                "action": "sell",  # Short leg = sell
-            },
-            {
-                "expirationDate": long_instrument.get("expiration_date"),
-                "strike": long_instrument.get("strike_price"),
-                "optionType": long_instrument.get("type"),
-                "effect": "open",
-                "action": "buy",  # Long leg = buy
-            },
-        ]
-
-        # Use correct Robin Stocks API: order_option_debit_spread(price, symbol, quantity, spread, timeInForce='gtc')
-        order_result = await execute_with_retry(
-            rh.order_option_debit_spread,
-            debit_price,
-            symbol,
-            quantity,
-            spread,
-            timeInForce="gfd",
-        )
-
-        if not order_result:
-            return create_success_response(
-                {"error": "Spread order placement failed", "status": "error"}
-            )
-
-        # Check for API error responses
-        if isinstance(order_result, dict) and "non_field_errors" in order_result:
-            error_msgs = order_result["non_field_errors"]
-            return create_success_response(
-                {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
-            )
-
-        order_result = sanitize_api_response(order_result)
-
-        logger.info(
-            f"Debit spread order placed for {quantity} contracts at ${debit_price} debit"
-        )
+    # Basic validation - both should be same underlying and type
+    if short_instrument.get("chain_symbol") != long_instrument.get("chain_symbol"):
         return create_success_response(
             {
-                "order_id": order_result.get("id"),
-                "short_instrument_id": short_instrument_id,
-                "long_instrument_id": long_instrument_id,
-                "quantity": quantity,
-                "debit_price": debit_price,
-                "order_type": "debit_spread",
-                "state": order_result.get("state"),
-                "created_at": order_result.get("created_at"),
-                "status": "success",
+                "error": "Options must be on the same underlying symbol",
+                "status": "error",
             }
         )
 
-    except Exception as e:
+    if short_instrument.get("type") != long_instrument.get("type"):
         return create_success_response(
-            {"error": f"Spread order placement failed: {e!s}", "status": "error"}
+            {"error": "Options must be same type (call or put)", "status": "error"}
         )
+
+    # Check buying power for net debit
+    account = await execute_with_retry(rh.load_account_profile)
+    buying_power = float(account.get("buying_power", 0))
+    total_debit = debit_price * quantity * 100  # Total cost
+
+    if buying_power < total_debit:
+        return create_success_response(
+            {
+                "error": f"Insufficient buying power. Need ${total_debit:.2f}, have ${buying_power:.2f}",
+                "status": "error",
+            }
+        )
+
+    # Place spread order
+    symbol = short_instrument.get("chain_symbol")
+    if not symbol:
+        return create_success_response(
+            {"error": "Could not extract symbol from instrument", "status": "error"}
+        )
+
+    # Create spread array with correct Robin Stocks format
+    spread = [
+        {
+            "expirationDate": short_instrument.get("expiration_date"),
+            "strike": short_instrument.get("strike_price"),
+            "optionType": short_instrument.get("type"),
+            "effect": "open",
+            "action": "sell",  # Short leg = sell
+        },
+        {
+            "expirationDate": long_instrument.get("expiration_date"),
+            "strike": long_instrument.get("strike_price"),
+            "optionType": long_instrument.get("type"),
+            "effect": "open",
+            "action": "buy",  # Long leg = buy
+        },
+    ]
+
+    # Use correct Robin Stocks API: order_option_debit_spread(price, symbol, quantity, spread, timeInForce='gtc')
+    order_result = await execute_with_retry(
+        rh.order_option_debit_spread,
+        debit_price,
+        symbol,
+        quantity,
+        spread,
+        timeInForce="gfd",
+    )
+
+    if not order_result:
+        return create_success_response(
+            {"error": "Spread order placement failed", "status": "error"}
+        )
+
+    # Check for API error responses
+    if isinstance(order_result, dict) and "non_field_errors" in order_result:
+        error_msgs = order_result["non_field_errors"]
+        return create_success_response(
+            {"error": f"Order failed: {'; '.join(error_msgs)}", "status": "error"}
+        )
+
+    order_result = sanitize_api_response(order_result)
+
+    logger.info(
+        f"Debit spread order placed for {quantity} contracts at ${debit_price} debit"
+    )
+    return create_success_response(
+        {
+            "order_id": order_result.get("id"),
+            "short_instrument_id": short_instrument_id,
+            "long_instrument_id": long_instrument_id,
+            "quantity": quantity,
+            "debit_price": debit_price,
+            "order_type": "debit_spread",
+            "state": order_result.get("state"),
+            "created_at": order_result.get("created_at"),
+            "status": "success",
+        }
+    )
 
 
 # Order Management Tools
@@ -1565,30 +1388,24 @@ async def cancel_stock_order(order_id: str) -> dict[str, Any]:
         )
 
     # Cancel order
-    try:
-        cancel_result = await execute_with_retry(rh.cancel_stock_order, order_id)
+    cancel_result = await execute_with_retry(rh.cancel_stock_order, order_id)
 
-        if not cancel_result:
-            return create_success_response(
-                {"error": "Order cancellation failed", "status": "error"}
-            )
-
-        cancel_result = sanitize_api_response(cancel_result)
-
-        logger.info(f"Stock order {order_id} cancelled")
+    if not cancel_result:
         return create_success_response(
-            {
-                "order_id": order_id,
-                "status": "cancelled",
-                "cancelled_at": cancel_result.get("updated_at"),
-                "message": "Order successfully cancelled",
-            }
+            {"error": "Order cancellation failed", "status": "error"}
         )
 
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Order cancellation failed: {e!s}", "status": "error"}
-        )
+    cancel_result = sanitize_api_response(cancel_result)
+
+    logger.info(f"Stock order {order_id} cancelled")
+    return create_success_response(
+        {
+            "order_id": order_id,
+            "status": "cancelled",
+            "cancelled_at": cancel_result.get("updated_at"),
+            "message": "Order successfully cancelled",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -1611,30 +1428,24 @@ async def cancel_option_order(order_id: str) -> dict[str, Any]:
         )
 
     # Cancel order
-    try:
-        cancel_result = await execute_with_retry(rh.cancel_option_order, order_id)
+    cancel_result = await execute_with_retry(rh.cancel_option_order, order_id)
 
-        if not cancel_result:
-            return create_success_response(
-                {"error": "Order cancellation failed", "status": "error"}
-            )
-
-        cancel_result = sanitize_api_response(cancel_result)
-
-        logger.info(f"Option order {order_id} cancelled")
+    if not cancel_result:
         return create_success_response(
-            {
-                "order_id": order_id,
-                "status": "cancelled",
-                "cancelled_at": cancel_result.get("updated_at"),
-                "message": "Order successfully cancelled",
-            }
+            {"error": "Order cancellation failed", "status": "error"}
         )
 
-    except Exception as e:
-        return create_success_response(
-            {"error": f"Order cancellation failed: {e!s}", "status": "error"}
-        )
+    cancel_result = sanitize_api_response(cancel_result)
+
+    logger.info(f"Option order {order_id} cancelled")
+    return create_success_response(
+        {
+            "order_id": order_id,
+            "status": "cancelled",
+            "cancelled_at": cancel_result.get("updated_at"),
+            "message": "Order successfully cancelled",
+        }
+    )
 
 
 @handle_robin_stocks_errors
@@ -1647,44 +1458,37 @@ async def cancel_all_stock_orders() -> dict[str, Any]:
     """
     log_api_call("cancel_all_stock_orders")
 
-    try:
-        # Get all open stock orders
-        orders = await execute_with_retry(rh.get_all_open_stock_orders)
+    orders = await execute_with_retry(rh.get_all_open_stock_orders)
 
-        if not orders:
-            return create_success_response(
-                {"cancelled_count": 0, "message": "No open stock orders to cancel"}
-            )
-
-        cancelled_count = 0
-        failed_orders = []
-
-        # Cancel each order
-        for order in orders:
-            try:
-                order_id = order.get("id")
-                if order_id:
-                    await execute_with_retry(rh.cancel_stock_order, order_id)
-                    cancelled_count += 1
-            except Exception as e:
-                failed_orders.append({"order_id": order.get("id"), "error": str(e)})
-
-        logger.info(f"Cancelled {cancelled_count} stock orders")
-        result = {
-            "cancelled_count": cancelled_count,
-            "total_orders": len(orders),
-            "message": f"Successfully cancelled {cancelled_count} out of {len(orders)} stock orders",
-        }
-
-        if failed_orders:
-            result["failed_orders"] = failed_orders
-
-        return create_success_response(result)
-
-    except Exception as e:
+    if not orders:
         return create_success_response(
-            {"error": f"Failed to cancel stock orders: {e!s}", "status": "error"}
+            {"cancelled_count": 0, "message": "No open stock orders to cancel"}
         )
+
+    cancelled_count = 0
+    failed_orders = []
+
+    # Cancel each order
+    for order in orders:
+        try:
+            order_id = order.get("id")
+            if order_id:
+                await execute_with_retry(rh.cancel_stock_order, order_id)
+                cancelled_count += 1
+        except Exception as e:
+            failed_orders.append({"order_id": order.get("id"), "error": str(e)})
+
+    logger.info(f"Cancelled {cancelled_count} stock orders")
+    result = {
+        "cancelled_count": cancelled_count,
+        "total_orders": len(orders),
+        "message": f"Successfully cancelled {cancelled_count} out of {len(orders)} stock orders",
+    }
+
+    if failed_orders:
+        result["failed_orders"] = failed_orders
+
+    return create_success_response(result)
 
 
 @handle_robin_stocks_errors
@@ -1697,44 +1501,37 @@ async def cancel_all_option_orders() -> dict[str, Any]:
     """
     log_api_call("cancel_all_option_orders")
 
-    try:
-        # Get all open option orders
-        orders = await execute_with_retry(rh.get_all_open_option_orders)
+    orders = await execute_with_retry(rh.get_all_open_option_orders)
 
-        if not orders:
-            return create_success_response(
-                {"cancelled_count": 0, "message": "No open option orders to cancel"}
-            )
-
-        cancelled_count = 0
-        failed_orders = []
-
-        # Cancel each order
-        for order in orders:
-            try:
-                order_id = order.get("id")
-                if order_id:
-                    await execute_with_retry(rh.cancel_option_order, order_id)
-                    cancelled_count += 1
-            except Exception as e:
-                failed_orders.append({"order_id": order.get("id"), "error": str(e)})
-
-        logger.info(f"Cancelled {cancelled_count} option orders")
-        result = {
-            "cancelled_count": cancelled_count,
-            "total_orders": len(orders),
-            "message": f"Successfully cancelled {cancelled_count} out of {len(orders)} option orders",
-        }
-
-        if failed_orders:
-            result["failed_orders"] = failed_orders
-
-        return create_success_response(result)
-
-    except Exception as e:
+    if not orders:
         return create_success_response(
-            {"error": f"Failed to cancel option orders: {e!s}", "status": "error"}
+            {"cancelled_count": 0, "message": "No open option orders to cancel"}
         )
+
+    cancelled_count = 0
+    failed_orders = []
+
+    # Cancel each order
+    for order in orders:
+        try:
+            order_id = order.get("id")
+            if order_id:
+                await execute_with_retry(rh.cancel_option_order, order_id)
+                cancelled_count += 1
+        except Exception as e:
+            failed_orders.append({"order_id": order.get("id"), "error": str(e)})
+
+    logger.info(f"Cancelled {cancelled_count} option orders")
+    result = {
+        "cancelled_count": cancelled_count,
+        "total_orders": len(orders),
+        "message": f"Successfully cancelled {cancelled_count} out of {len(orders)} option orders",
+    }
+
+    if failed_orders:
+        result["failed_orders"] = failed_orders
+
+    return create_success_response(result)
 
 
 @handle_robin_stocks_errors
@@ -1747,51 +1544,45 @@ async def get_all_open_stock_orders() -> dict[str, Any]:
     """
     log_api_call("get_all_open_stock_orders")
 
-    try:
-        orders = await execute_with_retry(rh.get_all_open_stock_orders)
+    orders = await execute_with_retry(rh.get_all_open_stock_orders)
 
-        if not orders:
-            return create_success_response(
-                {"orders": [], "count": 0, "message": "No open stock orders found"}
-            )
-
-        order_list = []
-        for order in orders:
-            order = sanitize_api_response(order)
-
-            # Get symbol from instrument URL
-            instrument_url = order.get("instrument")
-            symbol = "N/A"
-            if instrument_url:
-                try:
-                    symbol = await execute_with_retry(
-                        rh.get_symbol_by_url, instrument_url
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to get symbol for instrument {instrument_url}: {e}"
-                    )
-
-            order_data = {
-                "order_id": order.get("id"),
-                "symbol": symbol,
-                "side": order.get("side", "N/A").upper(),
-                "quantity": order.get("quantity"),
-                "price": order.get("price"),
-                "order_type": order.get("type"),
-                "state": order.get("state"),
-                "created_at": order.get("created_at"),
-                "updated_at": order.get("updated_at"),
-            }
-            order_list.append(order_data)
-
-        logger.info(f"Retrieved {len(order_list)} open stock orders")
-        return create_success_response({"orders": order_list, "count": len(order_list)})
-
-    except Exception as e:
+    if not orders:
         return create_success_response(
-            {"error": f"Failed to retrieve open stock orders: {e!s}", "status": "error"}
+            {"orders": [], "count": 0, "message": "No open stock orders found"}
         )
+
+    order_list = []
+    for order in orders:
+        order = sanitize_api_response(order)
+
+        # Get symbol from instrument URL
+        instrument_url = order.get("instrument")
+        symbol = "N/A"
+        if instrument_url:
+            try:
+                symbol = await execute_with_retry(
+                    rh.get_symbol_by_url, instrument_url
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to get symbol for instrument {instrument_url}: {e}"
+                )
+
+        order_data = {
+            "order_id": order.get("id"),
+            "symbol": symbol,
+            "side": order.get("side", "N/A").upper(),
+            "quantity": order.get("quantity"),
+            "price": order.get("price"),
+            "order_type": order.get("type"),
+            "state": order.get("state"),
+            "created_at": order.get("created_at"),
+            "updated_at": order.get("updated_at"),
+        }
+        order_list.append(order_data)
+
+    logger.info(f"Retrieved {len(order_list)} open stock orders")
+    return create_success_response({"orders": order_list, "count": len(order_list)})
 
 
 @handle_robin_stocks_errors
@@ -1804,38 +1595,29 @@ async def get_all_open_option_orders() -> dict[str, Any]:
     """
     log_api_call("get_all_open_option_orders")
 
-    try:
-        orders = await execute_with_retry(rh.get_all_open_option_orders)
+    orders = await execute_with_retry(rh.get_all_open_option_orders)
 
-        if not orders:
-            return create_success_response(
-                {"orders": [], "count": 0, "message": "No open option orders found"}
-            )
-
-        order_list = []
-        for order in orders:
-            order = sanitize_api_response(order)
-
-            order_data = {
-                "order_id": order.get("id"),
-                "chain_symbol": order.get("chain_symbol"),
-                "side": order.get("direction", "N/A").upper(),
-                "quantity": order.get("quantity"),
-                "price": order.get("price"),
-                "order_type": order.get("type"),
-                "state": order.get("state"),
-                "created_at": order.get("created_at"),
-                "updated_at": order.get("updated_at"),
-            }
-            order_list.append(order_data)
-
-        logger.info(f"Retrieved {len(order_list)} open option orders")
-        return create_success_response({"orders": order_list, "count": len(order_list)})
-
-    except Exception as e:
+    if not orders:
         return create_success_response(
-            {
-                "error": f"Failed to retrieve open option orders: {e!s}",
-                "status": "error",
-            }
+            {"orders": [], "count": 0, "message": "No open option orders found"}
         )
+
+    order_list = []
+    for order in orders:
+        order = sanitize_api_response(order)
+
+        order_data = {
+            "order_id": order.get("id"),
+            "chain_symbol": order.get("chain_symbol"),
+            "side": order.get("direction", "N/A").upper(),
+            "quantity": order.get("quantity"),
+            "price": order.get("price"),
+            "order_type": order.get("type"),
+            "state": order.get("state"),
+            "created_at": order.get("created_at"),
+            "updated_at": order.get("updated_at"),
+        }
+        order_list.append(order_data)
+
+    logger.info(f"Retrieved {len(order_list)} open option orders")
+    return create_success_response({"orders": order_list, "count": len(order_list)})

--- a/tests/unit/test_trading_tools.py
+++ b/tests/unit/test_trading_tools.py
@@ -6,6 +6,8 @@ Focuses on the most regression-prone behaviors documented in CLAUDE.md:
 - exception branches propagate cleanly
 """
 
+import ast
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -38,6 +40,65 @@ MOCK_ORDER = {
     "state": "confirmed",
     "created_at": "2024-01-01T00:00:00Z",
 }
+
+
+def assert_decorator_error_response(
+    result: dict[str, dict[str, object]], function_name: str
+) -> None:
+    """Assert unexpected exceptions are handled by the shared decorator."""
+    payload = result["result"]
+    assert payload["status"] == "error"
+    assert "error_type" in payload
+    assert payload["context"] == f"in {function_name}"
+
+
+def _returns_create_success_error_response(handler: ast.ExceptHandler) -> bool:
+    for node in ast.walk(handler):
+        if not isinstance(node, ast.Return):
+            continue
+        value = node.value
+        if not (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id == "create_success_response"
+            and value.args
+            and isinstance(value.args[0], ast.Dict)
+        ):
+            continue
+
+        keys = {
+            key.value
+            for key in value.args[0].keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+        if {"error", "status"} <= keys:
+            return True
+    return False
+
+
+def test_trading_tools_do_not_keep_local_exception_response_boilerplate() -> None:
+    module_path = (
+        Path(__file__).parents[2]
+        / "src"
+        / "open_stocks_mcp"
+        / "tools"
+        / "robinhood_trading_tools.py"
+    )
+    tree = ast.parse(module_path.read_text())
+
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        if not (
+            isinstance(node.type, ast.Name)
+            and node.type.id == "Exception"
+            and _returns_create_success_error_response(node)
+        ):
+            continue
+        offenders.append(node.lineno)
+
+    assert offenders == []
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +156,7 @@ class TestOrderBuyMarket:
     @pytest.mark.asyncio
     @patch("open_stocks_mcp.tools.robinhood_trading_tools.execute_with_retry")
     async def test_order_placement_exception(self, mock_execute: AsyncMock) -> None:
-        """Exception during order placement returns error response."""
+        """Exception during order placement returns decorator error response."""
         mock_execute.side_effect = [
             MOCK_QUOTE,
             MOCK_ACCOUNT,
@@ -104,8 +165,7 @@ class TestOrderBuyMarket:
 
         result = await order_buy_market("AAPL", 5)
 
-        assert "error" in result["result"]
-        assert result["result"]["status"] == "error"
+        assert_decorator_error_response(result, "order_buy_market")
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -218,13 +278,12 @@ class TestOrderSellMarket:
     @pytest.mark.asyncio
     @patch("open_stocks_mcp.tools.robinhood_trading_tools.execute_with_retry")
     async def test_order_placement_exception(self, mock_execute: AsyncMock) -> None:
-        """Exception during order placement returns error response."""
+        """Exception during order placement returns decorator error response."""
         mock_execute.side_effect = [MOCK_POSITION, Exception("Timeout")]
 
         result = await order_sell_market("AAPL", 5)
 
-        assert "error" in result["result"]
-        assert result["result"]["status"] == "error"
+        assert_decorator_error_response(result, "order_sell_market")
 
     @pytest.mark.journey_trading
     @pytest.mark.unit
@@ -355,12 +414,12 @@ class TestOrderBuyLimit:
     @pytest.mark.asyncio
     @patch("open_stocks_mcp.tools.robinhood_trading_tools.execute_with_retry")
     async def test_order_placement_exception(self, mock_execute: AsyncMock) -> None:
-        """Exception during limit order placement returns error."""
+        """Exception during limit order placement returns decorator error."""
         mock_execute.side_effect = [MOCK_QUOTE, MOCK_ACCOUNT, Exception("API down")]
 
         result = await order_buy_limit("AAPL", 5, 140.00)
 
-        assert result["result"]["status"] == "error"
+        assert_decorator_error_response(result, "order_buy_limit")
 
 
 # ---------------------------------------------------------------------------
@@ -430,12 +489,12 @@ class TestOrderSellLimit:
     @pytest.mark.asyncio
     @patch("open_stocks_mcp.tools.robinhood_trading_tools.execute_with_retry")
     async def test_order_placement_exception(self, mock_execute: AsyncMock) -> None:
-        """Exception during limit sell placement returns error."""
+        """Exception during limit sell placement returns decorator error."""
         mock_execute.side_effect = [MOCK_POSITION, Exception("Connection reset")]
 
         result = await order_sell_limit("AAPL", 5, 160.00)
 
-        assert result["result"]["status"] == "error"
+        assert_decorator_error_response(result, "order_sell_limit")
 
 
 # ---------------------------------------------------------------------------
@@ -611,12 +670,12 @@ class TestCancelAllStockOrders:
     @pytest.mark.asyncio
     @patch("open_stocks_mcp.tools.robinhood_trading_tools.execute_with_retry")
     async def test_fetch_exception_returns_error(self, mock_execute: AsyncMock) -> None:
-        """Exception while fetching open orders returns error."""
+        """Exception while fetching open orders returns decorator error."""
         mock_execute.side_effect = Exception("Auth expired")
 
         result = await cancel_all_stock_orders()
 
-        assert result["result"]["status"] == "error"
+        assert_decorator_error_response(result, "cancel_all_stock_orders")
 
 
 # ---------------------------------------------------------------------------
@@ -688,6 +747,20 @@ class TestGetOpenOrders:
         result = await get_all_open_stock_orders()
 
         assert "result" in result
+
+    @pytest.mark.journey_trading
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch("open_stocks_mcp.tools.robinhood_trading_tools.execute_with_retry")
+    async def test_get_stock_orders_fetch_exception_returns_error(
+        self, mock_execute: AsyncMock
+    ) -> None:
+        """Exception while fetching stock orders returns decorator error."""
+        mock_execute.side_effect = Exception("Service unavailable")
+
+        result = await get_all_open_stock_orders()
+
+        assert_decorator_error_response(result, "get_all_open_stock_orders")
 
     @pytest.mark.journey_trading
     @pytest.mark.unit


### PR DESCRIPTION
Closes #62

## Changes
- Remove duplicated local unexpected-exception response wrappers from Robinhood trading tools so exceptions flow through @handle_robin_stocks_errors.
- Preserve explicit business-rule error responses and intentional partial-failure handling for bulk cancellation and symbol enrichment.
- Add an AST regression guard and update representative exception tests to assert decorator-shaped error responses.

## Test plan
- uv run pytest tests/unit/test_trading_tools.py -q
- uv run pytest tests/unit/test_error_handling.py -q
- uv run ruff check src/open_stocks_mcp/tools/robinhood_trading_tools.py tests/unit/test_trading_tools.py tests/unit/test_error_handling.py
- uv run mypy src/open_stocks_mcp/tools/robinhood_trading_tools.py