### PR TITLE
docs: add both-broker Docker example with Schwab setup

### DIFF
--- a/examples/open-stocks-mcp-docker/.env.example
+++ b/examples/open-stocks-mcp-docker/.env.example
@@ -34,6 +34,11 @@ ROBINHOOD_PASSWORD=your_secure_password
 #
 # Authentication Method: OAuth 2.0 with automatic token refresh
 # Setup: https://developer.schwab.com/
+#
+# To enable Schwab in Docker, use the both-broker compose override:
+#   docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up
+# The override mounts config.both-brokers.yaml which enables the Schwab
+# feature flag. Without it, these env vars alone will not activate Schwab.
 
 # Schwab API Key (from developer.schwab.com)
 # SCHWAB_API_KEY=your_api_key_here
@@ -41,13 +46,14 @@ ROBINHOOD_PASSWORD=your_secure_password
 # Schwab App Secret (from developer.schwab.com)
 # SCHWAB_APP_SECRET=your_app_secret_here
 
-# OAuth Callback URL (must match your app registration)
+# OAuth Callback URL (must match your Schwab app registration)
 # Default: https://127.0.0.1:8182/
 # SCHWAB_CALLBACK_URL=https://127.0.0.1:8182/
 
-# Token storage path (where OAuth tokens are saved)
-# Default: ~/.tokens/schwab_token.json
-# SCHWAB_TOKEN_PATH=/app/.tokens/schwab_token.json
+# Token storage path — /home/mcp/.tokens is the Docker mcp_tokens volume,
+# which maps to ./data/tokens/ on the host when using a bind mount.
+# The token persists across container restarts.
+# SCHWAB_TOKEN_PATH=/home/mcp/.tokens/schwab_token.json
 
 # ===========================================
 # Multi-Broker Settings
@@ -63,6 +69,15 @@ ROBINHOOD_PASSWORD=your_secure_password
 # Options: robinhood, schwab
 # Default: robinhood
 # DEFAULT_BROKER=robinhood
+
+# ===========================================
+# API KEY (REQUIRED when binding to 0.0.0.0)
+# ===========================================
+# Protects the /mcp endpoint from unauthorized access. The server refuses
+# to start without it when bound to 0.0.0.0 (as docker-compose.yml does).
+# Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Clients must send: Authorization: Bearer $MCP_API_KEY
+# MCP_API_KEY=your_random_secret_here
 
 # ===========================================
 # OPTIONAL: Logging Configuration

--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -20,10 +20,16 @@ This setup uses a production-ready approach:
 
 ### 1. Choose Your Setup
 
-**Production (Recommended):**
+**Robinhood Only (Default):**
 Uses the published PyPI package (v0.6.5 with full trading support):
 ```bash
 docker-compose up
+```
+
+**Both Brokers (Robinhood + Schwab):**
+Adds Schwab via a compose override that mounts `config.both-brokers.yaml`:
+```bash
+docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up
 ```
 
 **Development (Latest Features):**
@@ -97,11 +103,70 @@ INFO -   - Health Check: http://0.0.0.0:3001/health
 - ✅ Log file created at `./data/logs/open_stocks_mcp.log` (persistent)
 - ✅ Health check responds: `curl http://localhost:3001/health`
 
-### 5. Start the Server
+### 5. Both Brokers Setup (Robinhood + Schwab)
+
+To run with both brokers, you need the compose override and Schwab credentials:
+
+```bash
+# 1. Add Schwab credentials to your .env (alongside existing Robinhood creds)
+#    SCHWAB_API_KEY=your_api_key_here
+#    SCHWAB_APP_SECRET=your_app_secret_here
+#    SCHWAB_CALLBACK_URL=https://127.0.0.1:8182/
+#    SCHWAB_TOKEN_PATH=/home/mcp/.tokens/schwab_token.json
+
+# 2. Start with both-broker compose override
+docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up
+```
+
+The override mounts `config.both-brokers.yaml` into the container, which enables
+the `brokers.schwab` feature flag via the runtime config loader. Without this
+override, Schwab env vars alone will not activate the Schwab broker.
+
+#### Schwab OAuth First-Run Setup
+
+Schwab uses browser-based OAuth 2.0 authentication. The first-run flow **cannot
+complete in a fully detached container** because it requires a browser redirect to
+the callback URL:
+
+1. Run the container in the foreground so you can see the OAuth prompt:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up
+   ```
+2. When the Schwab broker starts, it will attempt OAuth. Follow the URL printed
+   in the logs to authorize in your browser.
+3. Ensure the `SCHWAB_CALLBACK_URL` (default `https://127.0.0.1:8182/`) is
+   reachable from your browser so the token exchange completes.
+4. Once authorized, the token is saved to `./data/tokens/schwab_token.json`
+   (via the `/home/mcp/.tokens` volume) and persists across container restarts.
+5. The token auto-refreshes for ~7 days. After that, repeat the browser flow.
+
+After the first successful OAuth, you can run detached:
+```bash
+docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up -d
+```
+
+#### Verify Both Brokers
+
+Call `broker_status` through the MCP JSON-RPC endpoint to confirm both brokers:
+
+```bash
+curl -sS -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"broker_status","arguments":{}},"id":1}'
+```
+
+The response includes a status entry for each configured broker:
+- `"robinhood"`: `"authenticated"`, `"failed"`, or `"not_configured"`
+- `"schwab"`: `"authenticated"`, `"failed"`, or `"not_configured"`
+
+Both should show `"authenticated"` after successful credential setup.
+
+### 6. Start the Server
 
 Run the server using Docker Compose:
 
-**Production (Recommended - v0.6.5 with trading support):**
+**Robinhood Only (v0.6.5 with trading support):**
 ```bash
 # Foreground (see logs)
 docker-compose up
@@ -119,7 +184,16 @@ docker-compose -f docker-compose.dev.yml up
 docker-compose -f docker-compose.dev.yml up -d
 ```
 
-### 6. Verify Server Health
+**Both Brokers:**
+```bash
+# Foreground (see logs — required for Schwab first-run OAuth)
+docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up
+
+# Background (after Schwab OAuth token is persisted)
+docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up -d
+```
+
+### 7. Verify Server Health
 
 Check that the server is running properly:
 
@@ -273,8 +347,13 @@ docker-compose logs --since="1h"
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ROBINHOOD_USERNAME` | Yes | Your Robinhood account username |
-| `ROBINHOOD_PASSWORD` | Yes | Your Robinhood account password |
+| `ROBINHOOD_USERNAME` | For Robinhood | Your Robinhood account username |
+| `ROBINHOOD_PASSWORD` | For Robinhood | Your Robinhood account password |
+| `SCHWAB_API_KEY` | For Schwab | Schwab API key from developer.schwab.com |
+| `SCHWAB_APP_SECRET` | For Schwab | Schwab app secret from developer.schwab.com |
+| `SCHWAB_CALLBACK_URL` | No | OAuth callback URL (default: `https://127.0.0.1:8182/`) |
+| `SCHWAB_TOKEN_PATH` | No | Token storage path (default: `/home/mcp/.tokens/schwab_token.json`) |
+| `MCP_API_KEY` | Yes | Protects `/mcp` endpoint when bound to `0.0.0.0` |
 
 ### Persistent Storage
 
@@ -282,7 +361,7 @@ The Docker setup uses two persistent volumes:
 
 | Volume | Location | Type | Contents |
 |--------|----------|------|----------|
-| `mcp_tokens` | `/home/mcp/.tokens` | Docker-managed named volume | Robinhood session tokens |
+| `mcp_tokens` | `/home/mcp/.tokens` | Docker-managed named volume | Robinhood session tokens and Schwab OAuth tokens |
 | `mcp_logs` | `/home/mcp/.local/state/mcp-servers/logs` | Host bind mount (`./data/logs/`) | Application logs |
 
 **Benefits:**

--- a/examples/open-stocks-mcp-docker/config.both-brokers.yaml
+++ b/examples/open-stocks-mcp-docker/config.both-brokers.yaml
@@ -1,0 +1,19 @@
+# Both-broker Docker configuration for Open Stocks MCP
+#
+# Enables Robinhood and Schwab broker feature flags.
+# Secrets (passwords, API keys) stay in .env — not in this file.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up
+
+environment: docker
+
+feature_flags:
+  brokers.robinhood:
+    default: true
+    environments:
+      docker: true
+  brokers.schwab:
+    default: true
+    environments:
+      docker: true

--- a/examples/open-stocks-mcp-docker/data/README.md
+++ b/examples/open-stocks-mcp-docker/data/README.md
@@ -4,9 +4,15 @@ This directory contains host-backed persistent data for the Open Stocks MCP serv
 
 - **logs/**: Application logs and debugging information
 
-Robinhood session tokens are stored in the Docker-managed `mcp_tokens` named
-volume (not on the host filesystem). Run `docker-compose down -v` to remove
-all volumes and force re-authentication.
+Broker tokens are stored in the Docker-managed `mcp_tokens` named volume
+(mounted at `/home/mcp/.tokens` inside the container):
+
+- **robinhood.pickle** — Robinhood session token (pickle format)
+- **schwab_token.json** — Schwab OAuth token (JSON, written after first-run browser flow)
+
+Both files contain sensitive authentication material. Run
+`docker-compose down -v` to remove all volumes and force re-authentication
+for both brokers.
 
 ## Security Note
 Never commit the contents of these directories to version control.

--- a/examples/open-stocks-mcp-docker/docker-compose.both-brokers.yml
+++ b/examples/open-stocks-mcp-docker/docker-compose.both-brokers.yml
@@ -1,0 +1,15 @@
+# Compose override that enables both Robinhood and Schwab brokers.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up
+#
+# Prerequisites:
+#   1. Copy .env.example to .env and fill in both Robinhood and Schwab credentials.
+#   2. Complete the Schwab OAuth first-run flow (see README.md).
+
+services:
+  open-stocks-mcp:
+    volumes:
+      - ./config.both-brokers.yaml:/usr/src/app/open-stocks-mcp.yaml:ro
+    environment:
+      - OPEN_STOCKS_CONFIG=/usr/src/app/open-stocks-mcp.yaml


### PR DESCRIPTION
Closes #108

## Changes
- Add `examples/open-stocks-mcp-docker/config.both-brokers.yaml` — YAML config enabling `brokers.robinhood` and `brokers.schwab` feature flags for the Docker environment
- Add `examples/open-stocks-mcp-docker/docker-compose.both-brokers.yml` — compose override that mounts the config read-only and sets `OPEN_STOCKS_CONFIG`
- Update `.env.example` with Schwab variables (`SCHWAB_API_KEY`, `SCHWAB_APP_SECRET`, `SCHWAB_CALLBACK_URL`, `SCHWAB_TOKEN_PATH`), Docker-specific token path guidance (`/home/mcp/.tokens`), and `MCP_API_KEY` entry
- Update `README.md` with both-broker quickstart, Schwab OAuth first-run limitations, and `broker_status` MCP JSON-RPC validation command
- Update `data/README.md` to describe both `robinhood.pickle` and `schwab_token.json` token files

## Test plan
- [x] `OPEN_STOCKS_CONFIG=examples/open-stocks-mcp-docker/config.both-brokers.yaml uv run python -c "from open_stocks_mcp.config import load_config; cfg = load_config(); assert cfg.is_feature_enabled('brokers.robinhood'); assert cfg.is_feature_enabled('brokers.schwab')"` — both broker feature flags enabled
- [x] Compose override YAML validated via `yaml.safe_load()` — service, volume mount, and env var present
- [x] `ruff check src/open_stocks_mcp/config.py` passes — no Python source changes needed
- [ ] `docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml config` — validates merged compose (requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)