### PR TITLE
docs: fix stale ADK eval paths and tool count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ if isinstance(order_result, dict) and 'non_field_errors' in order_result:
 1. Install: `pip install google-agent-developer-kit`
 2. Set environment variables (see above)
 3. Start Docker server: `cd examples/open-stocks-mcp-docker && docker-compose up -d`
-4. From project root: `MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json`
+4. From project root: `MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json`
 5. **Full Read-Only Suite**: For the complete read-only eval suite covering all 7 categories (`0_sys_*`, `2_mkt_*`, `3_wth_*`, `4_ntf_*`, `6_prf_*`, `8_opt_*`, `9_adv_*`), see `tests/evals/ADK-testing-evals.md` for the full manifest and per-category run commands. Each category eval uses the same pattern: `MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/<category>_test.json --config_file_path tests/evals/test_config.json`
 
 ### Phase 8 Development Priorities

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ export ROBINHOOD_PASSWORD="password"
 cd examples/open-stocks-mcp-docker && docker-compose up -d
 
 # Run evaluation
-MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json
+MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json
 ```
 
 ## Project Scope

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -55,26 +55,26 @@ adk --help
 cd /Users/wes/Development/open-stocks-mcp
 
 # Basic evaluation command (with recommended config)
-adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json
 
 # With custom configuration
-adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json
 
 # With detailed results output
-adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json --print_detailed_results
+adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json --print_detailed_results
 
 # With specific run ID for tracking
-adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json --run_id stock_trader_test_$(date +%s)
+adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json --run_id stock_trader_test_$(date +%s)
 
 # With custom model
-GOOGLE_MODEL="gemini-2.0-flash-exp" adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json
+GOOGLE_MODEL="gemini-2.0-flash-exp" adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json
 ```
 
 ### ❌ Wrong Way (From Agent Directory)
 ```bash
 # Don't do this - will cause path errors
 cd examples/google_adk_agent
-adk eval agent.py ../../tests/evals/list_available_tools_test.json  # ❌ Incorrect syntax
+adk eval agent.py ../../tests/evals/0_list_available_tools_test.json  # ❌ Incorrect syntax
 ```
 
 ### 📋 Prerequisites Checklist
@@ -122,12 +122,12 @@ list_available_tools_test_set:
 ## Available Evaluation Tests
 
 ### 1. List Available Tools Test
-**File**: `tests/evals/list_available_tools_test.json`  
+**File**: `tests/evals/0_list_available_tools_test.json`  
 **Purpose**: Validates that the agent can successfully list all available MCP tools  
-**Expected Output**: Alphabetically sorted bullet list of 60 MCP tools
+**Expected Output**: Alphabetically sorted bullet list of all registered MCP tools. The canonical expected response is the `final_response.parts[].text` field inside `tests/evals/0_list_available_tools_test.json`; update that file when the registered tool set changes.
 
 ```bash
-adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json
 ```
 
 ### 2. System & Monitoring Read-Only Evals (`0_sys_*`)
@@ -474,7 +474,7 @@ echo "Running all ADK evaluations..."
 
 # List available tools test
 echo "Testing tool listing..."
-adk eval examples/google_adk_agent tests/evals/list_available_tools_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/0_list_available_tools_test.json --config_file_path tests/evals/test_config.json
 
 # Add more tests as they are created
 # echo "Testing portfolio analysis..."


### PR DESCRIPTION
Closes #212

## Changes
- Replace all occurrences of `tests/evals/list_available_tools_test.json` with `tests/evals/0_list_available_tools_test.json` in `tests/evals/ADK-testing-evals.md` (9 occurrences) and `CLAUDE.md` (1 occurrence)
- Remove hardcoded \"60 MCP tools\" from the \"List Available Tools Test\" section's Expected Output; replace with a pointer to the `final_response.parts[].text` field in the eval JSON as the canonical source of truth

## Test plan
- `git grep -n "tests/evals/list_available_tools_test.json" tests/evals/ADK-testing-evals.md CLAUDE.md` → no matches
- `git grep -n "google-adk-agent" tests/evals/ADK-testing-evals.md CLAUDE.md` → no matches (prior hyphen fix preserved)
- `grep -n "60 MCP tools" tests/evals/ADK-testing-evals.md` → no matches
- `ls tests/evals/0_list_available_tools_test.json examples/google_adk_agent/` → both targets exist
- Pytest collection smoke check: 1038/1039 tests collected cleanly