### PR TITLE
fix: replace assert statements with explicit guards in schwab_stream.py

### DIFF
--- a/src/open_stocks_mcp/brokers/schwab_stream.py
+++ b/src/open_stocks_mcp/brokers/schwab_stream.py
@@ -74,7 +74,13 @@ class SchwabStreamManager:
                         logger.error(f"Error in Schwab stream custom handler: {e}")
 
             # Register handlers for Level One, Level 2 and account activity
-            assert self.stream_client is not None
+            if self.stream_client is None:
+                logger.error(
+                    "Schwab StreamClient unexpectedly None after construction;"
+                    " cannot start streamer"
+                )
+                self._is_running = False
+                return False
             self.stream_client.add_level_one_equity_handler(_core_handler)
             self.stream_client.add_level_one_option_handler(_core_handler)
             self.stream_client.add_nasdaq_book_handler(_core_handler)
@@ -129,8 +135,13 @@ class SchwabStreamManager:
                 await asyncio.sleep(5)  # Wait before retry
                 if self._is_running:
                     # Attempt re-login
+                    if self.stream_client is None:
+                        logger.error(
+                            "Schwab stream_client is None before re-login;"
+                            " exiting reconnect loop"
+                        )
+                        break
                     try:
-                        assert self.stream_client is not None
                         await self.stream_client.login()
                     except Exception as re_login_err:
                         logger.error(

--- a/src/open_stocks_mcp/brokers/schwab_stream.py
+++ b/src/open_stocks_mcp/brokers/schwab_stream.py
@@ -140,6 +140,7 @@ class SchwabStreamManager:
                             "Schwab stream_client is None before re-login;"
                             " exiting reconnect loop"
                         )
+                        self._is_running = False
                         break
                     try:
                         await self.stream_client.login()

--- a/tests/unit/test_capabilities_and_streaming.py
+++ b/tests/unit/test_capabilities_and_streaming.py
@@ -379,11 +379,12 @@ async def test_schwab_stream_manager_run_loop_skips_relogin_when_stream_client_d
     fake_client.handle_responses = handle_responses_then_clear
     manager.stream_client = fake_client
 
-    async def fast_sleep(_: float) -> None:
-        manager._is_running = False  # stop loop after first sleep
+    async def noop_sleep(_: float) -> None:
+        pass  # do not touch _is_running; the guard must clear it
 
-    with patch("asyncio.sleep", side_effect=fast_sleep):
+    with patch("asyncio.sleep", side_effect=noop_sleep):
         await manager._run_loop()
 
-    # Loop must exit cleanly — no AttributeError, no relogin attempt on None client
+    # Loop must exit cleanly — guard sets _is_running=False and breaks
     assert call_count == 1
+    assert manager.is_running is False

--- a/tests/unit/test_capabilities_and_streaming.py
+++ b/tests/unit/test_capabilities_and_streaming.py
@@ -330,3 +330,60 @@ async def test_schwab_stream_manager_start_registers_book_handlers(
         await manager.start()
         mock_stream_client.add_nasdaq_book_handler.assert_called_once()
         mock_stream_client.add_nyse_book_handler.assert_called_once()
+
+
+@patch("schwab.streaming.StreamClient")
+@pytest.mark.asyncio
+async def test_schwab_stream_manager_start_handles_missing_stream_client(
+    mock_stream_client_class: MagicMock,
+) -> None:
+    """Guard path: StreamClient() unexpectedly returns None."""
+    from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
+
+    mock_broker = MagicMock()
+    mock_broker.is_available.return_value = True
+    mock_broker.client = MagicMock()
+
+    mock_stream_client_class.return_value = None  # StreamClient(...) → None
+
+    manager = SchwabStreamManager(mock_broker)
+
+    with patch("asyncio.create_task") as mock_create_task:
+        result = await manager.start()
+
+    assert result is False
+    assert manager.is_running is False
+    mock_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schwab_stream_manager_run_loop_skips_relogin_when_stream_client_disappears() -> (
+    None
+):
+    """Guard path: stream_client cleared between handle_responses() and login()."""
+    from open_stocks_mcp.brokers.schwab_stream import SchwabStreamManager
+
+    mock_broker = MagicMock()
+    manager = SchwabStreamManager(mock_broker)
+    manager._is_running = True
+
+    call_count = 0
+
+    async def handle_responses_then_clear() -> None:
+        nonlocal call_count
+        call_count += 1
+        manager.stream_client = None  # simulate client disappearing
+        raise RuntimeError("connection dropped")
+
+    fake_client = AsyncMock()
+    fake_client.handle_responses = handle_responses_then_clear
+    manager.stream_client = fake_client
+
+    async def fast_sleep(_: float) -> None:
+        manager._is_running = False  # stop loop after first sleep
+
+    with patch("asyncio.sleep", side_effect=fast_sleep):
+        await manager._run_loop()
+
+    # Loop must exit cleanly — no AttributeError, no relogin attempt on None client
+    assert call_count == 1


### PR DESCRIPTION
Closes #202

## Changes
- Replaced `assert self.stream_client is not None` on line 77 of `schwab_stream.py` with an explicit `if self.stream_client is None:` guard that logs a clear error, sets `_is_running = False`, and returns `False` before any handler registration — ensuring correct behavior under `python -O`.
- Replaced `assert self.stream_client is not None` on line 133 of `schwab_stream.py` with an explicit `if self.stream_client is None:` guard that logs a clear error and `break`s the reconnect loop — preventing a silent `AttributeError` under `python -O`.
- Added `test_schwab_stream_manager_start_handles_missing_stream_client` — verifies that when `StreamClient()` returns `None`, `start()` returns `False`, `is_running` stays `False`, and no background task is created.
- Added `test_schwab_stream_manager_run_loop_skips_relogin_when_stream_client_disappears` — verifies that when `stream_client` is cleared mid-loop, `_run_loop()` exits cleanly without touching the None client.

## Test plan
- `uv run pytest tests/unit/test_capabilities_and_streaming.py -k "schwab_stream_manager_start_handles_missing_stream_client or schwab_stream_manager_run_loop_skips_relogin_when_stream_client_disappears" -q` — 2 passed
- `uv run pytest tests/unit/test_capabilities_and_streaming.py -k schwab_stream_manager -q` — 13 passed (all existing tests intact)
- `uv run ruff check src/open_stocks_mcp/brokers/schwab_stream.py tests/unit/test_capabilities_and_streaming.py` — no issues
- `uv run mypy src/open_stocks_mcp/brokers/schwab_stream.py tests/unit/test_capabilities_and_streaming.py` — no issues