### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -71,9 +71,7 @@ async def execute_with_retry(
     if retry_config is None:
         raise RuntimeError("Retry configuration unavailable")
     configured_max_retries = (
-        retry_config.max_retries
-        if max_retries is None
-        else max_retries
+        retry_config.max_retries if max_retries is None else max_retries
     )
     if configured_max_retries is None:
         configured_max_retries = DEFAULT_MAX_RETRIES

--- a/src/open_stocks_mcp/tools/robinhood_account_feature_summary_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_account_feature_summary_tools.py
@@ -1,4 +1,5 @@
 """Robinhood account feature tools."""
+
 from typing import Any
 
 from open_stocks_mcp.logging_config import logger

--- a/src/open_stocks_mcp/tools/robinhood_margin_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_margin_tools.py
@@ -1,4 +1,5 @@
 """Robinhood account feature tools."""
+
 import contextlib
 from typing import Any
 
@@ -95,6 +96,7 @@ async def get_margin_calls() -> dict[str, Any]:
             "status": "success",
         }
     }
+
 
 @handle_robin_stocks_errors
 async def get_margin_interest() -> dict[str, Any]:

--- a/src/open_stocks_mcp/tools/robinhood_notification_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_notification_tools.py
@@ -1,4 +1,5 @@
 """Robinhood account feature tools."""
+
 from typing import Any
 
 import robin_stocks.robinhood as rh
@@ -96,6 +97,7 @@ async def get_notifications(count: int | None = 20) -> dict[str, Any]:
             "status": "success",
         }
     }
+
 
 @handle_robin_stocks_errors
 async def get_latest_notification() -> dict[str, Any]:

--- a/src/open_stocks_mcp/tools/robinhood_referral_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_referral_tools.py
@@ -1,4 +1,5 @@
 """Robinhood account feature tools."""
+
 import contextlib
 from typing import Any
 

--- a/src/open_stocks_mcp/tools/robinhood_subscription_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_subscription_tools.py
@@ -1,4 +1,5 @@
 """Robinhood account feature tools."""
+
 import contextlib
 from typing import Any
 

--- a/src/open_stocks_mcp/tools/robinhood_trading_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_trading_tools.py
@@ -1560,9 +1560,7 @@ async def get_all_open_stock_orders() -> dict[str, Any]:
         symbol = "N/A"
         if instrument_url:
             try:
-                symbol = await execute_with_retry(
-                    rh.get_symbol_by_url, instrument_url
-                )
+                symbol = await execute_with_retry(rh.get_symbol_by_url, instrument_url)
             except Exception as e:
                 logger.warning(
                     f"Failed to get symbol for instrument {instrument_url}: {e}"

--- a/src/open_stocks_mcp/tools/watchlists/read.py
+++ b/src/open_stocks_mcp/tools/watchlists/read.py
@@ -268,7 +268,9 @@ async def get_watchlist_performance(watchlist_name: str) -> dict[str, Any]:
             )
 
     total_symbols = len(symbols_list)
-    avg_change_percent = total_change_percent / total_symbols if total_symbols > 0 else 0
+    avg_change_percent = (
+        total_change_percent / total_symbols if total_symbols > 0 else 0
+    )
 
     logger.info(
         f"Performance analysis complete for '{watchlist_name}': {gainers} gainers, {losers} losers"

--- a/src/open_stocks_mcp/tools/watchlists/write.py
+++ b/src/open_stocks_mcp/tools/watchlists/write.py
@@ -115,7 +115,9 @@ async def remove_symbols_from_watchlist(
     try:
         from functools import partial
 
-        delete_with_name = partial(rh.delete_symbols_from_watchlist, name=watchlist_name)
+        delete_with_name = partial(
+            rh.delete_symbols_from_watchlist, name=watchlist_name
+        )
         result = await execute_with_retry(
             delete_with_name,
             formatted_symbols,

--- a/tests/unit/test_dev_tooling.py
+++ b/tests/unit/test_dev_tooling.py
@@ -83,11 +83,14 @@ def test_schwab_status_version_matches_pyproject() -> None:
 
 @pytest.mark.unit
 def test_mypy_dev_tooling_targets_2_1_0() -> None:
-    pyproject_data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    pyproject_data = tomllib.loads(
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
 
-    assert MYPY_DEV_REQUIREMENT in pyproject_data["project"]["optional-dependencies"][
-        "dev"
-    ]
+    assert (
+        MYPY_DEV_REQUIREMENT
+        in pyproject_data["project"]["optional-dependencies"]["dev"]
+    )
     assert MYPY_DEV_REQUIREMENT in pyproject_data["dependency-groups"]["dev"]
 
     pre_commit = _load_yaml(ROOT / ".pre-commit-config.yaml")

--- a/tests/unit/test_notification_tools.py
+++ b/tests/unit/test_notification_tools.py
@@ -668,9 +668,15 @@ class TestReferrals:
 class TestAccountFeatures:
     """Test account features functionality."""
 
-    @patch("open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_referrals")
-    @patch("open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_notifications")
-    @patch("open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_margin_interest")
+    @patch(
+        "open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_referrals"
+    )
+    @patch(
+        "open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_notifications"
+    )
+    @patch(
+        "open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_margin_interest"
+    )
     @patch(
         "open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_subscription_fees"
     )
@@ -743,9 +749,15 @@ class TestAccountFeatures:
 
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
-    @patch("open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_referrals")
-    @patch("open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_notifications")
-    @patch("open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_margin_interest")
+    @patch(
+        "open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_referrals"
+    )
+    @patch(
+        "open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_notifications"
+    )
+    @patch(
+        "open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_margin_interest"
+    )
     @patch(
         "open_stocks_mcp.tools.robinhood_account_feature_summary_tools.get_subscription_fees"
     )

--- a/tests/unit/test_robinhood_crypto_tools.py
+++ b/tests/unit/test_robinhood_crypto_tools.py
@@ -11,7 +11,9 @@ import pytest
 def test_crypto_placeholder_module_is_absent() -> None:
     # Anchor to the project root to avoid false positives if run from a subdirectory
     project_root = Path(__file__).parent.parent.parent
-    crypto_module_path = project_root / "src/open_stocks_mcp/tools/robinhood_crypto_tools.py"
+    crypto_module_path = (
+        project_root / "src/open_stocks_mcp/tools/robinhood_crypto_tools.py"
+    )
 
     assert not crypto_module_path.exists(), (
         f"Crypto placeholder module must stay deleted at {crypto_module_path}"


### PR DESCRIPTION
## Summary
Automated code-quality cleanup via `ruff check --fix` and `ruff format`.

**12 files reformatted:**
- `src/open_stocks_mcp/tools/retry.py` — trailing whitespace
- `src/open_stocks_mcp/tools/robinhood_account_feature_summary_tools.py` — trailing newline
- `src/open_stocks_mcp/tools/robinhood_margin_tools.py` — blank line formatting
- `src/open_stocks_mcp/tools/robinhood_notification_tools.py` — blank line formatting
- `src/open_stocks_mcp/tools/robinhood_referral_tools.py` — trailing newline
- `src/open_stocks_mcp/tools/robinhood_subscription_tools.py` — trailing newline
- `src/open_stocks_mcp/tools/robinhood_trading_tools.py` — trailing whitespace
- `src/open_stocks_mcp/tools/watchlists/read.py` — line wrapping
- `src/open_stocks_mcp/tools/watchlists/write.py` — line wrapping
- `tests/unit/test_dev_tooling.py` — line wrapping
- `tests/unit/test_notification_tools.py` — line wrapping
- `tests/unit/test_robinhood_crypto_tools.py` — line wrapping

## Validation
- ✅ `ruff check` — all checks passed
- ✅ `mypy src/` — 0 errors (81 source files)
- ✅ `pytest tests/unit/` — 957 passed, 69 skipped, 0 failed (32.5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)