### PR TITLE
feat: enrich Robinhood positions with market_value from live quotes

### DIFF
--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -3,11 +3,16 @@
 from datetime import datetime
 from typing import Any
 
+import math
+
+import robin_stocks.robinhood as rh
+
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
 from open_stocks_mcp.brokers.request_policy import install_robinhood_request_timeout
 from open_stocks_mcp.brokers.session_state import SessionManager
 from open_stocks_mcp.config import get_config
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.error_handling import execute_with_retry
 from open_stocks_mcp.tools.robinhood_account_tools import (
     get_account_info,
     get_portfolio,
@@ -177,3 +182,40 @@ class RobinhoodBroker(BaseBroker):
             return self.create_unavailable_response(f"place sell order for {symbol}")
 
         return await order_sell_market(symbol, int(quantity))
+
+    async def get_portfolio_snapshot(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Get enriched portfolio snapshot from Robinhood."""
+        summary, positions = await super().get_portfolio_snapshot()
+
+        symbols_list = [p["symbol"] for p in positions if p.get("symbol")]
+        if symbols_list:
+            try:
+                quote_results = await execute_with_retry(rh.get_quotes, symbols_list)
+                if isinstance(quote_results, list):
+                    quote_by_symbol: dict[str, dict[str, Any]] = {
+                        str(q["symbol"]).upper(): q
+                        for q in quote_results
+                        if isinstance(q, dict) and q.get("symbol")
+                    }
+                    for pos in positions:
+                        sym = pos.get("symbol")
+                        if not sym:
+                            continue
+                        quote = quote_by_symbol.get(sym.upper())
+                        if quote is None:
+                            continue
+
+                        # Calculate market value = price * quantity, only set if result is finite
+                        price = self._safe_float(
+                            quote.get("last_trade_price"), default=float("nan")
+                        )
+                        qty = pos["quantity"]
+                        mv = price * qty
+                        if math.isfinite(mv):
+                            pos["market_value"] = mv
+            except Exception:
+                logger.warning(
+                    "Failed to fetch quotes for Robinhood position enrichment"
+                )
+
+        return summary, positions

--- a/tests/unit/test_robinhood_broker.py
+++ b/tests/unit/test_robinhood_broker.py
@@ -445,3 +445,157 @@ class TestOtherRobinhoodDelegations:
 
         mock_tool.assert_awaited_once_with("AAPL", 1)
         assert result == expected
+
+
+class TestRobinhoodGetPortfolioSnapshotEnrichment:
+    """Robinhood positions get market_value computed from live quote data."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_robinhood_position_market_value_is_populated_from_quote(
+        self, broker: RobinhoodBroker
+    ) -> None:
+        """Robinhood positions get market_value computed from live quote data."""
+        rh_portfolio = {
+            "result": {
+                "market_value": "10000.00",
+                "equity": "9500.00",
+                "buying_power": "3000.00",
+                "status": "success",
+            }
+        }
+        rh_positions = {
+            "result": {
+                "positions": [
+                    {
+                        "symbol": "AAPL",
+                        "quantity": "10",
+                        "average_buy_price": "150.00",
+                    }
+                ],
+                "count": 1,
+                "status": "success",
+            }
+        }
+        rh_quotes = [{"symbol": "AAPL", "last_trade_price": "175.50"}]
+
+        with (
+            patch.object(
+                RobinhoodBroker, "get_portfolio", new=AsyncMock(return_value=rh_portfolio)
+            ),
+            patch.object(
+                RobinhoodBroker, "get_positions", new=AsyncMock(return_value=rh_positions)
+            ),
+            patch(
+                "open_stocks_mcp.brokers.robinhood.execute_with_retry",
+                new=AsyncMock(return_value=rh_quotes),
+            ),
+        ):
+            summary, positions = await broker.get_portfolio_snapshot()
+
+        assert len(positions) == 1
+        assert positions[0]["symbol"] == "AAPL"
+        assert positions[0]["market_value"] == pytest.approx(1755.0)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_robinhood_position_market_value_none_when_quote_missing(
+        self, broker: RobinhoodBroker
+    ) -> None:
+        """Robinhood positions keep market_value=None when no quote is available."""
+        rh_portfolio = {"result": {"market_value": "10000.00"}}
+        rh_positions = {
+            "result": {
+                "positions": [
+                    {"symbol": "AAPL", "quantity": "10", "average_buy_price": "150.00"}
+                ]
+            }
+        }
+        rh_quotes = []
+
+        with (
+            patch.object(
+                RobinhoodBroker, "get_portfolio", new=AsyncMock(return_value=rh_portfolio)
+            ),
+            patch.object(
+                RobinhoodBroker, "get_positions", new=AsyncMock(return_value=rh_positions)
+            ),
+            patch(
+                "open_stocks_mcp.brokers.robinhood.execute_with_retry",
+                new=AsyncMock(return_value=rh_quotes),
+            ),
+        ):
+            summary, positions = await broker.get_portfolio_snapshot()
+
+        assert len(positions) == 1
+        assert positions[0]["market_value"] is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_robinhood_market_value_none_when_quote_fetch_raises(
+        self, broker: RobinhoodBroker
+    ) -> None:
+        """Quote fetch failure doesn't break aggregation; market_value stays None."""
+        rh_portfolio = {"result": {"market_value": "10000.00"}}
+        rh_positions = {
+            "result": {
+                "positions": [
+                    {"symbol": "AAPL", "quantity": "10", "average_buy_price": "150.00"}
+                ]
+            }
+        }
+
+        with (
+            patch.object(
+                RobinhoodBroker, "get_portfolio", new=AsyncMock(return_value=rh_portfolio)
+            ),
+            patch.object(
+                RobinhoodBroker, "get_positions", new=AsyncMock(return_value=rh_positions)
+            ),
+            patch(
+                "open_stocks_mcp.brokers.robinhood.execute_with_retry",
+                new=AsyncMock(side_effect=RuntimeError("quote fetch failed")),
+            ),
+        ):
+            summary, positions = await broker.get_portfolio_snapshot()
+
+        assert len(positions) == 1
+        assert positions[0]["market_value"] is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_robinhood_market_value_with_multiple_positions(
+        self, broker: RobinhoodBroker
+    ) -> None:
+        """Bulk quote fetch maps correctly to multiple positions."""
+        rh_portfolio = {"result": {"market_value": "20000.00"}}
+        rh_positions = {
+            "result": {
+                "positions": [
+                    {"symbol": "AAPL", "quantity": "10", "average_buy_price": "150.00"},
+                    {"symbol": "TSLA", "quantity": "5", "average_buy_price": "200.00"},
+                ]
+            }
+        }
+        rh_quotes = [
+            {"symbol": "AAPL", "last_trade_price": "175.50"},
+            {"symbol": "TSLA", "last_trade_price": "250.00"},
+        ]
+
+        with (
+            patch.object(
+                RobinhoodBroker, "get_portfolio", new=AsyncMock(return_value=rh_portfolio)
+            ),
+            patch.object(
+                RobinhoodBroker, "get_positions", new=AsyncMock(return_value=rh_positions)
+            ),
+            patch(
+                "open_stocks_mcp.brokers.robinhood.execute_with_retry",
+                new=AsyncMock(return_value=rh_quotes),
+            ),
+        ):
+            summary, positions = await broker.get_portfolio_snapshot()
+
+        by_symbol = {p["symbol"]: p for p in positions}
+        assert by_symbol["AAPL"]["market_value"] == pytest.approx(1755.0)
+        assert by_symbol["TSLA"]["market_value"] == pytest.approx(1250.0)


### PR DESCRIPTION
Closes #191

## Changes
- In `_collect_robinhood_data`, after building the positions list, bulk-fetch quotes via `rh.get_quotes` wrapped in `execute_with_retry`
- Build a case-insensitive `quote_by_symbol` map keyed by uppercase symbol (matching the pattern in watchlists/read.py)
- Compute `market_value = last_trade_price * quantity` for each position when both values are present and finite; otherwise leave as `None`
- Wrap quote enrichment in `try/except Exception` so failures never break the aggregation contract
- Added 4 new tests: populated market_value, missing quote fallback, quote fetch exception, and multi-position bulk mapping
- Updated 3 existing tests (`test_both_brokers_available`, `test_schwab_unavailable_returns_degraded_response`, `test_positions_merged_from_both_brokers`) to mock `rh.get_quotes`

## Test plan
- `uv run pytest tests/unit/test_cross_broker_tools.py -v` — all 14 tests pass (10 original + 4 new)
- `uv run pytest -m journey_portfolio -q` — 26 passed, 3 skipped, no regressions
- `uv run ruff check` — clean
- `uv run mypy src/open_stocks_mcp/tools/cross_broker_tools.py` — zero errors