### PR TITLE
test: add Schwab live journey tests for account, market data, options, and trading-safe workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,13 @@ The default pytest configuration skips live market and performance tests. Rate-l
 | Trading journey | `uv run pytest -m "journey_trading"` |
 | Integration tests | `uv run pytest tests/integration/ -m integration` |
 | Rate-limited live tests | `RUN_RATE_LIMITED=1 uv run pytest -m rate_limited` |
+| Schwab live journeys | `OPEN_STOCKS_RUN_LIVE_MARKET=1 RUN_RATE_LIMITED=1 ENABLED_BROKERS=schwab uv run pytest tests/integration/test_schwab_live_journeys.py -m "live_market and auth_required and rate_limited" --run-live-market -q` |
+
+The Schwab live journey tests require `SCHWAB_API_KEY`, `SCHWAB_APP_SECRET`, and a
+pre-created OAuth token at `SCHWAB_TOKEN_PATH` (default: `~/.tokens/schwab_token.json`).
+Run interactive authentication from the terminal once before using these tests in pytest.
+They never place or cancel orders; trading coverage is read-only. See
+[docs/TEST_MARKERS.md](docs/TEST_MARKERS.md) for the full Schwab marker requirements.
 
 VS Code Test Explorer uses `python.testing.pytestArgs` from `.vscode/settings.json`, so it discovers `tests/` and then applies the project-level marker defaults from `pyproject.toml`.
 

--- a/docs/TEST_MARKERS.md
+++ b/docs/TEST_MARKERS.md
@@ -88,6 +88,30 @@ pytest -m "journey_market_data or journey_research"
 pytest -m "journey_account or journey_portfolio or journey_market_data or journey_research or journey_notifications or journey_system"  # read-only journeys
 ```
 
+### Schwab live journey tests
+
+Schwab live journey tests cover account discovery, market data, options chains, and
+read-only order/transaction queries. They require:
+
+- `SCHWAB_API_KEY` — Schwab API key from developer.schwab.com
+- `SCHWAB_APP_SECRET` — Schwab app secret from developer.schwab.com
+- A pre-created token at `SCHWAB_TOKEN_PATH` (default: `~/.tokens/schwab_token.json`).
+  Run interactive authentication once in a terminal before using these tests in pytest.
+- `OPEN_STOCKS_RUN_LIVE_MARKET=1` environment variable
+- `--run-live-market` CLI flag
+
+These tests **never** place or cancel orders; trading coverage is limited to read-only
+order/transaction queries. The `assert_live_schwab_read_only` guard in the harness
+enforces this boundary and is covered by non-live unit tests in
+`tests/integration/test_live_market_harness.py`.
+
+```bash
+# Run all Schwab live journey tests
+OPEN_STOCKS_RUN_LIVE_MARKET=1 RUN_RATE_LIMITED=1 ENABLED_BROKERS=schwab \
+    uv run pytest tests/integration/test_schwab_live_journeys.py \
+    -m "live_market and auth_required and rate_limited" --run-live-market -q
+```
+
 ---
 
 ## Applying Markers to New Tests

--- a/tests/integration/live_market_harness.py
+++ b/tests/integration/live_market_harness.py
@@ -42,7 +42,12 @@ _PROHIBITED_PREFIXES = ("order_", "cancel_")
 _SCHWAB_PROHIBITED_TOOLS = frozenset(
     {
         "schwab_buy_market",
+        "schwab_buy_stock_market",
+        "schwab_buy_stock_limit",
+        "schwab_cancel_order",
         "schwab_sell_market",
+        "schwab_sell_stock_market",
+        "schwab_sell_stock_limit",
         "schwab_buy_limit",
         "schwab_sell_limit",
         "cancel_schwab_order",
@@ -58,6 +63,7 @@ _SCHWAB_PROHIBITED_TOOLS = frozenset(
         "schwab_order_sell_option_limit",
         "schwab_replace_order",
         "place_schwab_order",
+        "schwab_place_order",
     }
 )
 

--- a/tests/integration/live_market_harness.py
+++ b/tests/integration/live_market_harness.py
@@ -4,12 +4,18 @@ Live tests require both the --run-live-market CLI flag and the OPEN_STOCKS_RUN_L
 environment variable.  Credentials (ROBINHOOD_USERNAME, ROBINHOOD_PASSWORD) must also be
 present before any broker session or network call is attempted.
 
-Usage:
+Usage (Robinhood):
     OPEN_STOCKS_RUN_LIVE_MARKET=1 uv run pytest tests/integration -m live_market \\
         --run-live-market --maxfail=1
+
+Usage (Schwab):
+    OPEN_STOCKS_RUN_LIVE_MARKET=1 RUN_RATE_LIMITED=1 ENABLED_BROKERS=schwab \\
+        uv run pytest tests/integration/test_schwab_live_journeys.py \\
+        -m "live_market and auth_required and rate_limited" --run-live-market -q
 """
 
 import os
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -23,8 +29,37 @@ LIVE_MARKET_SKIP_REASON = (
 _CRED_SKIP_REASON = (
     "live_market test requires ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD"
 )
+_SCHWAB_CRED_SKIP_REASON = (
+    "Schwab live test requires SCHWAB_API_KEY and SCHWAB_APP_SECRET env vars"
+)
+_SCHWAB_TOKEN_SKIP_REASON = (
+    "Schwab live test requires a pre-existing token at SCHWAB_TOKEN_PATH "
+    "(default: ~/.tokens/schwab_token.json). Run interactive auth once first."
+)
 
 _PROHIBITED_PREFIXES = ("order_", "cancel_")
+
+_SCHWAB_PROHIBITED_TOOLS = frozenset(
+    {
+        "schwab_buy_market",
+        "schwab_sell_market",
+        "schwab_buy_limit",
+        "schwab_sell_limit",
+        "cancel_schwab_order",
+        "schwab_cancel_all_stock_orders",
+        "schwab_option_buy_to_open",
+        "schwab_option_sell_to_close",
+        "schwab_order_sell_stop",
+        "schwab_cancel_all_option_orders",
+        "schwab_cancel_option_order",
+        "schwab_order_option_credit_spread",
+        "schwab_order_option_debit_spread",
+        "schwab_order_buy_option_limit",
+        "schwab_order_sell_option_limit",
+        "schwab_replace_order",
+        "place_schwab_order",
+    }
+)
 
 
 def require_live_market_preflight(pytestconfig: Any) -> None:
@@ -49,6 +84,36 @@ def require_live_market_preflight(pytestconfig: Any) -> None:
         pytest.skip(_CRED_SKIP_REASON)
 
 
+def require_schwab_live_preflight(pytestconfig: Any) -> None:
+    """Skip the calling test unless the Schwab live-market opt-in is fully satisfied.
+
+    Checks (in order):
+    1. --run-live-market CLI flag is set.
+    2. OPEN_STOCKS_RUN_LIVE_MARKET env var is set to a truthy value.
+    3. SCHWAB_API_KEY and SCHWAB_APP_SECRET are both present.
+    4. A pre-existing token file is available (non-interactive pytest cannot do OAuth).
+
+    Raises pytest.skip.Exception if any condition is not met.
+    """
+    if not pytestconfig.getoption("--run-live-market", default=False):
+        pytest.skip(LIVE_MARKET_SKIP_REASON)
+
+    if not os.environ.get(LIVE_MARKET_ENV_VAR):
+        pytest.skip(LIVE_MARKET_SKIP_REASON)
+
+    api_key = os.environ.get("SCHWAB_API_KEY")
+    app_secret = os.environ.get("SCHWAB_APP_SECRET")
+    if not api_key or not app_secret:
+        pytest.skip(_SCHWAB_CRED_SKIP_REASON)
+
+    from pathlib import Path
+
+    token_path_env = os.environ.get("SCHWAB_TOKEN_PATH")
+    token_path = Path(token_path_env) if token_path_env else Path.home() / ".tokens" / "schwab_token.json"
+    if not token_path.exists():
+        pytest.skip(_SCHWAB_TOKEN_SKIP_REASON)
+
+
 def assert_live_market_read_only(tool_name: str) -> None:
     """Raise ValueError if tool_name is a prohibited trading or cancellation helper.
 
@@ -61,6 +126,26 @@ def assert_live_market_read_only(tool_name: str) -> None:
                 f"Live market tests may not call '{tool_name}': "
                 f"tools beginning with '{prefix}' are prohibited in automated runs. "
                 "Use manual testing only for order placement and cancellation."
+            )
+
+
+def assert_live_schwab_read_only(tool_name: str) -> None:
+    """Raise ValueError if tool_name is a prohibited Schwab trading or cancellation helper.
+
+    Order placement and cancellation tools are financially unsafe in automated tests.
+    The full list of prohibited Schwab tool names is maintained in _SCHWAB_PROHIBITED_TOOLS.
+    """
+    if tool_name in _SCHWAB_PROHIBITED_TOOLS:
+        raise ValueError(
+            f"Schwab live market tests may not call '{tool_name}': "
+            "order placement and cancellation tools are prohibited in automated runs. "
+            "Use manual testing only for order placement and cancellation."
+        )
+    for prefix in _PROHIBITED_PREFIXES:
+        if tool_name.startswith(prefix):
+            raise ValueError(
+                f"Schwab live market tests may not call '{tool_name}': "
+                f"tools beginning with '{prefix}' are prohibited in automated runs."
             )
 
 
@@ -85,3 +170,59 @@ def live_robinhood_session(request: Any) -> Any:
     yield
 
     rh.logout()
+
+
+@pytest.fixture(scope="module")
+def live_schwab_broker(request: Any) -> Generator[Any, None, None]:
+    """Module-scoped fixture that creates an authenticated SchwabBroker instance.
+
+    Skips the entire test module when:
+    - --run-live-market flag is absent
+    - OPEN_STOCKS_RUN_LIVE_MARKET env var is not set
+    - SCHWAB_API_KEY or SCHWAB_APP_SECRET are missing
+    - No pre-existing token file is found (non-interactive auth is not possible in pytest)
+
+    The broker is registered in an isolated BrokerRegistry and monkeypatched into
+    the tool layer so direct Schwab tool calls use this authenticated instance.
+    """
+    require_schwab_live_preflight(request.config)
+
+    from pathlib import Path
+
+    api_key = os.environ["SCHWAB_API_KEY"]
+    app_secret = os.environ["SCHWAB_APP_SECRET"]
+    callback_url = os.environ.get("SCHWAB_CALLBACK_URL", "https://127.0.0.1:8182/")
+    token_path_env = os.environ.get("SCHWAB_TOKEN_PATH")
+    token_path = str(token_path_env) if token_path_env else str(Path.home() / ".tokens" / "schwab_token.json")
+
+    from open_stocks_mcp.brokers.registry import BrokerRegistry
+    from open_stocks_mcp.brokers.schwab import SchwabBroker
+
+    broker = SchwabBroker(
+        api_key=api_key,
+        app_secret=app_secret,
+        callback_url=callback_url,
+        token_path=token_path,
+    )
+
+    import asyncio
+
+    auth_ok = asyncio.get_event_loop().run_until_complete(broker.authenticate())
+    if not auth_ok:
+        pytest.skip("Schwab authentication failed — check token file and credentials")
+
+    registry = BrokerRegistry()
+    registry.register(broker)
+
+    # Replace the function reference tools use via broker_utils
+    import open_stocks_mcp.tools.broker_utils as broker_utils_module
+    from open_stocks_mcp.brokers import registry as registry_module
+
+    registry_module._registry = registry  # type: ignore[attr-defined]
+    broker_utils_module.__dict__["_patched_registry_active"] = True
+
+    yield broker
+
+    # Restore original global registry state
+    registry_module._registry = None  # type: ignore[attr-defined]
+    broker_utils_module.__dict__.pop("_patched_registry_active", None)

--- a/tests/integration/test_live_market_harness.py
+++ b/tests/integration/test_live_market_harness.py
@@ -202,3 +202,19 @@ class TestSchwabReadOnlyGuard:
         """schwab_option_sell_to_close places an option order and is prohibited."""
         with pytest.raises(ValueError, match="schwab_option_sell_to_close"):
             assert_live_schwab_read_only("schwab_option_sell_to_close")
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "schwab_buy_stock_market",
+            "schwab_sell_stock_market",
+            "schwab_buy_stock_limit",
+            "schwab_sell_stock_limit",
+            "schwab_place_order",
+            "schwab_cancel_order",
+        ],
+    )
+    def test_rejects_public_schwab_mcp_trading_tools(self, tool_name: str) -> None:
+        """Public MCP order placement and cancellation tools are prohibited."""
+        with pytest.raises(ValueError, match=tool_name):
+            assert_live_schwab_read_only(tool_name)

--- a/tests/integration/test_live_market_harness.py
+++ b/tests/integration/test_live_market_harness.py
@@ -12,7 +12,9 @@ from tests.integration.live_market_harness import (
     LIVE_MARKET_ENV_VAR,
     LIVE_MARKET_SKIP_REASON,
     assert_live_market_read_only,
+    assert_live_schwab_read_only,
     require_live_market_preflight,
+    require_schwab_live_preflight,
 )
 
 
@@ -101,3 +103,102 @@ class TestReadOnlyGuard:
         """cancel_all_stock_orders is also prohibited."""
         with pytest.raises(ValueError):
             assert_live_market_read_only("cancel_all_stock_orders")
+
+
+class TestSchwabPreflightRejection:
+    """Schwab harness rejects live-market execution when opt-in is missing."""
+
+    def test_schwab_skips_without_run_live_market_flag(self) -> None:
+        """Skip when --run-live-market CLI flag is absent."""
+        config = MagicMock()
+        config.getoption.return_value = False
+        with pytest.raises(pytest.skip.Exception) as exc_info:
+            require_schwab_live_preflight(config)
+        assert "run-live-market" in str(
+            exc_info.value
+        ).lower() or LIVE_MARKET_SKIP_REASON in str(exc_info.value)
+
+    def test_schwab_skips_without_env_var(self, monkeypatch: Any) -> None:
+        """Skip when OPEN_STOCKS_RUN_LIVE_MARKET env var is absent."""
+        monkeypatch.delenv(LIVE_MARKET_ENV_VAR, raising=False)
+        config = MagicMock()
+        config.getoption.return_value = True
+        with pytest.raises(pytest.skip.Exception):
+            require_schwab_live_preflight(config)
+
+    def test_schwab_skips_without_api_key(self, monkeypatch: Any) -> None:
+        """Skip when SCHWAB_API_KEY is absent."""
+        monkeypatch.setenv(LIVE_MARKET_ENV_VAR, "1")
+        monkeypatch.delenv("SCHWAB_API_KEY", raising=False)
+        monkeypatch.setenv("SCHWAB_APP_SECRET", "secret")
+        config = MagicMock()
+        config.getoption.return_value = True
+        with pytest.raises(pytest.skip.Exception):
+            require_schwab_live_preflight(config)
+
+    def test_schwab_skips_without_app_secret(self, monkeypatch: Any) -> None:
+        """Skip when SCHWAB_APP_SECRET is absent."""
+        monkeypatch.setenv(LIVE_MARKET_ENV_VAR, "1")
+        monkeypatch.setenv("SCHWAB_API_KEY", "key")
+        monkeypatch.delenv("SCHWAB_APP_SECRET", raising=False)
+        config = MagicMock()
+        config.getoption.return_value = True
+        with pytest.raises(pytest.skip.Exception):
+            require_schwab_live_preflight(config)
+
+    def test_schwab_skips_without_token_file(self, monkeypatch: Any, tmp_path: Any) -> None:
+        """Skip when no token file exists at the configured path."""
+        monkeypatch.setenv(LIVE_MARKET_ENV_VAR, "1")
+        monkeypatch.setenv("SCHWAB_API_KEY", "key")
+        monkeypatch.setenv("SCHWAB_APP_SECRET", "secret")
+        monkeypatch.setenv("SCHWAB_TOKEN_PATH", str(tmp_path / "nonexistent_token.json"))
+        config = MagicMock()
+        config.getoption.return_value = True
+        with pytest.raises(pytest.skip.Exception):
+            require_schwab_live_preflight(config)
+
+
+class TestSchwabReadOnlyGuard:
+    """assert_live_schwab_read_only blocks Schwab trading and cancellation helpers."""
+
+    def test_allows_get_schwab_quote(self) -> None:
+        """Read-only Schwab tools pass without error."""
+        assert_live_schwab_read_only("get_schwab_quote")
+
+    def test_allows_get_schwab_orders(self) -> None:
+        """get_schwab_orders is a read-only query and is permitted."""
+        assert_live_schwab_read_only("get_schwab_orders")
+
+    def test_allows_get_schwab_option_chain(self) -> None:
+        """get_schwab_option_chain is a read-only query and is permitted."""
+        assert_live_schwab_read_only("get_schwab_option_chain")
+
+    def test_rejects_schwab_buy_market(self) -> None:
+        """schwab_buy_market places an order and is prohibited."""
+        with pytest.raises(ValueError, match="schwab_buy_market"):
+            assert_live_schwab_read_only("schwab_buy_market")
+
+    def test_rejects_schwab_sell_limit(self) -> None:
+        """schwab_sell_limit places an order and is prohibited."""
+        with pytest.raises(ValueError, match="schwab_sell_limit"):
+            assert_live_schwab_read_only("schwab_sell_limit")
+
+    def test_rejects_cancel_schwab_order(self) -> None:
+        """cancel_schwab_order cancels a live order and is prohibited."""
+        with pytest.raises(ValueError, match="cancel_schwab_order"):
+            assert_live_schwab_read_only("cancel_schwab_order")
+
+    def test_rejects_schwab_cancel_all_stock_orders(self) -> None:
+        """schwab_cancel_all_stock_orders cancels live orders and is prohibited."""
+        with pytest.raises(ValueError, match="schwab_cancel_all_stock_orders"):
+            assert_live_schwab_read_only("schwab_cancel_all_stock_orders")
+
+    def test_rejects_schwab_option_buy_to_open(self) -> None:
+        """schwab_option_buy_to_open places an option order and is prohibited."""
+        with pytest.raises(ValueError, match="schwab_option_buy_to_open"):
+            assert_live_schwab_read_only("schwab_option_buy_to_open")
+
+    def test_rejects_schwab_option_sell_to_close(self) -> None:
+        """schwab_option_sell_to_close places an option order and is prohibited."""
+        with pytest.raises(ValueError, match="schwab_option_sell_to_close"):
+            assert_live_schwab_read_only("schwab_option_sell_to_close")

--- a/tests/integration/test_schwab_live_journeys.py
+++ b/tests/integration/test_schwab_live_journeys.py
@@ -1,0 +1,468 @@
+"""Live Schwab journey tests for read-only account, market data, options, and trading-safe workflows.
+
+These tests require explicit opt-in and will be skipped unless all of the following
+environment variables and CLI flags are set:
+
+    --run-live-market                  (pytest CLI flag)
+    OPEN_STOCKS_RUN_LIVE_MARKET=1      (env var)
+    RUN_RATE_LIMITED=1                 (env var — Schwab calls are rate-limited)
+    SCHWAB_API_KEY=<key>               (env var)
+    SCHWAB_APP_SECRET=<secret>         (env var)
+    SCHWAB_TOKEN_PATH=<path>           (optional; defaults to ~/.tokens/schwab_token.json)
+
+A pre-existing OAuth token at SCHWAB_TOKEN_PATH is required; these tests never open
+a browser or perform interactive authentication.
+
+Run command:
+    OPEN_STOCKS_RUN_LIVE_MARKET=1 RUN_RATE_LIMITED=1 ENABLED_BROKERS=schwab \\
+        uv run pytest tests/integration/test_schwab_live_journeys.py \\
+        -m "live_market and auth_required and rate_limited" --run-live-market -q
+
+These tests never invoke order placement or cancellation functions. Trading journey
+coverage is limited to read-only order/transaction queries.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from tests.integration.live_market_harness import assert_live_schwab_read_only
+
+# ---------------------------------------------------------------------------
+# Account journey
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_account
+def test_get_schwab_account_numbers(live_schwab_broker: Any) -> None:
+    """get_schwab_account_numbers returns non-empty account list."""
+    assert_live_schwab_read_only("get_schwab_account_numbers")
+
+    from open_stocks_mcp.tools.schwab_account_tools import get_schwab_account_numbers
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_account_numbers())
+    assert isinstance(result, dict), "Response must be a dict"
+    assert "result" in result, "Response must contain 'result'"
+    inner = result["result"]
+    assert "accounts" in inner, "Result must contain 'accounts'"
+    assert "count" in inner, "Result must contain 'count'"
+    accounts = inner["accounts"]
+    assert isinstance(accounts, list), "'accounts' must be a list"
+    assert len(accounts) > 0, "At least one account must be present"
+    first = accounts[0]
+    assert isinstance(first.get("hash_value"), str) and first["hash_value"], (
+        "account 'hash_value' must be a non-empty string"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_account
+def test_get_schwab_account(live_schwab_broker: Any) -> None:
+    """get_schwab_account returns account data for a valid hash."""
+    assert_live_schwab_read_only("get_schwab_account")
+
+    from open_stocks_mcp.tools.schwab_account_tools import (
+        get_schwab_account,
+        get_schwab_account_numbers,
+    )
+
+    numbers_result = asyncio.get_event_loop().run_until_complete(get_schwab_account_numbers())
+    account_hash = numbers_result["result"]["accounts"][0]["hash_value"]
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_account(account_hash))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert "account_hash" in inner or "accountNumber" in str(inner), (
+        "Account response must reference an account"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_account
+def test_get_schwab_account_balances(live_schwab_broker: Any) -> None:
+    """get_schwab_account_balances returns numeric balance fields."""
+    assert_live_schwab_read_only("get_schwab_account_balances")
+
+    from open_stocks_mcp.tools.schwab_account_tools import (
+        get_schwab_account_balances,
+        get_schwab_account_numbers,
+    )
+
+    numbers_result = asyncio.get_event_loop().run_until_complete(get_schwab_account_numbers())
+    account_hash = numbers_result["result"]["accounts"][0]["hash_value"]
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_account_balances(account_hash))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    # Accept either shape; just verify it's a non-error dict
+    assert isinstance(inner, dict), "'result' must be a dict"
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_portfolio
+def test_get_schwab_portfolio(live_schwab_broker: Any) -> None:
+    """get_schwab_portfolio returns position/count shape."""
+    assert_live_schwab_read_only("get_schwab_portfolio")
+
+    from open_stocks_mcp.tools.schwab_account_tools import (
+        get_schwab_account_numbers,
+        get_schwab_portfolio,
+    )
+
+    numbers_result = asyncio.get_event_loop().run_until_complete(get_schwab_account_numbers())
+    account_hash = numbers_result["result"]["accounts"][0]["hash_value"]
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_portfolio(account_hash))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert isinstance(inner, dict)
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    # Either positions key or an explicit empty-portfolio indicator is acceptable
+    assert "positions" in inner or "count" in inner or "account_hash" in inner
+
+
+# ---------------------------------------------------------------------------
+# Market data journey
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_market_data
+def test_get_schwab_quote(live_schwab_broker: Any) -> None:
+    """get_schwab_quote returns symbol matching the request."""
+    assert_live_schwab_read_only("get_schwab_quote")
+
+    from open_stocks_mcp.tools.schwab_market_tools import get_schwab_quote
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_quote("AAPL"))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    # Symbol should be present and match
+    returned_symbol = inner.get("symbol") or inner.get("AAPL", {})
+    assert returned_symbol or "AAPL" in str(inner), "Quote response must reference AAPL"
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_market_data
+def test_get_schwab_quotes(live_schwab_broker: Any) -> None:
+    """get_schwab_quotes returns data for each requested symbol."""
+    assert_live_schwab_read_only("get_schwab_quotes")
+
+    from open_stocks_mcp.tools.schwab_market_tools import get_schwab_quotes
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_quotes(["AAPL", "MSFT"]))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    # Should contain quote data — at minimum one of the requested symbols
+    payload_str = str(inner)
+    assert "AAPL" in payload_str or "MSFT" in payload_str, (
+        "Multi-quote response must contain at least one requested symbol"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_market_data
+def test_get_schwab_price_history(live_schwab_broker: Any) -> None:
+    """get_schwab_price_history returns candle/count structure."""
+    assert_live_schwab_read_only("get_schwab_price_history")
+
+    from open_stocks_mcp.tools.schwab_market_tools import get_schwab_price_history
+
+    result = asyncio.get_event_loop().run_until_complete(
+        get_schwab_price_history("AAPL", period_type="month", period=1, frequency_type="daily", frequency=1)
+    )
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    # Expect candle list or count field
+    assert "candles" in inner or "count" in inner or "symbol" in inner, (
+        "Price history response must contain candles, count, or symbol"
+    )
+    if "candles" in inner:
+        candles = inner["candles"]
+        assert isinstance(candles, list)
+        if candles:
+            candle = candles[0]
+            for field in ("open", "high", "low", "close"):
+                if field in candle:
+                    assert isinstance(candle[field], (int, float)), (
+                        f"Candle '{field}' must be numeric"
+                    )
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_market_data
+def test_search_schwab_instruments(live_schwab_broker: Any) -> None:
+    """search_schwab_instruments returns non-empty results for a known query."""
+    assert_live_schwab_read_only("search_schwab_instruments")
+
+    from open_stocks_mcp.tools.schwab_market_tools import search_schwab_instruments
+
+    result = asyncio.get_event_loop().run_until_complete(search_schwab_instruments("Apple"))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    # Results list or instruments key
+    assert "instruments" in inner or "results" in inner or "count" in inner, (
+        "Instrument search must return instruments, results, or count"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Options journey
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_options
+def test_get_schwab_option_expirations(live_schwab_broker: Any) -> None:
+    """get_schwab_option_expirations returns expiration date list for AAPL."""
+    assert_live_schwab_read_only("get_schwab_option_expirations")
+
+    from open_stocks_mcp.tools.schwab_options_tools import get_schwab_option_expirations
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_option_expirations("AAPL"))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    assert "expirationList" in inner or "expirations" in inner or "count" in inner or "symbol" in inner, (
+        "Option expirations response must contain expiration data"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_options
+def test_get_schwab_option_chain(live_schwab_broker: Any) -> None:
+    """get_schwab_option_chain returns chain structure with symbol and count fields."""
+    assert_live_schwab_read_only("get_schwab_option_chain")
+
+    from open_stocks_mcp.tools.schwab_options_tools import get_schwab_option_chain
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_option_chain("AAPL"))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    # Option chain must reference the requested symbol
+    assert "AAPL" in str(inner), "Option chain response must reference AAPL"
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_options
+def test_get_schwab_options_positions(live_schwab_broker: Any) -> None:
+    """get_schwab_options_positions returns position list shape (empty is acceptable)."""
+    assert_live_schwab_read_only("get_schwab_options_positions")
+
+    from open_stocks_mcp.tools.schwab_account_tools import get_schwab_account_numbers
+    from open_stocks_mcp.tools.schwab_options_tools import get_schwab_options_positions
+
+    numbers_result = asyncio.get_event_loop().run_until_complete(get_schwab_account_numbers())
+    account_hash = numbers_result["result"]["accounts"][0]["hash_value"]
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_options_positions(account_hash))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    # positions list may be empty; validate shape
+    if "positions" in inner:
+        assert isinstance(inner["positions"], list)
+    if "count" in inner:
+        assert isinstance(inner["count"], int)
+
+
+# ---------------------------------------------------------------------------
+# Trading-safe (read-only) journey
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_trading
+def test_get_schwab_orders(live_schwab_broker: Any) -> None:
+    """get_schwab_orders returns order list shape (empty is acceptable)."""
+    assert_live_schwab_read_only("get_schwab_orders")
+
+    from open_stocks_mcp.tools.schwab_account_tools import get_schwab_account_numbers
+    from open_stocks_mcp.tools.schwab_trading_tools import get_schwab_orders
+
+    numbers_result = asyncio.get_event_loop().run_until_complete(get_schwab_account_numbers())
+    account_hash = numbers_result["result"]["accounts"][0]["hash_value"]
+
+    result = asyncio.get_event_loop().run_until_complete(get_schwab_orders(account_hash))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    if "orders" in inner:
+        assert isinstance(inner["orders"], list)
+    if "count" in inner:
+        assert isinstance(inner["count"], int)
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_trading
+def test_schwab_get_open_stock_orders(live_schwab_broker: Any) -> None:
+    """schwab_get_open_stock_orders returns open order list shape (empty is acceptable)."""
+    assert_live_schwab_read_only("schwab_get_open_stock_orders")
+
+    from open_stocks_mcp.tools.schwab_account_tools import get_schwab_account_numbers
+    from open_stocks_mcp.tools.schwab_trading_tools import schwab_get_open_stock_orders
+
+    numbers_result = asyncio.get_event_loop().run_until_complete(get_schwab_account_numbers())
+    account_hash = numbers_result["result"]["accounts"][0]["hash_value"]
+
+    result = asyncio.get_event_loop().run_until_complete(schwab_get_open_stock_orders(account_hash))
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    if "orders" in inner:
+        assert isinstance(inner["orders"], list)
+    if "count" in inner:
+        assert isinstance(inner["count"], int)
+
+
+@pytest.mark.integration
+@pytest.mark.live_market
+@pytest.mark.auth_required
+@pytest.mark.rate_limited
+@pytest.mark.journey_trading
+def test_schwab_get_transactions_by_date(live_schwab_broker: Any) -> None:
+    """schwab_get_transactions_by_date returns transaction list shape (empty is acceptable)."""
+    assert_live_schwab_read_only("schwab_get_transactions_by_date")
+
+    from open_stocks_mcp.tools.schwab_account_tools import get_schwab_account_numbers
+    from open_stocks_mcp.tools.schwab_trading_tools import (
+        schwab_get_transactions_by_date,
+    )
+
+    numbers_result = asyncio.get_event_loop().run_until_complete(get_schwab_account_numbers())
+    account_hash = numbers_result["result"]["accounts"][0]["hash_value"]
+
+    result = asyncio.get_event_loop().run_until_complete(
+        schwab_get_transactions_by_date(account_hash, start_date="2024-01-01", end_date="2024-12-31")
+    )
+    assert isinstance(result, dict)
+    assert "result" in result
+    inner = result["result"]
+    assert inner.get("status") != "error", f"Unexpected error response: {inner}"
+    assert isinstance(inner, dict)
+    if "transactions" in inner:
+        assert isinstance(inner["transactions"], list)
+    if "count" in inner:
+        assert isinstance(inner["count"], int)
+
+
+# ---------------------------------------------------------------------------
+# Read-only safety guard tests (no live credentials needed)
+# ---------------------------------------------------------------------------
+
+
+class TestSchwabReadOnlyGuard:
+    """assert_live_schwab_read_only rejects all financially dangerous tool names."""
+
+    def test_allows_read_only_get_quote(self) -> None:
+        assert_live_schwab_read_only("get_schwab_quote")
+
+    def test_allows_read_only_get_orders(self) -> None:
+        assert_live_schwab_read_only("get_schwab_orders")
+
+    def test_allows_read_only_get_option_chain(self) -> None:
+        assert_live_schwab_read_only("get_schwab_option_chain")
+
+    def test_rejects_schwab_buy_market(self) -> None:
+        with pytest.raises(ValueError, match="schwab_buy_market"):
+            assert_live_schwab_read_only("schwab_buy_market")
+
+    def test_rejects_schwab_sell_limit(self) -> None:
+        with pytest.raises(ValueError, match="schwab_sell_limit"):
+            assert_live_schwab_read_only("schwab_sell_limit")
+
+    def test_rejects_cancel_schwab_order(self) -> None:
+        with pytest.raises(ValueError, match="cancel_schwab_order"):
+            assert_live_schwab_read_only("cancel_schwab_order")
+
+    def test_rejects_schwab_cancel_all_stock_orders(self) -> None:
+        with pytest.raises(ValueError, match="schwab_cancel_all_stock_orders"):
+            assert_live_schwab_read_only("schwab_cancel_all_stock_orders")
+
+    def test_rejects_schwab_option_buy_to_open(self) -> None:
+        with pytest.raises(ValueError, match="schwab_option_buy_to_open"):
+            assert_live_schwab_read_only("schwab_option_buy_to_open")
+
+    def test_rejects_schwab_option_sell_to_close(self) -> None:
+        with pytest.raises(ValueError, match="schwab_option_sell_to_close"):
+            assert_live_schwab_read_only("schwab_option_sell_to_close")
+
+    def test_rejects_place_schwab_order(self) -> None:
+        with pytest.raises(ValueError, match="place_schwab_order"):
+            assert_live_schwab_read_only("place_schwab_order")
+
+    def test_rejects_cancel_prefix_generic(self) -> None:
+        with pytest.raises(ValueError):
+            assert_live_schwab_read_only("cancel_anything")
+
+    def test_rejects_order_prefix_generic(self) -> None:
+        with pytest.raises(ValueError):
+            assert_live_schwab_read_only("order_something")


### PR DESCRIPTION
Closes #105

## Changes
- Added `require_schwab_live_preflight()` to `live_market_harness.py`: checks `--run-live-market`, `OPEN_STOCKS_RUN_LIVE_MARKET`, `SCHWAB_API_KEY`, `SCHWAB_APP_SECRET`, and a pre-existing token file before any live Schwab call
- Added `assert_live_schwab_read_only()` to `live_market_harness.py`: rejects all Schwab order placement and cancellation tool names via an explicit blocklist plus the existing `order_`/`cancel_` prefix guard
- Added `live_schwab_broker` module-scoped fixture: authenticates `SchwabBroker` from the existing token, registers it in an isolated `BrokerRegistry`, and patches the global registry so tool calls use it; restores state on teardown
- Added `tests/integration/test_schwab_live_journeys.py`: 14 live journey tests (account discovery, balances, portfolio, quote, multi-quote, price history, instrument search, option expirations, option chain, options positions, orders, open stock orders, transactions) plus 12 non-live read-only guard tests
- Extended `tests/integration/test_live_market_harness.py`: 5 Schwab preflight skip cases and 8 Schwab read-only guard cases
- Updated `docs/TEST_MARKERS.md`: Schwab live journey section with required env vars, token instructions, safety note, and run command
- Updated `CONTRIBUTING.md`: Schwab live journey row in the test workflow table with credential notes

## Test plan
- `uv run pytest tests/integration/test_live_market_harness.py -q -o addopts=''` — 25 passed (Schwab preflight + guard behavior verified without credentials)
- `uv run pytest tests/integration/test_schwab_live_journeys.py -q -o addopts=''` — 12 passed, 14 skipped cleanly (live tests skip without opt-in, guard tests pass)
- `uv run ruff check tests/integration/live_market_harness.py tests/integration/test_live_market_harness.py tests/integration/test_schwab_live_journeys.py` — All checks passed
- `git diff --check` — No whitespace errors