### PR TITLE
feat: add pytest-timeout plugin with 60s default timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-benchmark>=5.0.0",
     "pytest-mock>=3.15.1",
+    "pytest-timeout>=2.3.1",
     "ruff>=0.15.14",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
@@ -156,6 +157,8 @@ testpaths = ["tests"]
 addopts = [
     "--strict-markers",
     "--strict-config",
+    "--timeout=60",
+    "--timeout-method=thread",
     "--verbose",
     "-m",
     "not live_market",
@@ -183,6 +186,7 @@ markers = [
     "journey_advanced_data: Level II & premium features tests (pricebook, level2_data)",
     "journey_market_intelligence: Movers & trends tests (top_movers, top_100_stocks)",
     "journey_trading: Trading operations tests (buy/sell orders, cancellation)",
+    "timeout: per-test timeout override in seconds (pytest-timeout)",
 ]
 
 [tool.uv]
@@ -195,6 +199,7 @@ dev = [
     "pytest-benchmark>=5.0.0",
     "pytest-mock>=3.15.1",
     "pytest-cov>=7.1.0",
+    "pytest-timeout>=2.3.1",
     "httpx>=0.28.1",
     "ruff>=0.15.14",
     "mypy>=2.1.0",

--- a/tests/unit/test_pytest_timeout_sanity.py
+++ b/tests/unit/test_pytest_timeout_sanity.py
@@ -1,0 +1,40 @@
+"""Sanity test proving pytest-timeout is installed and enforces deadlines."""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.timeout(30)
+def test_timeout_kills_hanging_test(tmp_path: Path) -> None:
+    """A deliberately hanging test must be terminated by pytest-timeout."""
+    test_file = tmp_path / "test_hang.py"
+    test_file.write_text(
+        textwrap.dedent("""\
+            import time
+
+            def test_hang():
+                time.sleep(30)
+        """)
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(test_file),
+            "--timeout=2",
+            "--timeout-method=thread",
+            "-q",
+            "--override-ini=addopts=",
+            "--no-header",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode != 0
+    assert "Timeout" in result.stdout or "Timeout" in result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -1764,6 +1764,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 docs = [
@@ -1786,6 +1787,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -1815,6 +1817,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.15.1" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.34.2" },
@@ -1838,6 +1841,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.0.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "ruff", specifier = ">=0.15.14" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
@@ -2384,6 +2388,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #233

## Changes
- Added `pytest-timeout>=2.3.1` to both `[project.optional-dependencies] dev` and `[dependency-groups] dev` in `pyproject.toml`
- Configured `--timeout=60` and `--timeout-method=thread` in `[tool.pytest.ini_options] addopts` so every test gets a 60-second deadline by default
- Registered the `timeout` marker under `--strict-markers` to allow `@pytest.mark.timeout()` overrides
- Regenerated `uv.lock` to include `pytest-timeout 2.4.0`
- Added `tests/unit/test_pytest_timeout_sanity.py` — a self-verifying test that spawns a deliberately hanging subprocess and asserts pytest-timeout kills it with a `Failed: Timeout` outcome

## Test plan
- `uv run pytest tests/unit/test_pytest_timeout_sanity.py -q` — proves the plugin is installed and active (1 passed, 2.54s)
- `uv run pytest -m "not slow and not exception_test" -q --durations=20` — full default suite passes; slowest test is 7.01s, well under the 60s cap (no overrides needed)
- `grep -c 'name = "pytest-timeout"' uv.lock` — confirms lockfile contains the new dependency
- `uv run ruff check . && uv run ruff format --check .` — no lint/format regressions