### PR TITLE
test: add symlink-escape regression test for SchwabBroker._validate_token_path

### DIFF
--- a/tests/unit/test_schwab_broker.py
+++ b/tests/unit/test_schwab_broker.py
@@ -189,6 +189,22 @@ class TestSchwabBroker:
                 api_key="test", app_secret="test", token_path="/tmp/outside_token.json"
             )
 
+    @pytest.mark.unit
+    @pytest.mark.journey_system
+    def test_rejects_symlink_escaping_tokens_dir(self, tmp_path: Path) -> None:
+        """Symlink under ~/.tokens pointing outside is rejected."""
+        tokens_dir = Path.home() / ".tokens"
+        tokens_dir.mkdir(parents=True, exist_ok=True)
+        link_path = tokens_dir / "escape_link.json"
+        target = tmp_path / "outside.json"
+        target.write_text("{}")
+        try:
+            link_path.symlink_to(target)
+            with pytest.raises(ValueError, match="token_path must be under"):
+                SchwabBroker(api_key="test", app_secret="test", token_path=str(link_path))
+        finally:
+            link_path.unlink(missing_ok=True)
+
     def test_accepts_token_path_inside_tokens_dir(self) -> None:
         """Test that token_path can be inside ~/.tokens directory."""
         token_dir = Path.home() / ".tokens"

--- a/tests/unit/test_schwab_broker.py
+++ b/tests/unit/test_schwab_broker.py
@@ -193,15 +193,19 @@ class TestSchwabBroker:
     @pytest.mark.journey_system
     def test_rejects_symlink_escaping_tokens_dir(self, tmp_path: Path) -> None:
         """Symlink under ~/.tokens pointing outside is rejected."""
-        tokens_dir = Path.home() / ".tokens"
+        fake_home = tmp_path / "home"
+        tokens_dir = fake_home / ".tokens"
         tokens_dir.mkdir(parents=True, exist_ok=True)
         link_path = tokens_dir / "escape_link.json"
         target = tmp_path / "outside.json"
         target.write_text("{}")
         try:
-            link_path.symlink_to(target)
-            with pytest.raises(ValueError, match="token_path must be under"):
-                SchwabBroker(api_key="test", app_secret="test", token_path=str(link_path))
+            with patch("pathlib.Path.home", return_value=fake_home):
+                link_path.symlink_to(target)
+                with pytest.raises(ValueError, match="token_path must be under"):
+                    SchwabBroker(
+                        api_key="test", app_secret="test", token_path=str(link_path)
+                    )
         finally:
             link_path.unlink(missing_ok=True)
 


### PR DESCRIPTION
Closes #96

## Changes
- Added `test_rejects_symlink_escaping_tokens_dir` to `TestSchwabBroker` in `tests/unit/test_schwab_broker.py`
- Test creates a symlink under `~/.tokens/` pointing to a file outside the tokens directory (`tmp_path/outside.json`)
- Asserts `ValueError` with `"token_path must be under"` is raised when constructing `SchwabBroker` with that symlink path
- Cleans up the symlink in a `finally` block
- Marked `@pytest.mark.unit` and `@pytest.mark.journey_system` for security regression coverage

## Test plan
- `uv run pytest tests/unit/test_schwab_broker.py::TestSchwabBroker::test_rejects_symlink_escaping_tokens_dir -v` — new test passes
- `uv run pytest tests/unit/test_schwab_broker.py -q` — all 29 tests pass, no regressions
- `ruff check` passes with no issues on the modified file