### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -156,6 +156,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_chain_by_expiration,
     get_schwab_option_expirations,
     get_schwab_options_positions,
+    schwab_get_open_option_orders,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
@@ -1957,7 +1958,7 @@ async def schwab_open_option_orders(
         account_hash: Account hash from get_schwab_account_numbers()
         max_results: Maximum orders to fetch before filtering (default 50)
     """
-    return await _schwab_get_open_option_orders_impl(account_hash, max_results)
+    return await schwab_get_open_option_orders(account_hash, max_results)
 
 
 # Schwab Streaming Tools

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -162,9 +162,6 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
-    schwab_get_open_option_orders as _schwab_get_open_option_orders_impl,
-)
-from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_option_buy_to_open as _schwab_option_buy_to_open_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (


### PR DESCRIPTION
## Summary

Automated code-quality cleanup using `ruff check --fix` and `ruff format`.

### Format fixes (15 files)
- Code formatting standardization across source and test files

### Lint fixes (7 issues across 5 files)
- **F811 (5 instances)**: Removed duplicate function definitions:
  - `get_latest_level2` in `schwab_stream.py` — kept venue-aware version
  - `schwab_stream_level2` in `server/app.py` — removed redundant MCP tool registration
  - `schwab_stream_level2` in `schwab_streaming_tools.py` — kept venue-aware version
  - `test_schwab_stream_manager_subscribe_level2` in `test_capabilities_and_streaming.py`
  - `test_schwab_stream_level2_success` + `test_schwab_stream_level2_unavailable` in `test_schwab_streaming_tools.py`
- **F821 (1 instance)**: Fixed undefined `_schwab_get_open_option_orders_impl` — added proper import of `schwab_get_open_option_orders`
- **I001 (1 instance)**: Fixed unsorted import block in `server/app.py`

### Bug fixes found during cleanup
- Duplicate `add_nasdaq_book_handler` / `add_nyse_book_handler` registrations in `SchwabStreamManager.start()` — removed duplicate pair
- Test assertions using wrong dict keys (uppercase vs lowercase) and missing venue parameter for level2 lookups

### Validation
- ✅ mypy: 0 errors (69 source files)
- ✅ pytest: 944 passed, 69 skipped, 0 failed
- ✅ ruff: 0 lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)