### PR TITLE
feat: honor ENABLED_BROKERS and DEFAULT_BROKER env vars

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -147,12 +147,14 @@ from open_stocks_mcp.tools.schwab_options_tools import (
     get_schwab_option_chain_by_expiration,
     get_schwab_option_expirations,
     get_schwab_options_positions,
-    schwab_get_option_orders,
     schwab_get_open_option_orders,
-    schwab_get_option_quote as _schwab_get_option_quote_impl,
+    schwab_get_option_orders,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_find_tradable_options as _schwab_find_tradable_options_impl,
+)
+from open_stocks_mcp.tools.schwab_options_tools import (
+    schwab_get_option_quote as _schwab_get_option_quote_impl,
 )
 from open_stocks_mcp.tools.schwab_options_tools import (
     schwab_option_buy_to_open as _schwab_option_buy_to_open_impl,
@@ -2041,6 +2043,46 @@ def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:
     return mcp
 
 
+KNOWN_BROKERS = {"robinhood", "schwab"}
+
+
+def _parse_enabled_brokers(raw: str | None) -> list[str]:
+    """Parse comma-separated list of enabled brokers.
+
+    Args:
+        raw: Raw environment variable value
+
+    Returns:
+        List of normalized broker names
+    """
+    if raw is None:
+        return ["robinhood"]
+
+    tokens = [t.strip().lower() for t in raw.split(",") if t.strip()]
+    return list(dict.fromkeys(tokens))
+
+
+def _apply_default_broker(registry: Any, raw: str | None) -> None:
+    """Apply the default broker if specified.
+
+    Args:
+        registry: Broker registry
+        raw: Raw environment variable value
+    """
+    if not raw:
+        return
+
+    name = raw.strip().lower()
+    registered = registry.list_brokers()
+
+    if name in registered:
+        registry.set_active_broker(name)
+    else:
+        logger.warning(
+            f"⚠️  DEFAULT_BROKER '{name}' not in registered brokers: {registered}"
+        )
+
+
 async def setup_brokers(
     username: str | None,
     password: str | None,
@@ -2055,6 +2097,7 @@ async def setup_brokers(
     Args:
         username: Robinhood username (optional)
         password: Robinhood password (optional)
+        config: Server configuration (optional)
     """
     if config is None:
         config = load_config()
@@ -2064,47 +2107,60 @@ async def setup_brokers(
     # Get the global registry
     registry = await get_broker_registry()
 
-    robinhood_enabled = config.is_feature_enabled("brokers.robinhood")
-    schwab_enabled = config.is_feature_enabled("brokers.schwab")
+    # Get enabled brokers from environment
+    enabled = _parse_enabled_brokers(os.getenv("ENABLED_BROKERS"))
+
+    # Log warnings for unknown brokers
+    for broker_name in enabled:
+        if broker_name not in KNOWN_BROKERS:
+            logger.warning(
+                f"⚠️  Unknown broker '{broker_name}' in ENABLED_BROKERS. "
+                f"Known brokers: {KNOWN_BROKERS}"
+            )
 
     # Setup Robinhood broker if enabled and credentials provided
-    if robinhood_enabled and username and password:
-        logger.info("Configuring Robinhood broker...")
-        session_manager = get_session_manager()
-        robinhood_broker = RobinhoodBroker(
-            username=username,
-            password=password,
-            session_manager=session_manager,
-        )
-        registry.register(robinhood_broker)
-        logger.info("✓ Robinhood broker registered")
-    elif robinhood_enabled:
-        logger.warning(
-            "⚠️  Robinhood credentials not provided - skipping Robinhood integration"
-        )
+    if "robinhood" in enabled:
+        if username and password:
+            logger.info("Configuring Robinhood broker...")
+            session_manager = get_session_manager()
+            robinhood_broker = RobinhoodBroker(
+                username=username,
+                password=password,
+                session_manager=session_manager,
+            )
+            registry.register(robinhood_broker)
+            logger.info("✓ Robinhood broker registered")
+        else:
+            logger.warning(
+                "⚠️  Robinhood credentials not provided - skipping Robinhood integration"
+            )
+            logger.info(
+                "   Set ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD to enable Robinhood"
+            )
+    elif username or password:
         logger.info(
-            "   Set ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD to enable Robinhood"
+            "Robinhood credentials supplied but Robinhood is disabled via ENABLED_BROKERS"
         )
-    else:
-        logger.info("Robinhood broker disabled by feature flag brokers.robinhood")
 
-    # Setup Schwab broker if enabled and credentials configured
-    if schwab_enabled and config.schwab_api_key and config.schwab_app_secret:
-        logger.info("Configuring Schwab broker...")
-        schwab_broker = SchwabBroker(
-            api_key=config.schwab_api_key,
-            app_secret=config.schwab_app_secret,
-            callback_url=config.schwab_callback_url,
-            token_path=config.schwab_token_path,
-        )
-        registry.register(schwab_broker)
-        logger.info("✓ Schwab broker registered")
-    elif schwab_enabled:
-        logger.warning(
-            "⚠️  Schwab enabled but SCHWAB_API_KEY/SCHWAB_APP_SECRET not configured"
-        )
-    else:
-        logger.info("Schwab broker disabled by feature flag brokers.schwab")
+    # Setup Schwab broker if enabled
+    if "schwab" in enabled:
+        if config.schwab_api_key and config.schwab_app_secret:
+            logger.info("Configuring Schwab broker...")
+            schwab_broker = SchwabBroker(
+                api_key=config.schwab_api_key,
+                app_secret=config.schwab_app_secret,
+                callback_url=config.schwab_callback_url,
+                token_path=config.schwab_token_path,
+            )
+            registry.register(schwab_broker)
+            logger.info("✓ Schwab broker registered")
+        else:
+            logger.info(
+                "Schwab enablement gate honored, but Schwab registration is tracked in #54"
+            )
+
+    # Apply default broker if specified
+    _apply_default_broker(registry, os.getenv("DEFAULT_BROKER"))
 
     # Attempt to authenticate all registered brokers
     await attempt_broker_logins(require_at_least_one=False)

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -397,7 +397,8 @@ def test_create_mcp_server_applies_rate_limiter_from_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_setup_brokers_skips_robinhood_when_flag_disabled() -> None:
+async def test_setup_brokers_skips_robinhood_when_flag_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("ENABLED_BROKERS", "schwab")
     mock_registry = MagicMock()
     config = MagicMock()
     config.is_feature_enabled.side_effect = lambda name: {
@@ -420,7 +421,10 @@ async def test_setup_brokers_skips_robinhood_when_flag_disabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_setup_brokers_registers_robinhood_when_flag_enabled() -> None:
+async def test_setup_brokers_registers_robinhood_when_flag_enabled(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ENABLED_BROKERS", "robinhood")
     mock_registry = MagicMock()
     config = MagicMock()
     config.is_feature_enabled.side_effect = lambda name: {
@@ -444,7 +448,10 @@ async def test_setup_brokers_registers_robinhood_when_flag_enabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_setup_brokers_registers_schwab_when_enabled_and_configured() -> None:
+async def test_setup_brokers_registers_schwab_when_enabled_and_configured(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ENABLED_BROKERS", "schwab")
     mock_registry = MagicMock()
     config = MagicMock()
     config.is_feature_enabled.side_effect = lambda name: {
@@ -465,6 +472,173 @@ async def test_setup_brokers_registers_schwab_when_enabled_and_configured() -> N
         await setup_brokers(None, None, config=config)
 
     mock_registry.register.assert_called_once()
+
+
+@pytest.mark.journey_system
+class TestSetupBrokers:
+    """Test setup_brokers environment variable gating."""
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_default_behavior(self, monkeypatch) -> None:
+        """Test default behavior (unset ENABLED_BROKERS) registers Robinhood."""
+        monkeypatch.delenv("ENABLED_BROKERS", raising=False)
+        mock_registry = MagicMock()
+        mock_registry.register = MagicMock()
+
+        with (
+            patch(
+                "open_stocks_mcp.server.app.get_broker_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
+            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        ):
+            await setup_brokers("user", "pass")
+
+        # Current behavior (and desired default): registers Robinhood if creds provided
+        mock_registry.register.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_respects_enabled_brokers_schwab_only(
+        self, monkeypatch
+    ) -> None:
+        """Test that setting ENABLED_BROKERS=schwab skips Robinhood even if creds present."""
+        monkeypatch.setenv("ENABLED_BROKERS", "schwab")
+        mock_registry = MagicMock()
+        mock_registry.register = MagicMock()
+
+        with (
+            patch(
+                "open_stocks_mcp.server.app.get_broker_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
+            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        ):
+            await setup_brokers("user", "pass")
+
+        # Should NOT register Robinhood
+        mock_registry.register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_empty_enabled_brokers(self, monkeypatch) -> None:
+        """Test that setting ENABLED_BROKERS='' results in no brokers."""
+        monkeypatch.setenv("ENABLED_BROKERS", "")
+        mock_registry = MagicMock()
+        mock_registry.register = MagicMock()
+
+        with (
+            patch(
+                "open_stocks_mcp.server.app.get_broker_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        ):
+            await setup_brokers("user", "pass")
+
+        mock_registry.register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_whitespace_and_case_insensitivity(
+        self, monkeypatch
+    ) -> None:
+        """Test whitespace tolerance and case insensitivity in ENABLED_BROKERS."""
+        monkeypatch.setenv("ENABLED_BROKERS", " Robinhood , schwab ")
+        mock_registry = MagicMock()
+        mock_registry.register = MagicMock()
+
+        with (
+            patch(
+                "open_stocks_mcp.server.app.get_broker_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
+            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        ):
+            await setup_brokers("user", "pass")
+
+        # Robinhood should be registered
+        mock_registry.register.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_unknown_token_logs_warning(
+        self, monkeypatch, caplog
+    ) -> None:
+        """Test that unknown tokens in ENABLED_BROKERS log a warning but don't crash."""
+        monkeypatch.setenv("ENABLED_BROKERS", "bogus,robinhood")
+        mock_registry = MagicMock()
+        mock_registry.register = MagicMock()
+
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="open_stocks_mcp")
+
+        with (
+            patch(
+                "open_stocks_mcp.server.app.get_broker_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
+            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        ):
+            await setup_brokers("user", "pass")
+
+        assert "bogus" in caplog.text
+        # Robinhood should still be registered
+        mock_registry.register.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_default_broker_valid(self, monkeypatch) -> None:
+        """Test that valid DEFAULT_BROKER calls set_active_broker."""
+        monkeypatch.setenv("DEFAULT_BROKER", "robinhood")
+        mock_registry = MagicMock()
+        mock_registry.register = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood"]
+
+        with (
+            patch(
+                "open_stocks_mcp.server.app.get_broker_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
+            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        ):
+            await setup_brokers("user", "pass")
+
+        mock_registry.set_active_broker.assert_called_once_with("robinhood")
+
+    @pytest.mark.asyncio
+    async def test_setup_brokers_default_broker_invalid_logs_warning(
+        self, monkeypatch, caplog
+    ) -> None:
+        """Test that invalid DEFAULT_BROKER logs a warning."""
+        monkeypatch.setenv("DEFAULT_BROKER", "schwab")
+        mock_registry = MagicMock()
+        mock_registry.register = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood"]
+
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="open_stocks_mcp")
+
+        with (
+            patch(
+                "open_stocks_mcp.server.app.get_broker_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
+            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        ):
+            await setup_brokers("user", "pass")
+
+        assert "schwab" in caplog.text
+        mock_registry.set_active_broker.assert_not_called()
 
 
 def test_main_debug_flag_passes_debug_config_to_server() -> None:


### PR DESCRIPTION
Closes #228

## Changes
- Implemented `_parse_enabled_brokers` helper to parse `ENABLED_BROKERS` env var as a comma-separated list.
- Implemented `_apply_default_broker` helper to set the active broker via `DEFAULT_BROKER` env var.
- Updated `setup_brokers()` to use these helpers as the primary gate for broker registration.
- Added `TestSetupBrokers` unit tests covering various environment variable combinations.
- Updated existing tests to align with the new environment-driven enablement logic.

## Test plan
- Run `uv run pytest tests/server/test_server_app.py -k "test_setup_brokers" -q` to verify new and updated tests.
- Run `uv run ruff check` and `uv run mypy` to verify code quality.