### PR TITLE
docs: update logout() docstring to document fail-hard contract

### DIFF
--- a/src/open_stocks_mcp/brokers/session_state.py
+++ b/src/open_stocks_mcp/brokers/session_state.py
@@ -216,6 +216,11 @@ class SessionManager:
         return info
 
     async def logout(self) -> None:
+        """Logout and clear session.
+
+        Robin Stocks logout exceptions are logged and re-raised. Local
+        session state is reset in the finally block even when logout raises.
+        """
         async with self._lock:
             try:
                 loop = asyncio.get_event_loop()

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -306,6 +306,18 @@ async def test_logout_reraises_exception_and_still_clears_state() -> None:
     assert manager._failed_login_attempts == 0
 
 
+def test_logout_docstring_contract() -> None:
+    """Assert that logout() documents its fail-hard and finally-cleanup contract."""
+    doc = SessionManager.logout.__doc__
+    assert doc is not None
+    # Contract: Exceptions are logged and re-raised
+    assert "logged" in doc.lower()
+    assert "re-raised" in doc.lower()
+    # Contract: Session state is reset in finally block
+    assert "finally" in doc.lower()
+    assert "session state" in doc.lower()
+
+
 @pytest.mark.asyncio
 async def test_refresh_session_reauthenticates() -> None:
     manager = SessionManager()


### PR DESCRIPTION
Closes #90

## Changes
- Updated `SessionManager.logout()` docstring in `src/open_stocks_mcp/brokers/session_state.py` to explicitly document that exceptions are logged and re-raised, and that session state is always reset via the `finally` block.
- Added a focused unit test in `tests/unit/test_session_manager.py` to assert the presence of these contract terms in the docstring.

## Test plan
- Run `uv run pytest tests/unit/test_session_manager.py -k 'logout' -q` to verify that the docstring contract test and existing behavior tests pass.