### PR TITLE
refactor: move schwab error decorator to schwab module

### DIFF
--- a/src/open_stocks_mcp/tools/error_handling.py
+++ b/src/open_stocks_mcp/tools/error_handling.py
@@ -20,11 +20,11 @@ from open_stocks_mcp.tools.responses import (
     create_success_response,
     handle_robin_stocks_errors,
     handle_robin_stocks_sync_errors,
-    handle_schwab_errors,
     log_api_call,
     sanitize_api_response,
 )
 from open_stocks_mcp.tools.retry import DEFAULT_MAX_RETRIES, execute_with_retry
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
 from open_stocks_mcp.tools.validation import (
     validate_period,
     validate_symbol,

--- a/src/open_stocks_mcp/tools/responses.py
+++ b/src/open_stocks_mcp/tools/responses.py
@@ -64,22 +64,6 @@ def handle_robin_stocks_sync_errors(
     return wrapper
 
 
-def handle_schwab_errors(
-    func: Callable[P, Awaitable[R]],
-) -> Callable[P, Awaitable[R | dict[str, Any]]]:
-    """Decorator to handle Schwab API errors consistently."""
-
-    @functools.wraps(func)
-    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R | dict[str, Any]:
-        context = f"in {func.__name__}"
-        try:
-            return await func(*args, **kwargs)
-        except Exception as e:
-            return create_error_response(e, context)
-
-    return wrapper
-
-
 def sanitize_api_response(data: Any) -> Any:
     """Sanitize API response data to remove sensitive information."""
     if isinstance(data, dict):

--- a/src/open_stocks_mcp/tools/schwab/__init__.py
+++ b/src/open_stocks_mcp/tools/schwab/__init__.py
@@ -1,0 +1,5 @@
+"""Schwab-specific tool helpers and adapters."""
+
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
+
+__all__ = ["handle_schwab_errors"]

--- a/src/open_stocks_mcp/tools/schwab/error_handling.py
+++ b/src/open_stocks_mcp/tools/schwab/error_handling.py
@@ -1,0 +1,26 @@
+"""Schwab-specific error handling helpers."""
+
+import functools
+from collections.abc import Awaitable, Callable
+from typing import Any, ParamSpec, TypeVar
+
+from open_stocks_mcp.tools.responses import create_error_response
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def handle_schwab_errors(
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R | dict[str, Any]]]:
+    """Decorator to handle Schwab API errors consistently."""
+
+    @functools.wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R | dict[str, Any]:
+        context = f"in {func.__name__}"
+        try:
+            return await func(*args, **kwargs)
+        except Exception as e:
+            return create_error_response(e, context)
+
+    return wrapper

--- a/src/open_stocks_mcp/tools/schwab_account_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_account_tools.py
@@ -13,8 +13,8 @@ from open_stocks_mcp.tools.broker_utils import (
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
-    handle_schwab_errors,
 )
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
 
 
 @handle_schwab_errors

--- a/src/open_stocks_mcp/tools/schwab_market_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_market_tools.py
@@ -13,8 +13,8 @@ from open_stocks_mcp.tools.broker_utils import (
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
-    handle_schwab_errors,
 )
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
 
 
 @handle_schwab_errors

--- a/src/open_stocks_mcp/tools/schwab_options_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_options_tools.py
@@ -14,8 +14,8 @@ from open_stocks_mcp.tools.broker_utils import (
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
-    handle_schwab_errors,
 )
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
 
 _OPEN_OPTION_STATUSES = frozenset(
     {

--- a/src/open_stocks_mcp/tools/schwab_payment_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_payment_tools.py
@@ -12,8 +12,8 @@ from open_stocks_mcp.tools.broker_utils import (
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
-    handle_schwab_errors,
 )
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
 
 
 def _classify_transaction(tx: dict[str, Any]) -> str:

--- a/src/open_stocks_mcp/tools/schwab_portfolio_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_portfolio_tools.py
@@ -16,8 +16,8 @@ from open_stocks_mcp.tools.broker_utils import (
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
-    handle_schwab_errors,
 )
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
 
 
 def _to_float(value: Any) -> float:

--- a/src/open_stocks_mcp/tools/schwab_trading_tools.py
+++ b/src/open_stocks_mcp/tools/schwab_trading_tools.py
@@ -35,8 +35,8 @@ from open_stocks_mcp.tools.broker_utils import (
 from open_stocks_mcp.tools.error_handling import (
     create_error_response,
     create_success_response,
-    handle_schwab_errors,
 )
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
 
 
 @handle_schwab_errors

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -26,12 +26,12 @@ from open_stocks_mcp.tools.error_handling import (
     create_success_response,
     execute_with_retry,
     handle_robin_stocks_errors,
-    handle_schwab_errors,
     log_api_call,
     sanitize_api_response,
     validate_period,
     validate_symbol,
 )
+from open_stocks_mcp.tools.schwab.error_handling import handle_schwab_errors
 
 pytestmark = [pytest.mark.unit, pytest.mark.journey_system]
 

--- a/tests/unit/test_error_handling_module_split.py
+++ b/tests/unit/test_error_handling_module_split.py
@@ -1,7 +1,8 @@
 """Regression tests for the error_handling module split."""
 
-from open_stocks_mcp.tools import error_handling
+from open_stocks_mcp.tools import error_handling, responses
 from open_stocks_mcp.tools.responses import create_success_response
+from open_stocks_mcp.tools.schwab import error_handling as schwab_error_handling
 from open_stocks_mcp.tools.validation import validate_symbol
 
 
@@ -16,6 +17,15 @@ def test_error_handling_reexports_core_symbols() -> None:
 def test_error_handling_does_not_export_unused_span_validator() -> None:
     assert "validate_span" not in error_handling.__all__
     assert not hasattr(error_handling, "validate_span")
+
+
+def test_schwab_decorator_moved_to_schwab_module_with_facade_compatibility() -> None:
+    assert not hasattr(responses, "handle_schwab_errors")
+    assert hasattr(schwab_error_handling, "handle_schwab_errors")
+    assert (
+        error_handling.handle_schwab_errors
+        is schwab_error_handling.handle_schwab_errors
+    )
 
 
 def test_validation_behavior_preserved() -> None:


### PR DESCRIPTION
Closes #128

## Changes
- moved `handle_schwab_errors` from `tools/responses.py` into new `tools/schwab/error_handling.py`
- added `tools/schwab/__init__.py` export and kept compatibility re-export via `tools/error_handling.py`
- updated Schwab tool modules to import the decorator from `open_stocks_mcp.tools.schwab.error_handling`
- updated module-split and decorator behavior tests to enforce the new boundary

## Test plan
- uv run pytest tests/unit/test_error_handling_module_split.py tests/unit/test_error_handling.py -k "schwab or module_split" -q
- uv run pytest tests/unit/test_error_handling.py tests/unit/test_error_handling_module_split.py tests/unit/test_schwab_tool_layering.py -q
- uv run ruff check src/open_stocks_mcp/tools/responses.py src/open_stocks_mcp/tools/error_handling.py src/open_stocks_mcp/tools/schwab src/open_stocks_mcp/tools/schwab_account_tools.py src/open_stocks_mcp/tools/schwab_market_tools.py src/open_stocks_mcp/tools/schwab_options_tools.py src/open_stocks_mcp/tools/schwab_payment_tools.py src/open_stocks_mcp/tools/schwab_portfolio_tools.py src/open_stocks_mcp/tools/schwab_trading_tools.py tests/unit/test_error_handling.py tests/unit/test_error_handling_module_split.py