### PR TITLE
test: add regression tests for chmod hardening warning logs

### DIFF
--- a/tests/unit/test_security_umask.py
+++ b/tests/unit/test_security_umask.py
@@ -60,6 +60,71 @@ def test_session_manager_fixes_existing_permissions(tmp_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
+def test_schwab_default_token_dir_chmod_warning(tmp_path):
+    """SchwabBroker logs a warning when chmod on default ~/.tokens dir fails."""
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch(
+            "open_stocks_mcp.brokers.schwab.os.chmod",
+            side_effect=PermissionError("denied"),
+        ),
+        patch("open_stocks_mcp.brokers.schwab.logger") as mock_logger,
+    ):
+        SchwabBroker(api_key="test", app_secret="test")
+
+    mock_logger.warning.assert_called_once()
+    msg = mock_logger.warning.call_args[0][0]
+    assert "Could not set secure permissions" in msg
+    assert str(tmp_path / ".tokens") in msg
+    assert "denied" in msg
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
+def test_schwab_custom_token_dir_chmod_warning(tmp_path):
+    """SchwabBroker logs a warning when chmod on custom token parent dir fails."""
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch(
+            "open_stocks_mcp.brokers.schwab.os.chmod",
+            side_effect=[None, PermissionError("denied")],
+        ),
+        patch("open_stocks_mcp.brokers.schwab.logger") as mock_logger,
+    ):
+        SchwabBroker(
+            api_key="test",
+            app_secret="test",
+            token_path=str(tmp_path / ".tokens" / "custom" / "schwab_token.json"),
+        )
+
+    mock_logger.warning.assert_called_once()
+    msg = mock_logger.warning.call_args[0][0]
+    assert "Could not set secure permissions" in msg
+    assert str(tmp_path / ".tokens" / "custom") in msg
+    assert "denied" in msg
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
+def test_session_manager_tokens_dir_chmod_warning(tmp_path):
+    """SessionManager logs a warning when chmod on tokens dir fails."""
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch(
+            "open_stocks_mcp.brokers.session_pickle.Path.chmod",
+            side_effect=PermissionError("denied"),
+        ),
+        patch("open_stocks_mcp.brokers.session_pickle.logger") as mock_logger,
+    ):
+        manager = SessionManager()
+        manager._get_tokens_dir()
+
+    mock_logger.warning.assert_called_once()
+    msg = mock_logger.warning.call_args[0][0]
+    assert "Could not set secure permissions" in msg
+    assert str(tmp_path / ".tokens") in msg
+    assert "denied" in msg
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
 def test_log_directory_permissions(tmp_path):
     """Verify that the log directory is created with secure 0o700 permissions."""
     log_dir = tmp_path / "logs"


### PR DESCRIPTION
Closes #93

## Changes
- Added 3 regression tests in `tests/unit/test_security_umask.py` that verify warning logs are emitted when `os.chmod` security hardening fails:
  - `test_schwab_default_token_dir_chmod_warning` — verifies `SchwabBroker.__init__` logs a warning when chmod on the default `~/.tokens` dir raises `PermissionError`
  - `test_schwab_custom_token_dir_chmod_warning` — verifies the warning when chmod on a custom token parent dir fails (second chmod call)
  - `test_session_manager_tokens_dir_chmod_warning` — verifies `SessionManager._get_tokens_dir()` (via `SessionPickleManager`) logs a warning when chmod fails

The production code already has the correct warning logging in all three locations (`schwab.py` lines 58-59 and 74-76, `session_pickle.py` lines 25-26). These tests serve as regression guards to prevent future regressions back to silent `pass`.

## Test plan
- `uv run pytest tests/unit/test_security_umask.py -q` — all 8 tests pass (5 existing + 3 new)
- `uv run ruff check` on touched files — passes
- `uv run mypy` on source modules — passes
- Tests are `skipif(os.name == "nt")` to avoid Windows permission semantics