### PR TITLE
feat: implement pluggable broker architecture for portfolio aggregation

### DIFF
--- a/src/open_stocks_mcp/brokers/base.py
+++ b/src/open_stocks_mcp/brokers/base.py
@@ -1,5 +1,6 @@
 """Base broker interface for multi-broker support."""
 
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -285,6 +286,57 @@ class BaseBroker(ABC):
             Order result in standardized format
         """
         pass
+
+    async def get_portfolio_snapshot(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Get a normalized snapshot of the broker's portfolio and positions.
+
+        This method provides a standard interface for cross-broker aggregation.
+        Default implementation uses get_portfolio() and get_positions() and
+        normalizes the results.
+
+        Returns:
+            Tuple of (summary dict, positions list)
+            Summary dict keys: market_value, equity, buying_power
+            Position dict keys: symbol, quantity, average_buy_price, market_value, broker
+        """
+        summary: dict[str, Any] = {}
+        positions: list[dict[str, Any]] = []
+
+        portfolio_result, positions_result = await asyncio.gather(
+            self.get_portfolio(),
+            self.get_positions(),
+        )
+
+        portfolio_data = portfolio_result.get("result", {})
+        if "error" not in portfolio_data:
+            summary["market_value"] = self._safe_float(portfolio_data.get("market_value"))
+            summary["equity"] = self._safe_float(portfolio_data.get("equity"))
+            summary["buying_power"] = self._safe_float(portfolio_data.get("buying_power"))
+
+        positions_data = positions_result.get("result", {})
+        if "error" not in positions_data:
+            for pos in positions_data.get("positions", []):
+                positions.append(
+                    {
+                        "symbol": pos.get("symbol"),
+                        "quantity": self._safe_float(pos.get("quantity")),
+                        "average_buy_price": self._safe_float(
+                            pos.get("average_buy_price")
+                        ),
+                        "market_value": self._safe_float(pos.get("market_value"), None),
+                        "broker": self.name,
+                    }
+                )
+
+        return summary, positions
+
+    @staticmethod
+    def _safe_float(value: Any, default: Any = 0.0) -> Any:
+        """Convert value to float, returning default on failure."""
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
 
     # Add more abstract methods as needed for common operations
     # Each broker implements these according to their API

--- a/src/open_stocks_mcp/brokers/schwab.py
+++ b/src/open_stocks_mcp/brokers/schwab.py
@@ -374,3 +374,52 @@ class SchwabBroker(BaseBroker):
         except Exception as e:
             logger.error(f"Error getting Schwab transaction {transaction_id}: {e}")
             return {"result": {"error": str(e), "status": "error"}}
+
+    async def get_portfolio_snapshot(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Get a normalized snapshot of Schwab accounts and positions."""
+        summary: dict[str, Any] = {
+            "market_value": 0.0,
+            "equity": 0.0,
+            "buying_power": 0.0,
+        }
+        positions: list[dict[str, Any]] = []
+
+        if not self.is_available():
+            return summary, positions
+
+        from open_stocks_mcp.tools.schwab_account_tools import get_schwab_accounts
+
+        accounts_result = await get_schwab_accounts(include_positions=True)
+        accounts_data = accounts_result.get("result", {})
+        if "error" in accounts_data:
+            return summary, positions
+
+        total_market_value = 0.0
+        total_buying_power = 0.0
+
+        for account in accounts_data.get("accounts", []):
+            sec_account = account.get("securitiesAccount", {})
+            balances = sec_account.get("currentBalances", {})
+            total_market_value += self._safe_float(balances.get("liquidationValue"))
+            total_buying_power += self._safe_float(balances.get("buyingPower"))
+
+            for pos in sec_account.get("positions", []):
+                instrument = pos.get("instrument", {})
+                quantity = self._safe_float(pos.get("longQuantity")) + self._safe_float(
+                    pos.get("shortQuantity")
+                )
+                positions.append(
+                    {
+                        "symbol": instrument.get("symbol"),
+                        "quantity": quantity,
+                        "average_buy_price": self._safe_float(pos.get("averagePrice")),
+                        "market_value": self._safe_float(pos.get("marketValue")),
+                        "broker": self.name,
+                    }
+                )
+
+        summary["market_value"] = total_market_value
+        summary["equity"] = total_market_value
+        summary["buying_power"] = total_buying_power
+
+        return summary, positions

--- a/src/open_stocks_mcp/tools/cross_broker_tools.py
+++ b/src/open_stocks_mcp/tools/cross_broker_tools.py
@@ -6,100 +6,6 @@ from typing import Any
 from open_stocks_mcp.brokers.registry import get_broker_registry
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.responses import create_success_response
-from open_stocks_mcp.tools.robinhood_account_tools import get_portfolio, get_positions
-from open_stocks_mcp.tools.schwab_account_tools import get_schwab_accounts
-
-
-def _safe_float(value: Any, default: float = 0.0) -> float:
-    """Convert value to float, returning default on failure."""
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return default
-
-
-async def _collect_robinhood_data(
-    broker_name: str,
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    """Collect portfolio summary and positions from Robinhood.
-
-    Returns:
-        Tuple of (summary dict, positions list)
-    """
-    summary: dict[str, Any] = {}
-    positions: list[dict[str, Any]] = []
-
-    portfolio_result, positions_result = await asyncio.gather(
-        get_portfolio(),
-        get_positions(),
-    )
-    portfolio_data = portfolio_result.get("result", {})
-    if "error" not in portfolio_data:
-        summary["market_value"] = _safe_float(portfolio_data.get("market_value"))
-        summary["equity"] = _safe_float(portfolio_data.get("equity"))
-        summary["buying_power"] = _safe_float(portfolio_data.get("buying_power"))
-
-    positions_data = positions_result.get("result", {})
-    if "error" not in positions_data:
-        for pos in positions_data.get("positions", []):
-            positions.append(
-                {
-                    "symbol": pos.get("symbol"),
-                    "quantity": _safe_float(pos.get("quantity")),
-                    "average_buy_price": _safe_float(pos.get("average_buy_price")),
-                    "market_value": None,
-                    "broker": broker_name,
-                }
-            )
-
-    return summary, positions
-
-
-async def _collect_schwab_data(
-    broker_name: str,
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    """Collect portfolio summary and positions from Schwab.
-
-    Returns:
-        Tuple of (summary dict, positions list)
-    """
-    summary: dict[str, Any] = {"market_value": 0.0, "equity": 0.0, "buying_power": 0.0}
-    positions: list[dict[str, Any]] = []
-
-    accounts_result = await get_schwab_accounts(include_positions=True)
-    accounts_data = accounts_result.get("result", {})
-    if "error" in accounts_data:
-        return summary, positions
-
-    total_market_value = 0.0
-    total_buying_power = 0.0
-
-    for account in accounts_data.get("accounts", []):
-        sec_account = account.get("securitiesAccount", {})
-        balances = sec_account.get("currentBalances", {})
-        total_market_value += _safe_float(balances.get("liquidationValue"))
-        total_buying_power += _safe_float(balances.get("buyingPower"))
-
-        for pos in sec_account.get("positions", []):
-            instrument = pos.get("instrument", {})
-            quantity = _safe_float(pos.get("longQuantity")) + _safe_float(
-                pos.get("shortQuantity")
-            )
-            positions.append(
-                {
-                    "symbol": instrument.get("symbol"),
-                    "quantity": quantity,
-                    "average_buy_price": _safe_float(pos.get("averagePrice")),
-                    "market_value": _safe_float(pos.get("marketValue")),
-                    "broker": broker_name,
-                }
-            )
-
-    summary["market_value"] = total_market_value
-    summary["equity"] = total_market_value
-    summary["buying_power"] = total_buying_power
-
-    return summary, positions
 
 
 async def get_aggregated_portfolio() -> dict[str, Any]:
@@ -151,19 +57,7 @@ async def get_aggregated_portfolio() -> dict[str, Any]:
             continue
 
         available_names.append(name)
-        if name == "robinhood":
-            coros.append(_collect_robinhood_data(name))
-        elif name == "schwab":
-            coros.append(_collect_schwab_data(name))
-        else:
-
-            async def _collect_unknown(
-                broker_name: str,
-            ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-                logger.warning(f"No aggregation collector for broker: {broker_name}")
-                return {}, []
-
-            coros.append(_collect_unknown(name))
+        coros.append(broker.get_portfolio_snapshot())
 
     if coros:
         results = await asyncio.gather(*coros, return_exceptions=True)

--- a/tests/unit/test_broker_base.py
+++ b/tests/unit/test_broker_base.py
@@ -303,3 +303,47 @@ class TestBaseBroker:
         assert broker.auth_info.last_auth_attempt > first_attempt_time
         assert broker.auth_info.last_successful_auth is not None
         assert broker.is_available()
+
+    @pytest.mark.asyncio
+    async def test_portfolio_snapshot_normalizes_default_portfolio_and_positions(self):
+        """Test the default portfolio snapshot method normalizes results."""
+        broker = MockBroker("mock")
+
+        async def mock_portfolio():
+            return {
+                "result": {
+                    "market_value": "1000.00",
+                    "equity": "1100.00",
+                    "buying_power": "500.00",
+                }
+            }
+
+        async def mock_positions():
+            return {
+                "result": {
+                    "positions": [
+                        {
+                            "symbol": "AAPL",
+                            "quantity": "10",
+                            "average_buy_price": "150.00",
+                            "market_value": "1700.00",
+                        }
+                    ]
+                }
+            }
+
+        broker.get_portfolio = mock_portfolio
+        broker.get_positions = mock_positions
+
+        summary, positions = await broker.get_portfolio_snapshot()
+
+        assert summary["market_value"] == 1000.0
+        assert summary["equity"] == 1100.0
+        assert summary["buying_power"] == 500.0
+
+        assert len(positions) == 1
+        assert positions[0]["symbol"] == "AAPL"
+        assert positions[0]["quantity"] == 10.0
+        assert positions[0]["average_buy_price"] == 150.0
+        assert positions[0]["market_value"] == 1700.0
+        assert positions[0]["broker"] == "mock"

--- a/tests/unit/test_cross_broker_tools.py
+++ b/tests/unit/test_cross_broker_tools.py
@@ -70,57 +70,24 @@ class TestGetAggregatedPortfolio:
             rh_broker if name == "robinhood" else schwab_broker
         )
 
-        async def _slow_rh_portfolio(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        async def _slow_snapshot(*_args: Any, **_kwargs: Any) -> tuple[dict[str, Any], list[dict[str, Any]]]:
             await asyncio.sleep(0.2)
-            return {
-                "result": {
-                    "market_value": "0",
-                    "equity": "0",
-                    "buying_power": "0",
-                    "status": "success",
-                }
-            }
+            return (
+                {
+                    "market_value": 0.0,
+                    "equity": 0.0,
+                    "buying_power": 0.0,
+                },
+                [],
+            )
 
-        async def _slow_rh_positions(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
-            await asyncio.sleep(0.2)
-            return {"result": {"positions": [], "count": 0, "status": "success"}}
-
-        async def _slow_schwab_accounts(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
-            await asyncio.sleep(0.2)
-            return {
-                "result": {
-                    "accounts": [
-                        {
-                            "securitiesAccount": {
-                                "currentBalances": {
-                                    "liquidationValue": 0.0,
-                                    "buyingPower": 0.0,
-                                },
-                                "positions": [],
-                            }
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
+        rh_broker.get_portfolio_snapshot = AsyncMock(side_effect=_slow_snapshot)
+        schwab_broker.get_portfolio_snapshot = AsyncMock(side_effect=_slow_snapshot)
 
         with (
             patch(
                 "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
                 return_value=mock_registry,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
-                AsyncMock(side_effect=_slow_rh_portfolio),
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
-                AsyncMock(side_effect=_slow_rh_positions),
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
-                AsyncMock(side_effect=_slow_schwab_accounts),
             ),
         ):
             start = time.perf_counter()
@@ -143,74 +110,47 @@ class TestGetAggregatedPortfolio:
             rh_broker if name == "robinhood" else schwab_broker
         )
 
-        rh_portfolio = AsyncMock(
-            return_value={
-                "result": {
-                    "market_value": "10000.00",
-                    "equity": "9500.00",
-                    "buying_power": "3000.00",
-                    "status": "success",
-                }
-            }
+        rh_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 10000.00,
+                    "equity": 9500.00,
+                    "buying_power": 3000.00,
+                },
+                [
+                    {
+                        "symbol": "AAPL",
+                        "quantity": 10.0,
+                        "average_buy_price": 150.00,
+                        "market_value": 1500.0,
+                        "broker": "robinhood",
+                    }
+                ],
+            )
         )
-        rh_positions = AsyncMock(
-            return_value={
-                "result": {
-                    "positions": [
-                        {
-                            "symbol": "AAPL",
-                            "quantity": "10",
-                            "average_buy_price": "150.00",
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
-        )
-        schwab_accounts = AsyncMock(
-            return_value={
-                "result": {
-                    "accounts": [
-                        {
-                            "securitiesAccount": {
-                                "currentBalances": {
-                                    "liquidationValue": 5000.0,
-                                    "buyingPower": 2000.0,
-                                },
-                                "positions": [
-                                    {
-                                        "instrument": {"symbol": "MSFT"},
-                                        "longQuantity": 5,
-                                        "averagePrice": 300.0,
-                                        "marketValue": 1750.0,
-                                    }
-                                ],
-                            }
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
+        schwab_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 5000.0,
+                    "equity": 5000.0,
+                    "buying_power": 2000.0,
+                },
+                [
+                    {
+                        "symbol": "MSFT",
+                        "quantity": 5.0,
+                        "average_buy_price": 300.0,
+                        "market_value": 1750.0,
+                        "broker": "schwab",
+                    }
+                ],
+            )
         )
 
         with (
             patch(
                 "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
                 return_value=mock_registry,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
-                rh_portfolio,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
-                rh_positions,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
-                schwab_accounts,
             ),
         ):
             result = await get_aggregated_portfolio()
@@ -240,44 +180,29 @@ class TestGetAggregatedPortfolio:
             rh_broker if name == "robinhood" else schwab_broker
         )
 
-        rh_portfolio = AsyncMock(
-            return_value={
-                "result": {
-                    "market_value": "10000.00",
-                    "equity": "9500.00",
-                    "buying_power": "3000.00",
-                    "status": "success",
-                }
-            }
-        )
-        rh_positions = AsyncMock(
-            return_value={
-                "result": {
-                    "positions": [
-                        {
-                            "symbol": "AAPL",
-                            "quantity": "10",
-                            "average_buy_price": "150.00",
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
+        rh_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 10000.00,
+                    "equity": 9500.00,
+                    "buying_power": 3000.00,
+                },
+                [
+                    {
+                        "symbol": "AAPL",
+                        "quantity": 10.0,
+                        "average_buy_price": 150.00,
+                        "market_value": 1500.0,
+                        "broker": "robinhood",
+                    }
+                ],
+            )
         )
 
         with (
             patch(
                 "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
                 return_value=mock_registry,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
-                rh_portfolio,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
-                rh_positions,
             ),
         ):
             result = await get_aggregated_portfolio()
@@ -304,34 +229,21 @@ class TestGetAggregatedPortfolio:
             rh_broker if name == "robinhood" else schwab_broker
         )
 
-        schwab_accounts = AsyncMock(
-            return_value={
-                "result": {
-                    "accounts": [
-                        {
-                            "securitiesAccount": {
-                                "currentBalances": {
-                                    "liquidationValue": 5000.0,
-                                    "buyingPower": 2000.0,
-                                },
-                                "positions": [],
-                            }
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
+        schwab_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 5000.0,
+                    "equity": 5000.0,
+                    "buying_power": 2000.0,
+                },
+                [],
+            )
         )
 
         with (
             patch(
                 "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
                 return_value=mock_registry,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
-                schwab_accounts,
             ),
         ):
             result = await get_aggregated_portfolio()
@@ -386,55 +298,31 @@ class TestGetAggregatedPortfolio:
             rh_broker if name == "robinhood" else schwab_broker
         )
 
-        rh_portfolio = AsyncMock(
-            return_value={
-                "result": {
-                    "market_value": "10000.00",
-                    "equity": "9500.00",
-                    "buying_power": "3000.00",
-                    "status": "success",
-                }
-            }
+        rh_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 10000.00,
+                    "equity": 9500.00,
+                    "buying_power": 3000.00,
+                },
+                [],
+            )
         )
-        rh_positions = AsyncMock(
-            return_value={"result": {"positions": [], "count": 0, "status": "success"}}
-        )
-        schwab_accounts = AsyncMock(
-            return_value={
-                "result": {
-                    "accounts": [
-                        {
-                            "securitiesAccount": {
-                                "currentBalances": {
-                                    "liquidationValue": 5000.0,
-                                    "buyingPower": 2000.0,
-                                },
-                                "positions": [],
-                            }
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
+        schwab_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 5000.0,
+                    "equity": 5000.0,
+                    "buying_power": 2000.0,
+                },
+                [],
+            )
         )
 
         with (
             patch(
                 "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
                 return_value=mock_registry,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
-                rh_portfolio,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
-                rh_positions,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
-                schwab_accounts,
             ),
         ):
             result = await get_aggregated_portfolio()
@@ -460,74 +348,47 @@ class TestGetAggregatedPortfolio:
             rh_broker if name == "robinhood" else schwab_broker
         )
 
-        rh_portfolio = AsyncMock(
-            return_value={
-                "result": {
-                    "market_value": "10000.00",
-                    "equity": "9500.00",
-                    "buying_power": "3000.00",
-                    "status": "success",
-                }
-            }
+        rh_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 10000.00,
+                    "equity": 9500.00,
+                    "buying_power": 3000.00,
+                },
+                [
+                    {
+                        "symbol": "AAPL",
+                        "quantity": 10.0,
+                        "average_buy_price": 150.00,
+                        "market_value": 1500.0,
+                        "broker": "robinhood",
+                    }
+                ],
+            )
         )
-        rh_positions = AsyncMock(
-            return_value={
-                "result": {
-                    "positions": [
-                        {
-                            "symbol": "AAPL",
-                            "quantity": "10",
-                            "average_buy_price": "150.00",
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
-        )
-        schwab_accounts = AsyncMock(
-            return_value={
-                "result": {
-                    "accounts": [
-                        {
-                            "securitiesAccount": {
-                                "currentBalances": {
-                                    "liquidationValue": 5000.0,
-                                    "buyingPower": 2000.0,
-                                },
-                                "positions": [
-                                    {
-                                        "instrument": {"symbol": "MSFT"},
-                                        "longQuantity": 5,
-                                        "averagePrice": 300.0,
-                                        "marketValue": 1750.0,
-                                    }
-                                ],
-                            }
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
+        schwab_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 5000.0,
+                    "equity": 5000.0,
+                    "buying_power": 2000.0,
+                },
+                [
+                    {
+                        "symbol": "MSFT",
+                        "quantity": 5.0,
+                        "average_buy_price": 300.0,
+                        "market_value": 1750.0,
+                        "broker": "schwab",
+                    }
+                ],
+            )
         )
 
         with (
             patch(
                 "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
                 return_value=mock_registry,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
-                rh_portfolio,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
-                rh_positions,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
-                schwab_accounts,
             ),
         ):
             result = await get_aggregated_portfolio()
@@ -555,32 +416,21 @@ class TestGetAggregatedPortfolio:
             rh_broker if name == "robinhood" else schwab_broker
         )
 
-        rh_portfolio = AsyncMock(
-            return_value={
-                "result": {
-                    "market_value": "10000.00",
-                    "equity": "9500.00",
-                    "buying_power": "3000.00",
-                    "status": "success",
-                }
-            }
-        )
-        rh_positions = AsyncMock(
-            return_value={"result": {"positions": [], "count": 0, "status": "success"}}
+        rh_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 10000.00,
+                    "equity": 9500.00,
+                    "buying_power": 3000.00,
+                },
+                [],
+            )
         )
 
         with (
             patch(
                 "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
                 return_value=mock_registry,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
-                rh_portfolio,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_positions",
-                rh_positions,
             ),
         ):
             result = await get_aggregated_portfolio()
@@ -625,48 +475,32 @@ class TestGetAggregatedPortfolio:
         )
 
         # Robinhood raises an exception during portfolio collection
-        rh_portfolio = AsyncMock(side_effect=RuntimeError("rh boom"))
+        rh_broker.get_portfolio_snapshot = AsyncMock(side_effect=RuntimeError("rh boom"))
 
         # Schwab returns valid data with one MSFT position
-        schwab_accounts = AsyncMock(
-            return_value={
-                "result": {
-                    "accounts": [
-                        {
-                            "securitiesAccount": {
-                                "currentBalances": {
-                                    "liquidationValue": 5000.0,
-                                    "buyingPower": 2000.0,
-                                },
-                                "positions": [
-                                    {
-                                        "instrument": {"symbol": "MSFT"},
-                                        "longQuantity": 5,
-                                        "averagePrice": 300.0,
-                                        "marketValue": 1750.0,
-                                    }
-                                ],
-                            }
-                        }
-                    ],
-                    "count": 1,
-                    "status": "success",
-                }
-            }
+        schwab_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 5000.0,
+                    "equity": 5000.0,
+                    "buying_power": 2000.0,
+                },
+                [
+                    {
+                        "symbol": "MSFT",
+                        "quantity": 5.0,
+                        "average_buy_price": 300.0,
+                        "market_value": 1750.0,
+                        "broker": "schwab",
+                    }
+                ],
+            )
         )
 
         with (
             patch(
                 "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
                 return_value=mock_registry,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_portfolio",
-                rh_portfolio,
-            ),
-            patch(
-                "open_stocks_mcp.tools.cross_broker_tools.get_schwab_accounts",
-                schwab_accounts,
             ),
         ):
             result = await get_aggregated_portfolio()
@@ -687,3 +521,45 @@ class TestGetAggregatedPortfolio:
         # Robinhood should be in unavailable_brokers and partial_failure should be True
         assert "robinhood" in data["unavailable_brokers"]
         assert data["partial_failure"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_registered_third_broker_snapshot_is_aggregated_without_name_branch(self) -> None:
+        """A third broker registered under a new name is aggregated if it implements snapshots."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["paper"]
+
+        paper_broker = MockBroker("paper", authenticated=True)
+        # We'll use get_portfolio_snapshot which we are about to add
+        paper_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=(
+                {
+                    "market_value": 1000.0,
+                    "equity": 1000.0,
+                    "buying_power": 500.0,
+                },
+                [
+                    {
+                        "symbol": "BTC",
+                        "quantity": 0.5,
+                        "average_buy_price": 20000.0,
+                        "market_value": 25000.0,
+                        "broker": "paper",
+                    }
+                ],
+            )
+        )
+        mock_registry.get_broker.return_value = paper_broker
+
+        with patch(
+            "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+            return_value=mock_registry,
+        ):
+            result = await get_aggregated_portfolio()
+
+        data = result["result"]
+        assert data["brokers"]["paper"]["status"] == "available"
+        assert data["aggregated"]["total_market_value"] == 1000.0
+        assert len(data["aggregated"]["positions"]) == 1
+        assert data["aggregated"]["positions"][0]["symbol"] == "BTC"

--- a/tests/unit/test_schwab_broker.py
+++ b/tests/unit/test_schwab_broker.py
@@ -490,3 +490,81 @@ class TestSchwabBroker:
         assert result["result"]["status"] == "error"
         assert result["result"]["status"] != "not_implemented"
         assert "account hash" in result["result"]["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_portfolio_snapshot_normalizes_accounts_and_positions(
+        self, schwab_broker: SchwabBroker
+    ) -> None:
+        """Test Schwab specific portfolio snapshot normalization."""
+        schwab_broker._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+        schwab_broker.client = MagicMock()
+
+        # Mock get_schwab_accounts called by SchwabBroker.get_portfolio_snapshot
+        mock_accounts = {
+            "result": {
+                "accounts": [
+                    {
+                        "securitiesAccount": {
+                            "currentBalances": {
+                                "liquidationValue": 5000.0,
+                                "buyingPower": 2000.0,
+                            },
+                            "positions": [
+                                {
+                                    "instrument": {"symbol": "MSFT"},
+                                    "longQuantity": 5,
+                                    "shortQuantity": 0,
+                                    "averagePrice": 300.0,
+                                    "marketValue": 1750.0,
+                                }
+                            ],
+                        }
+                    },
+                    {
+                        "securitiesAccount": {
+                            "currentBalances": {
+                                "liquidationValue": 3000.0,
+                                "buyingPower": 1000.0,
+                            },
+                            "positions": [
+                                {
+                                    "instrument": {"symbol": "GOOGL"},
+                                    "longQuantity": 0,
+                                    "shortQuantity": 2,
+                                    "averagePrice": 140.0,
+                                    "marketValue": 280.0,
+                                }
+                            ],
+                        }
+                    },
+                ]
+            }
+        }
+
+        with patch(
+            "open_stocks_mcp.tools.schwab_account_tools.get_schwab_accounts",
+            new=AsyncMock(return_value=mock_accounts),
+        ):
+            summary, positions = await schwab_broker.get_portfolio_snapshot()
+
+        # Aggregated summary: liquidationValue sums 5000 + 3000 = 8000
+        assert summary["market_value"] == 8000.0
+        assert summary["equity"] == 8000.0
+        assert summary["buying_power"] == 3000.0
+
+        # Positions from both accounts
+        assert len(positions) == 2
+        symbols = {p["symbol"] for p in positions}
+        assert symbols == {"MSFT", "GOOGL"}
+
+        msft = next(p for p in positions if p["symbol"] == "MSFT")
+        assert msft["quantity"] == 5.0
+        assert msft["average_buy_price"] == 300.0
+        assert msft["market_value"] == 1750.0
+        assert msft["broker"] == "schwab"
+
+        googl = next(p for p in positions if p["symbol"] == "GOOGL")
+        assert googl["quantity"] == 2.0  # 0 long + 2 short
+        assert googl["average_buy_price"] == 140.0
+        assert googl["market_value"] == 280.0
+        assert googl["broker"] == "schwab"


### PR DESCRIPTION
Closes #190

## Changes
- Added `get_portfolio_snapshot()` to `BaseBroker` to provide a normalized interface for portfolio data.
- Implemented `SchwabBroker.get_portfolio_snapshot()` to correctly normalize Schwab's account-based portfolio structure.
- Refactored `get_aggregated_portfolio()` in `cross_broker_tools.py` to use the new registry-driven dispatch, removing hardcoded broker names and direct tool imports.
- Updated existing unit tests to use the new broker interface.
- Added new tests for base broker normalization and Schwab-specific normalization.
- Added a regression test verifying that a newly registered third broker can contribute to aggregation without core code changes.

## Test plan
- `uv run pytest tests/unit/test_cross_broker_tools.py` - verifies aggregation logic and third-broker support.
- `uv run pytest tests/unit/test_broker_base.py` - verifies default snapshot normalization.
- `uv run pytest tests/unit/test_schwab_broker.py` - verifies Schwab-specific snapshot normalization.
- `uv run ruff check` and `uv run mypy` - ensures code quality and type safety.