### PR TITLE
fix: export registry initialization error

### DIFF
--- a/src/open_stocks_mcp/brokers/__init__.py
+++ b/src/open_stocks_mcp/brokers/__init__.py
@@ -1,7 +1,11 @@
 """Broker abstraction layer for multi-broker MCP support."""
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
-from open_stocks_mcp.brokers.registry import BrokerRegistry, get_broker_registry
+from open_stocks_mcp.brokers.registry import (
+    BrokerRegistry,
+    RegistryNotInitializedError,
+    get_broker_registry,
+)
 from open_stocks_mcp.brokers.robinhood import RobinhoodBroker
 from open_stocks_mcp.brokers.schwab import SchwabBroker
 from open_stocks_mcp.brokers.session_state import SessionManager, get_session_manager
@@ -10,6 +14,7 @@ __all__ = [
     "BaseBroker",
     "BrokerAuthStatus",
     "BrokerRegistry",
+    "RegistryNotInitializedError",
     "RobinhoodBroker",
     "SchwabBroker",
     "SessionManager",

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -416,6 +416,13 @@ class TestBrokerRegistry:
 class TestBrokerRegistrySingleton:
     """Test get_broker_registry singleton pattern."""
 
+    def test_package_reexports_registry_not_initialized_error(self):
+        """Test brokers package exposes the registry initialization error."""
+        import open_stocks_mcp.brokers as broker_exports
+
+        assert broker_exports.RegistryNotInitializedError is RegistryNotInitializedError
+        assert "RegistryNotInitializedError" in broker_exports.__all__
+
     @pytest.mark.asyncio
     async def test_get_broker_registry_returns_instance(self):
         """Test get_broker_registry returns BrokerRegistry instance."""


### PR DESCRIPTION
Closes #132

## Changes
- Re-export RegistryNotInitializedError from open_stocks_mcp.brokers.
- Add a regression test proving the package export is the same class and appears in __all__.

## Test plan
- uv run pytest tests/unit/test_broker_registry.py -k package_reexports_registry_not_initialized_error -q
- uv run pytest tests/unit/test_broker_registry.py -q
- uv run ruff check src/open_stocks_mcp/brokers/__init__.py tests/unit/test_broker_registry.py
- uv run mypy src/open_stocks_mcp/brokers/__init__.py src/open_stocks_mcp/brokers/registry.py