### PR TITLE
feat: add Schwab option orders tool

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -158,6 +158,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_chain_by_expiration,
     get_schwab_option_expirations,
     get_schwab_options_positions,
+    schwab_get_option_orders,
     schwab_get_open_option_orders,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
@@ -1861,6 +1862,20 @@ async def schwab_options_positions(account_hash: str) -> dict[str, Any]:
         account_hash: Account hash from schwab_account_numbers
     """
     return await get_schwab_options_positions(account_hash)
+
+
+@mcp.tool()
+async def schwab_option_orders(
+    account_hash: str, max_results: int = 50, status: str | None = None
+) -> dict[str, Any]:
+    """Get option orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum number of orders to return (default: 50)
+        status: Optional order status filter (e.g. FILLED, WORKING, CANCELED)
+    """
+    return await schwab_get_option_orders(account_hash, max_results, status)
 
 
 @mcp.tool()

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -687,3 +687,48 @@ async def schwab_get_open_option_orders(
     except Exception as e:
         logger.error(f"Error getting Schwab open option orders for {account_hash}: {e}")
         return create_error_response(e)
+
+
+@handle_schwab_errors
+async def schwab_get_option_orders(
+    account_hash: str, max_results: int = 50, status: str | None = None
+) -> dict[str, Any]:
+    """Get option orders for a Schwab account, optionally filtered by status.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum number of orders to fetch before filtering (default 50)
+        status: Optional order status filter (e.g. FILLED, WORKING, CANCELED)
+
+    Returns:
+        Dict with filtered option orders and count
+    """
+    broker, error = await get_authenticated_broker_or_error(
+        "schwab", f"get option orders for {account_hash}"
+    )
+    if error:
+        return error
+
+    try:
+
+        def _get_orders() -> Any:
+            response = broker.client.get_orders_for_account(
+                account_hash, max_results=max_results
+            )
+            return response.json()
+
+        orders_data = await execute_broker_request(_get_orders, retry_safe=True)
+        all_orders = orders_data if isinstance(orders_data, list) else []
+        option_orders = [order for order in all_orders if _has_option_leg(order)]
+        if status is not None:
+            option_orders = [
+                order for order in option_orders if order.get("status") == status
+            ]
+
+        return create_success_response(
+            {"orders": option_orders, "count": len(option_orders)}
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting Schwab option orders for {account_hash}: {e}")
+        return create_error_response(e)

--- a/tests/unit/test_schwab_options_tools.py
+++ b/tests/unit/test_schwab_options_tools.py
@@ -10,6 +10,7 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_chain,
     get_schwab_option_chain_by_expiration,
     get_schwab_option_expirations,
+    schwab_get_option_orders,
     get_schwab_option_positions_detailed,
     get_schwab_options_positions,
     schwab_find_tradable_options,
@@ -261,6 +262,66 @@ class TestSchwabOptionsTools:
         assert result["result"]["symbol"] == "AAPL"
         assert len(result["result"]["expirations"]) == 3
         assert result["result"]["count"] == 3
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    async def test_get_option_orders_filters_option_legs(
+        self, mock_execute_broker_request: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Include only orders containing OPTION legs."""
+        mock_get_broker.return_value = (MagicMock(), None)
+        mock_execute_broker_request.return_value = [
+            {
+                "orderId": "opt-1",
+                "orderLegCollection": [{"orderLegType": "OPTION"}],
+                "status": "WORKING",
+            },
+            {
+                "orderId": "eq-1",
+                "orderLegCollection": [{"instrument": {"assetType": "EQUITY"}}],
+                "status": "WORKING",
+            },
+        ]
+
+        result = await schwab_get_option_orders("acct-hash")
+
+        assert result["result"]["count"] == 1
+        assert result["result"]["orders"][0]["orderId"] == "opt-1"
+
+    @pytest.mark.journey_options
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    @patch(
+        "open_stocks_mcp.tools.schwab_options_tools.get_authenticated_broker_or_error"
+    )
+    @patch("open_stocks_mcp.tools.schwab_options_tools.execute_broker_request")
+    async def test_get_option_orders_status_filter(
+        self, mock_execute_broker_request: AsyncMock, mock_get_broker: AsyncMock
+    ) -> None:
+        """Apply status filter after selecting option orders."""
+        mock_get_broker.return_value = (MagicMock(), None)
+        mock_execute_broker_request.return_value = [
+            {
+                "orderId": "filled-1",
+                "orderLegCollection": [{"orderLegType": "OPTION"}],
+                "status": "FILLED",
+            },
+            {
+                "orderId": "working-1",
+                "orderLegCollection": [{"instrument": {"assetType": "OPTION"}}],
+                "status": "WORKING",
+            },
+        ]
+
+        result = await schwab_get_option_orders("acct-hash", status="FILLED")
+
+        assert result["result"]["count"] == 1
+        assert result["result"]["orders"][0]["status"] == "FILLED"
 
     @pytest.mark.journey_options
     @pytest.mark.unit


### PR DESCRIPTION
Closes #339

## Changes
- add schwab_get_option_orders(account_hash, max_results=50, status=None) with auth gating and broker request wrapping
- filter orders by OPTION legs (orderLegType or instrument.assetType) and optional status
- register new MCP tool wrapper schwab_option_orders in app.py
- add unit tests for option-leg filtering and status filtering behavior

## Test plan
- uv run pytest tests/unit/test_schwab_options_tools.py -k get_option_orders -x
- uv run pytest tests/unit/test_schwab_options_tools.py -m "journey_options" -q
- uv run mypy src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/server/app.py