### PR TITLE
feat: add schwab_get_option_quote single-contract lookup

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -159,6 +159,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_expirations,
     get_schwab_options_positions,
     schwab_get_open_option_orders,
+    schwab_get_option_quote as _schwab_get_option_quote_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
@@ -1910,6 +1911,26 @@ async def schwab_find_tradable_options(
     """
     return await _schwab_find_tradable_options_impl(
         symbol, expiration_date, option_type, strike
+    )
+
+
+@mcp.tool()
+async def schwab_option_quote(
+    symbol: str,
+    expiration_date: str,
+    strike: float,
+    option_type: str,
+) -> dict[str, Any]:
+    """Get a single option contract quote by expiration, strike, and type (Schwab).
+
+    Args:
+        symbol: Stock ticker symbol
+        expiration_date: Expiration date in YYYY-MM-DD format
+        strike: Strike price (e.g. 170.0)
+        option_type: 'CALL' or 'PUT'
+    """
+    return await _schwab_get_option_quote_impl(
+        symbol, expiration_date, strike, option_type
     )
 
 

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -401,6 +401,81 @@ async def get_schwab_option_positions_detailed(
 
 
 @handle_schwab_errors
+async def schwab_get_option_quote(
+    symbol: str,
+    expiration_date: str,
+    strike: float,
+    option_type: str,
+) -> dict[str, Any]:
+    """Get a single option contract quote by expiration, strike, and type.
+
+    Args:
+        symbol: Stock ticker symbol
+        expiration_date: Expiration date in YYYY-MM-DD format
+        strike: Strike price (e.g. 170.0)
+        option_type: 'CALL' or 'PUT'
+
+    Returns:
+        Dict with contract data including bid, ask, last, delta, gamma, theta,
+        vega, volatility, openInterest, totalVolume, and putCall.
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get option quote for {symbol}"
+    )
+    if error:
+        return error
+
+    try:
+        normalized_type = option_type.upper()
+        if normalized_type not in ("CALL", "PUT"):
+            return create_error_response(
+                ValueError(
+                    f"Invalid option_type '{option_type}'. Must be 'CALL' or 'PUT'."
+                )
+            )
+
+        contract_type_map = {
+            "CALL": Client.Options.ContractType.CALL,
+            "PUT": Client.Options.ContractType.PUT,
+        }
+        ct = contract_type_map[normalized_type]
+
+        def _get_option_chain() -> Any:
+            response = broker.client.get_option_chain(
+                symbol.upper(),
+                contract_type=ct,
+                include_underlying_quote=False,
+            )
+            return response.json()
+
+        chain_data = await execute_broker_request(_get_option_chain, retry_safe=True)
+
+        exp_map_key = "callExpDateMap" if normalized_type == "CALL" else "putExpDateMap"
+        exp_map: dict[str, Any] = chain_data.get(exp_map_key, {})
+
+        strike_key = f"{strike:.1f}"
+
+        for exp_chain_key, strikes_map in exp_map.items():
+            # Schwab keys have DTE suffix: "YYYY-MM-DD:N"
+            if not exp_chain_key.startswith(expiration_date):
+                continue
+            contracts = strikes_map.get(strike_key)
+            if contracts:
+                return create_success_response(contracts[0])
+
+        return create_error_response(
+            ValueError(
+                f"No {normalized_type} contract found for {symbol.upper()} "
+                f"expiring {expiration_date} at strike {strike_key}"
+            )
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab option quote for {symbol}: {e}")
+        return create_error_response(e)
+
+
+@handle_schwab_errors
 async def schwab_option_buy_to_open(
     account_hash: str,
     symbol: str,

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -294,6 +294,13 @@ class TestToolRegistration:
         assert "schwab_open_option_orders" in tool_names
 
     @pytest.mark.asyncio
+    async def test_schwab_option_quote_tool_is_registered(self) -> None:
+        """Test that schwab_option_quote is registered as an MCP tool."""
+        tools_list = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools_list]
+        assert "schwab_option_quote" in tool_names
+
+    @pytest.mark.asyncio
     async def test_schwab_streaming_tools_are_registered(self) -> None:
         """Test that Schwab streaming tools are registered."""
         tools_list = await mcp.list_tools()

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -14,6 +14,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_options_positions,
     schwab_find_tradable_options,
     schwab_get_open_option_orders,
+    schwab_get_option_quote,
     schwab_option_buy_to_open,
     schwab_option_sell_to_close,
 )
@@ -557,6 +558,85 @@ class TestSchwabOptionsTools:
         assert result["result"]["positions"] == []
         assert result["result"]["count"] == 0
         assert result["result"]["enrichment_success_rate"] == "0%"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_quote_returns_contract(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Successful lookup returns bid, ask, and putCall for the matching contract."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Options.ContractType.CALL = "CALL"
+
+        mock_execute.return_value = {
+            "symbol": "AAPL",
+            "status": "SUCCESS",
+            "callExpDateMap": {
+                "2024-01-19:7": {
+                    "170.0": [
+                        {
+                            "putCall": "CALL",
+                            "symbol": "AAPL  240119C00170000",
+                            "bid": 6.5,
+                            "ask": 6.55,
+                            "last": 6.52,
+                            "delta": 0.54,
+                            "gamma": 0.03,
+                            "theta": -0.08,
+                            "vega": 0.12,
+                            "volatility": 0.22,
+                            "openInterest": 1234,
+                            "totalVolume": 56,
+                        }
+                    ]
+                }
+            },
+        }
+
+        result = await schwab_get_option_quote("AAPL", "2024-01-19", 170.0, "CALL")
+
+        assert result["result"]["bid"] == 6.5
+        assert result["result"]["ask"] == 6.55
+        assert result["result"]["putCall"] == "CALL"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    @patch("open_stocks_mcp.tools.schwab_options_tools.Client")
+    async def test_get_option_quote_not_found(
+        self,
+        mock_client: MagicMock,
+        mock_execute: AsyncMock,
+        mock_get_broker: AsyncMock,
+    ) -> None:
+        """Empty chain returns an error response."""
+        mock_broker = MagicMock()
+        mock_get_broker.return_value = (mock_broker, None)
+        mock_client.Options.ContractType.CALL = "CALL"
+
+        mock_execute.return_value = {
+            "symbol": "AAPL",
+            "status": "SUCCESS",
+            "callExpDateMap": {},
+        }
+
+        result = await schwab_get_option_quote("AAPL", "2024-01-19", 170.0, "CALL")
+
+        assert result["result"]["status"] == "error"
 
     @pytest.mark.journey_options
     @pytest.mark.unit


### PR DESCRIPTION
Closes #337

## Changes
- Added `schwab_get_option_quote(symbol, expiration_date, strike, option_type)` to `schwab_options_tools.py` with `@handle_schwab_errors`, auth gating, and `execute_broker_request` dispatch
- Expiration lookup uses prefix-match against Schwab's `YYYY-MM-DD:N` formatted keys
- Strike lookup converts float to string form (`f"{strike:.1f}"`) for key comparison
- Returns error response when no matching contract found
- Registered as `@mcp.tool()` `schwab_option_quote` in `app.py`
- Added `test_get_option_quote_returns_contract` and `test_get_option_quote_not_found` unit tests
- Added `test_schwab_option_quote_tool_is_registered` to `TestToolRegistration`

## Test plan
- `uv run pytest tests/unit/test_schwab_options_tools.py -k option_quote -x` — 2 new tests pass
- `uv run pytest tests/server/test_server_app.py::TestToolRegistration::test_schwab_option_quote_tool_is_registered` — registration confirmed
- `uv run pytest tests/unit/test_schwab_options_tools.py -q` — all 27 existing tests unaffected
- `uv run mypy src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/server/app.py` — zero errors