### PR TITLE
docs: add both-broker Docker example

### DIFF
--- a/examples/open-stocks-mcp-docker/.env.example
+++ b/examples/open-stocks-mcp-docker/.env.example
@@ -46,8 +46,9 @@ ROBINHOOD_PASSWORD=your_secure_password
 # SCHWAB_CALLBACK_URL=https://127.0.0.1:8182/
 
 # Token storage path (where OAuth tokens are saved)
-# Default: ~/.tokens/schwab_token.json
-# SCHWAB_TOKEN_PATH=/app/.tokens/schwab_token.json
+# IMPORTANT: In Docker, this MUST be under /home/mcp/.tokens/ to be persistent.
+# /home/mcp/.tokens is a Docker volume that can be mapped to ./data/tokens on the host.
+# SCHWAB_TOKEN_PATH=/home/mcp/.tokens/schwab_token.json
 
 # ===========================================
 # Multi-Broker Settings
@@ -82,6 +83,14 @@ ROBINHOOD_PASSWORD=your_secure_password
 
 # Transport type (default: http for open-stocks-mcp-docker v0.4.0+)
 # TRANSPORT=http
+
+# ===========================================
+# SECURITY CONFIGURATION (REQUIRED for 0.0.0.0)
+# ===========================================
+# MCP_API_KEY is REQUIRED when binding to 0.0.0.0 (as the default docker-compose does).
+# The MCP HTTP transport will refuse to start without it for security.
+# Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# MCP_API_KEY=your_long_random_secret_here
 
 # ===========================================
 # SECURITY NOTES

--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -134,6 +134,65 @@ docker-compose logs -f
 docker inspect open-stocks-mcp-server --format='{{.State.Health.Status}}'
 ```
 
+## Multi-Broker Setup (Robinhood + Schwab)
+
+You can run Open Stocks MCP with both Robinhood and Schwab enabled using the provided both-broker configuration override.
+
+### 1. Configure Credentials
+
+Update your `.env` file with both Robinhood and Schwab credentials:
+
+```env
+# Robinhood
+ROBINHOOD_USERNAME=your_username
+ROBINHOOD_PASSWORD=your_password
+
+# Schwab
+SCHWAB_API_KEY=your_api_key
+SCHWAB_APP_SECRET=your_app_secret
+SCHWAB_TOKEN_PATH=/home/mcp/.tokens/schwab_token.json
+
+# Security (Required for Docker)
+MCP_API_KEY=your_long_random_secret
+```
+
+### 2. Start with Both-Broker Override
+
+Use the `docker-compose.both-brokers.yml` override to enable both brokers. This override mounts a custom configuration file that enables the Schwab feature flag.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up -d
+```
+
+### 3. Schwab OAuth Limitations
+
+Charles Schwab uses browser-based OAuth. When running in a detached Docker container:
+1. **First-run authorization**: Check the logs (`docker compose logs -f`) for the Schwab authorization URL.
+2. **Interactive login**: Copy the URL into your local browser to complete the Schwab authentication.
+3. **Callback reachability**: Your local browser must be able to reach the callback URL (default `https://127.0.0.1:8182/`) to pass the authorization code back to the server.
+4. **Token persistence**: Once completed, the OAuth token is saved to `/home/mcp/.tokens/schwab_token.json`. This is persisted in the `mcp_tokens` volume so you don't need to re-authenticate on every restart.
+
+### 4. Validate Both Brokers
+
+Confirm both brokers are active and authenticated using the `broker_status` tool. Note that you must provide the `Authorization: Bearer` header with your `MCP_API_KEY`:
+
+```bash
+curl -sS -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "params": {
+      "name": "broker_status",
+      "arguments": {}
+    },
+    "id": 1
+  }'
+```
+
+The response `result.content[0].text` will contain a JSON report showing `robinhood` and `schwab` statuses (e.g., `authenticated`, `failed`, or `not_configured`).
+
 ## Usage
 
 ### Connecting to the Server

--- a/examples/open-stocks-mcp-docker/config.both-brokers.yaml
+++ b/examples/open-stocks-mcp-docker/config.both-brokers.yaml
@@ -1,0 +1,10 @@
+# Both-Broker Configuration for Docker
+# Enables both Robinhood and Schwab feature flags.
+#
+# Usage: OPEN_STOCKS_CONFIG=config.both-brokers.yaml open-stocks-mcp-server
+
+environment: docker
+
+feature_flags:
+  brokers.robinhood: true
+  brokers.schwab: true

--- a/examples/open-stocks-mcp-docker/data/README.md
+++ b/examples/open-stocks-mcp-docker/data/README.md
@@ -4,10 +4,14 @@ This directory contains host-backed persistent data for the Open Stocks MCP serv
 
 - **logs/**: Application logs and debugging information
 
-Robinhood session tokens are stored in the Docker-managed `mcp_tokens` named
-volume (not on the host filesystem). Run `docker-compose down -v` to remove
-all volumes and force re-authentication.
+Broker session tokens are stored in the Docker-managed `mcp_tokens` named
+volume (not on the host filesystem). These include:
+- **robinhood.pickle**: Robinhood session data
+- **schwab_token.json**: Schwab OAuth2 tokens (if enabled)
+
+Run `docker-compose down -v` to remove all volumes and force re-authentication.
 
 ## Security Note
 Never commit the contents of these directories to version control.
+Both token types are sensitive and provide direct access to your accounts.
 The .gitignore file should exclude these paths.

--- a/examples/open-stocks-mcp-docker/docker-compose.both-brokers.yml
+++ b/examples/open-stocks-mcp-docker/docker-compose.both-brokers.yml
@@ -1,0 +1,14 @@
+# Docker Compose Override for Both-Broker Setup
+#
+# This override enables both Robinhood and Schwab brokers by mounting
+# the both-broker configuration file.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.both-brokers.yml up -d
+
+services:
+  open-stocks-mcp:
+    environment:
+      - OPEN_STOCKS_CONFIG=/usr/src/app/open-stocks-mcp.yaml
+    volumes:
+      - ./config.both-brokers.yaml:/usr/src/app/open-stocks-mcp.yaml:ro


### PR DESCRIPTION
Closes #108

## Changes
- Added `examples/open-stocks-mcp-docker/config.both-brokers.yaml` to enable both Robinhood and Schwab feature flags.
- Added `examples/open-stocks-mcp-docker/docker-compose.both-brokers.yml` override for multi-broker setup.
- Updated `examples/open-stocks-mcp-docker/.env.example` with Schwab credentials and `MCP_API_KEY` requirement.
- Updated `examples/open-stocks-mcp-docker/README.md` with a multi-broker quickstart, Schwab OAuth notes, and validation instructions.
- Updated `examples/open-stocks-mcp-docker/data/README.md` to document both broker token persistence.

## Test plan
- Validated `config.both-brokers.yaml` with `open_stocks_mcp.config.load_config()` to ensure both broker feature flags are enabled.
- Verified that all required terms appear in the updated documentation files using `rg`.
- Sanity checked source code with `ruff`.