### PR TITLE
test: harden schwab token path assertion

### DIFF
--- a/tests/unit/test_schwab_broker.py
+++ b/tests/unit/test_schwab_broker.py
@@ -191,12 +191,11 @@ class TestSchwabBroker:
 
     def test_accepts_token_path_inside_tokens_dir(self) -> None:
         """Test that token_path can be inside ~/.tokens directory."""
-        token_dir = Path.home() / ".tokens"
-        token_path = token_dir / "custom_schwab_token.json"
+        token_path = str(Path.home() / ".tokens" / "nested" / "token.json")
         broker = SchwabBroker(
-            api_key="test", app_secret="test", token_path=str(token_path)
+            api_key="test", app_secret="test", token_path=token_path
         )
-        assert broker.token_path == str(token_path.resolve())
+        assert Path(broker.token_path) == Path(token_path).expanduser().resolve()
 
     @pytest.mark.asyncio
     async def test_missing_credentials(self) -> None:


### PR DESCRIPTION
Closes #95

## Changes
- update `test_accepts_token_path_inside_tokens_dir` to build a nested token path under `~/.tokens`
- compare `Path(broker.token_path)` to `Path(token_path).expanduser().resolve()` for canonicalized equality
- keep scope limited to test assertions (no production Schwab broker changes)

## Test plan
- uv run pytest tests/unit/test_schwab_broker.py -k test_accepts_token_path_inside_tokens_dir -q
- uv run ruff check tests/unit/test_schwab_broker.py
