### PR TITLE
test: use __file__-anchored paths in test_example_notebooks.py

### DIFF
--- a/tests/unit/test_example_notebooks.py
+++ b/tests/unit/test_example_notebooks.py
@@ -7,7 +7,8 @@ from open_stocks_mcp.server.app import mcp
 
 pytestmark = [pytest.mark.unit, pytest.mark.journey_system]
 
-NOTEBOOK_DIR = Path("examples/notebooks")
+_REPO_ROOT = Path(__file__).parents[2]
+NOTEBOOK_DIR = _REPO_ROOT / "examples" / "notebooks"
 PORTFOLIO_NOTEBOOK = NOTEBOOK_DIR / "portfolio_snapshot.ipynb"
 OPTIONS_NOTEBOOK = NOTEBOOK_DIR / "options_analysis.ipynb"
 


### PR DESCRIPTION
Closes #249

## Changes
- Anchored notebook paths in `tests/unit/test_example_notebooks.py` to `__file__` via a new `_REPO_ROOT` constant.
- This ensures the tests pass regardless of the current working directory from which pytest is invoked.

## Test plan
- Verified failure from a non-root CWD (`/tmp`) before the fix.
- Verified success from both root CWD and non-root CWD (`/tmp`) after the fix.
- Confirmed `ruff check` passes.