### PR TITLE
feat: expose session pickle-clear circuit breaker state

### DIFF
--- a/src/open_stocks_mcp/brokers/session_state.py
+++ b/src/open_stocks_mcp/brokers/session_state.py
@@ -203,6 +203,8 @@ class SessionManager:
             "session_timeout_hours": self.session_timeout_hours,
             "failed_login_attempts": self._failed_login_attempts,
             "max_failed_attempts": self.max_failed_attempts,
+            "consecutive_pickle_clear_failures": self._pickle._consecutive_pickle_clear_failures,
+            "auth_retries_blocked": self.should_block_auth_retries(),
         }
 
         if self.login_time:

--- a/tests/unit/test_session_security.py
+++ b/tests/unit/test_session_security.py
@@ -241,3 +241,19 @@ class TestClearPickleFile:
         manager.reset_clear_failures()
 
         assert manager.should_block_auth_retries() is False
+
+
+class TestSessionInfoCircuitBreaker:
+    def test_get_session_info_includes_pickle_clear_circuit_breaker_state(
+        self, manager: SessionPickleManager
+    ) -> None:
+        session_manager = SessionManager(pickle_manager=manager)
+        manager._consecutive_pickle_clear_failures = manager._max_pickle_clear_failures
+
+        info = session_manager.get_session_info()
+
+        assert (
+            info["consecutive_pickle_clear_failures"]
+            == manager._consecutive_pickle_clear_failures
+        )
+        assert info["auth_retries_blocked"] is True

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -514,6 +514,8 @@ class TestServerTools:
             "username": "testuser",
             "login_time": "2023-01-01T10:00:00",
             "session_timeout_hours": 23,
+            "consecutive_pickle_clear_failures": 0,
+            "auth_retries_blocked": False,
         }
         mock_get_session_manager.return_value = mock_session_manager
 
@@ -523,6 +525,8 @@ class TestServerTools:
         assert result["result"]["is_authenticated"] is True
         assert result["result"]["is_valid"] is True
         assert result["result"]["username"] == "testuser"
+        assert result["result"]["consecutive_pickle_clear_failures"] == 0
+        assert result["result"]["auth_retries_blocked"] is False
         assert result["result"]["status"] == "success"
 
     @pytest.mark.journey_system


### PR DESCRIPTION
Closes #141

## Changes
- Added `consecutive_pickle_clear_failures` and `auth_retries_blocked` to `SessionManager.get_session_info()` output.
- Updated `session_status` unit test expectations to assert both fields are surfaced.
- Added a unit test proving `get_session_info()` reflects blocked auth-retry state when pickle-clear failures reach threshold.

## Test plan
- uv run pytest tests/unit/test_stock_market_tools.py -k session_status -v
- uv run pytest tests/unit/test_session_security.py -k get_session_info_includes_pickle_clear_circuit_breaker_state -v
- uv run pytest tests/unit/ -q
- uv run ruff check src/open_stocks_mcp/brokers/session_state.py
- uv run mypy src/open_stocks_mcp/brokers/session_state.py
