### PR TITLE
feat: make pickle-clear failure threshold a constructor parameter

### DIFF
--- a/src/open_stocks_mcp/brokers/session_pickle.py
+++ b/src/open_stocks_mcp/brokers/session_pickle.py
@@ -12,9 +12,9 @@ from open_stocks_mcp.logging_config import logger
 class SessionPickleManager:
     """Manages pickle read/write/clear and Fernet encryption for session tokens."""
 
-    def __init__(self) -> None:
+    def __init__(self, max_pickle_clear_failures: int = 3) -> None:
         self._consecutive_pickle_clear_failures = 0
-        self._max_pickle_clear_failures = 3
+        self._max_pickle_clear_failures = max_pickle_clear_failures
 
     def _get_tokens_dir(self) -> Path:
         tokens_dir = Path.home() / ".tokens"

--- a/src/open_stocks_mcp/brokers/session_state.py
+++ b/src/open_stocks_mcp/brokers/session_state.py
@@ -22,10 +22,12 @@ class SessionManager:
         self,
         session_timeout_hours: int = 23,
         max_failed_attempts: int = 3,
+        max_pickle_clear_failures: int = 3,
         pickle_manager: SessionPickleManager | None = None,
     ) -> None:
         self.session_timeout_hours = session_timeout_hours
         self.max_failed_attempts = max_failed_attempts
+        self._max_pickle_clear_failures = max_pickle_clear_failures
         self.login_time: datetime | None = None
         self.last_successful_call: datetime | None = None
         self.username: str | None = None
@@ -33,7 +35,9 @@ class SessionManager:
         self._lock = asyncio.Lock()
         self._is_authenticated = False
         self._failed_login_attempts = 0
-        self._pickle = pickle_manager or SessionPickleManager()
+        self._pickle = pickle_manager or SessionPickleManager(
+            max_pickle_clear_failures=self._max_pickle_clear_failures
+        )
 
     def set_credentials(self, username: str, password: str) -> None:
         self.username = username

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -466,3 +466,31 @@ async def test_ensure_authenticated_session_returns_error_tuple_on_exception() -
 
     assert success is False
     assert error == "invalid credentials"
+
+def test_pickle_clear_failure_threshold_can_be_configured(tmp_path: Path) -> None:
+    manager = SessionManager(max_pickle_clear_failures=1)
+    pickle_path = tmp_path / "robinhood.pickle"
+    pickle_path.write_text("session")
+    
+    with (
+        patch.object(manager._pickle, "_get_pickle_file_path", return_value=pickle_path),
+        patch.object(Path, "unlink", side_effect=PermissionError("denied"))
+    ):
+        manager._clear_pickle_file()
+        assert manager.should_block_auth_retries() is True
+
+def test_pickle_clear_failure_threshold_defaults_to_three(tmp_path: Path) -> None:
+    manager = SessionManager()
+    pickle_path = tmp_path / "robinhood.pickle"
+    pickle_path.write_text("session")
+    
+    with (
+        patch.object(manager._pickle, "_get_pickle_file_path", return_value=pickle_path),
+        patch.object(Path, "unlink", side_effect=PermissionError("denied"))
+    ):
+        manager._clear_pickle_file()
+        manager._clear_pickle_file()
+        assert manager.should_block_auth_retries() is False
+        
+        manager._clear_pickle_file()
+        assert manager.should_block_auth_retries() is True


### PR DESCRIPTION
Closes #140

## Changes
- Updated `SessionPickleManager` to accept `max_pickle_clear_failures` in its constructor.
- Updated `SessionManager` to accept `max_pickle_clear_failures` and pass it down.
- Added test coverage to verify that the threshold is configurable and defaults to 3.

## Test plan
- `uv run pytest tests/unit/test_session_manager.py -k 'pickle_clear_failure_threshold'`
- `uv run ruff check` and `uv run mypy`