### PR TITLE
fix: use proper JSON-RPC error code for tool authorization denial

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -649,11 +649,8 @@ def create_http_server(
                             {
                                 "jsonrpc": "2.0",
                                 "error": {
-                                    "code": -32600,
-                                    "message": (
-                                        "Tool is not allowed in read-only mode. "
-                                        "Enable --allow-trading to permit mutating tools."
-                                    ),
+                                    "code": -32001,
+                                    "message": "Tool call not permitted",
                                 },
                                 "id": request_id,
                             },
@@ -661,7 +658,7 @@ def create_http_server(
                             method=method,
                             request_id=request_id,
                             outcome="error",
-                            error_code=-32600,
+                            error_code=-32001,
                             error_type="forbidden_tool",
                         )
 

--- a/tests/http_transport/test_http_mcp_protocol.py
+++ b/tests/http_transport/test_http_mcp_protocol.py
@@ -145,12 +145,15 @@ class TestHTTPTransportReliability:
             "method_not_found": -32601,
             "invalid_params": -32602,
             "internal_error": -32603,
+            "forbidden_tool": -32001,
         }
 
         # Verify standard error codes
         assert error_codes["parse_error"] == -32700
         assert error_codes["method_not_found"] == -32601
         assert error_codes["internal_error"] == -32603
+        # Verify server-defined error codes
+        assert error_codes["forbidden_tool"] == -32001
 
 
 @pytest.mark.journey_system

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -519,8 +519,8 @@ class TestMCPIntegration:
         data = response.json()
         assert data["jsonrpc"] == "2.0"
         assert data["id"] == 1
-        assert data["error"]["code"] == -32600
-        assert "read-only mode" in data["error"]["message"].lower()
+        assert data["error"]["code"] == -32001
+        assert "not permitted" in data["error"]["message"].lower()
 
     @pytest.mark.anyio
     async def test_mcp_endpoint_allows_read_only_tools_by_default(


### PR DESCRIPTION
Closes #94

## Changes
- Replace JSON-RPC error code `-32600` (Invalid Request) with server-defined `-32001` for tool authorization denial in `http_transport.py`
- Use opaque error message `"Tool call not permitted"` instead of revealing read-only mode details and tool existence
- Add `forbidden_tool: -32001` to error code mapping test
- Update assertion in mutating tools block test to match new code and message

## Test plan
- `uv run pytest tests/http_transport/test_http_server.py tests/http_transport/test_http_mcp_protocol.py -q` — 51 passed
- `uv run ruff check` on all changed files — clean
- `uv run mypy src/open_stocks_mcp/server/http_transport.py` — no issues