### PR TITLE
feat: broker-specific rate limiter routing

### DIFF
--- a/src/open_stocks_mcp/brokers/registry.py
+++ b/src/open_stocks_mcp/brokers/registry.py
@@ -6,6 +6,10 @@ from typing import Any
 
 from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.rate_limiter import (
+    RateLimiter,
+    get_broker_rate_limit_defaults,
+)
 
 
 class RegistryNotInitializedError(LookupError):
@@ -32,6 +36,7 @@ class BrokerRegistry:
         self._authentication_attempts: dict[str, int] = {}
         self._refresh_locks: dict[tuple[str, str], asyncio.Lock] = {}
         self._refresh_futures: dict[tuple[str, str], asyncio.Future[bool]] = {}
+        self._rate_limiters: dict[str, RateLimiter] = {}
 
     def register(self, broker: BaseBroker) -> None:
         """Register a broker instance.
@@ -128,6 +133,24 @@ class BrokerRegistry:
             List of available broker names
         """
         return [name for name, broker in self._brokers.items() if broker.is_available()]
+
+    def get_rate_limiter(self, broker_name: str) -> RateLimiter:
+        """Get or create a broker-specific limiter by normalized broker name."""
+        normalized = broker_name.strip().lower()
+        limiter = self._rate_limiters.get(normalized)
+        if limiter is not None:
+            return limiter
+
+        calls_per_minute, calls_per_hour, burst_size = get_broker_rate_limit_defaults(
+            normalized
+        )
+        limiter = RateLimiter(
+            calls_per_minute=calls_per_minute,
+            calls_per_hour=calls_per_hour,
+            burst_size=burst_size,
+        )
+        self._rate_limiters[normalized] = limiter
+        return limiter
 
     def get_auth_status(self) -> dict[str, Any]:
         """Get authentication status for all brokers.

--- a/src/open_stocks_mcp/brokers/request_policy.py
+++ b/src/open_stocks_mcp/brokers/request_policy.py
@@ -62,6 +62,7 @@ async def execute_broker_request(
     *args: Any,
     policy: Any | None = None,
     retry_safe: bool = True,
+    broker_name: str = "schwab",
     **kwargs: Any,
 ) -> T:
     """Execute a synchronous broker SDK call with optional retries and deadline enforcement.
@@ -89,6 +90,11 @@ async def execute_broker_request(
     if deadline is not None:
         deadline = float(deadline)
 
+    from open_stocks_mcp.brokers.registry import get_broker_registry
+
+    registry = await get_broker_registry()
+    rate_limiter = registry.get_rate_limiter(broker_name)
+
     start_time = time.time()
     last_exception = None
 
@@ -101,6 +107,7 @@ async def execute_broker_request(
                 raise TimeoutError(f"Broker request exceeded deadline of {deadline}s")
 
         try:
+            await rate_limiter.acquire()
             # Run sync function in thread pool to avoid blocking the event loop
             return await asyncio.to_thread(func, *args, **kwargs)
         except Exception as e:

--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -1,6 +1,7 @@
 """Rate limiting for Robin Stocks API calls."""
 
 import asyncio
+import os
 import time
 from collections import defaultdict, deque
 from collections.abc import Callable, Coroutine
@@ -15,6 +16,9 @@ BURST_WINDOW_SECONDS = 1
 DEFAULT_CALLS_PER_MINUTE = 30
 DEFAULT_CALLS_PER_HOUR = 1000
 DEFAULT_BURST_SIZE = 5
+DEFAULT_SCHWAB_CALLS_PER_MINUTE = 120
+DEFAULT_SCHWAB_CALLS_PER_HOUR = 3600
+DEFAULT_SCHWAB_BURST_SIZE = 20
 
 
 class RateLimiter:
@@ -327,6 +331,36 @@ _request_coordinator: RequestCoordinator | None = None
 _batchers: dict[str, Batcher] = {}
 
 
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+
+
+def get_broker_rate_limit_defaults(broker_name: str) -> tuple[int, int, int]:
+    """Return broker-specific (per-minute, per-hour, burst) rate-limit defaults."""
+    normalized = broker_name.strip().lower()
+    if normalized == "schwab":
+        # Schwab integration docs call out ~120 req/min as the intended baseline.
+        return (
+            _int_env(
+                "OPEN_STOCKS_SCHWAB_CALLS_PER_MINUTE", DEFAULT_SCHWAB_CALLS_PER_MINUTE
+            ),
+            _int_env("OPEN_STOCKS_SCHWAB_CALLS_PER_HOUR", DEFAULT_SCHWAB_CALLS_PER_HOUR),
+            _int_env("OPEN_STOCKS_SCHWAB_BURST_SIZE", DEFAULT_SCHWAB_BURST_SIZE),
+        )
+    return (
+        _int_env("OPEN_STOCKS_ROBINHOOD_CALLS_PER_MINUTE", DEFAULT_CALLS_PER_MINUTE),
+        _int_env("OPEN_STOCKS_ROBINHOOD_CALLS_PER_HOUR", DEFAULT_CALLS_PER_HOUR),
+        _int_env("OPEN_STOCKS_ROBINHOOD_BURST_SIZE", DEFAULT_BURST_SIZE),
+    )
+
+
 def get_batcher(
     name: str,
     batch_size: int = 10,
@@ -371,13 +405,17 @@ def reset_request_coordinator() -> None:
     _request_coordinator = None
 
 
-def get_rate_limiter() -> RateLimiter:
+def get_rate_limiter(broker_name: str | None = None) -> RateLimiter:
     """Get the global rate limiter instance.
 
     Returns:
         The global RateLimiter instance
     """
     global _rate_limiter
+    if broker_name:
+        from open_stocks_mcp.brokers.registry import get_broker_registry_sync
+
+        return get_broker_registry_sync().get_rate_limiter(broker_name)
     if _rate_limiter is None:
         # Initialize with conservative defaults
         _rate_limiter = RateLimiter(
@@ -397,7 +435,11 @@ def get_request_coordinator() -> RequestCoordinator:
 
 
 async def rate_limited_call(
-    func: Any, *args: Any, endpoint: str | None = None, **kwargs: Any
+    func: Any,
+    *args: Any,
+    endpoint: str | None = None,
+    broker_name: str | None = None,
+    **kwargs: Any,
 ) -> Any:
     """Execute a function with rate limiting.
 
@@ -409,7 +451,7 @@ async def rate_limited_call(
     Returns:
         Result of the function call
     """
-    limiter = get_rate_limiter()
+    limiter = get_rate_limiter(broker_name=broker_name)
     await limiter.acquire(endpoint)
 
     if asyncio.iscoroutinefunction(func):

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -64,8 +64,6 @@ async def execute_with_retry(
     from open_stocks_mcp.brokers.registry import get_broker_registry
     from open_stocks_mcp.brokers.session_state import get_session_manager
     from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
-    from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
-
     last_exception = None
     retry_config = load_config().retry
     if retry_config is None:
@@ -80,8 +78,13 @@ async def execute_with_retry(
         retry_config.backoff_factor if backoff_factor is None else backoff_factor
     )
     session_manager = get_session_manager()
+    registry = await get_broker_registry()
     circuit_breaker = get_broker_circuit_breaker()
-    rate_limiter = get_rate_limiter() if rate_limit else None
+    rate_limiter = (
+        registry.get_rate_limiter(broker_name)
+        if rate_limit
+        else None
+    )
     auth_retry_count = 0
     max_auth_retries = retry_config.auth_max_retries
 
@@ -127,9 +130,7 @@ async def execute_with_retry(
                     auth_retry_count += 1
 
                     try:
-                        success = await (
-                            await get_broker_registry()
-                        ).coordinated_refresh(
+                        success = await registry.coordinated_refresh(
                             broker_name=broker_name,
                             account_id=account_id,
                             refresh_coro=session_manager.refresh_session,

--- a/src/open_stocks_mcp/tools/robinhood_dividend_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_dividend_tools.py
@@ -51,7 +51,7 @@ async def get_dividends() -> dict[str, Any]:
             return {"result": {"error": "Authentication required", "status": "error"}}
 
         # Apply rate limiting
-        rate_limiter = get_rate_limiter()
+        rate_limiter = get_rate_limiter("robinhood")
         await rate_limiter.acquire()
 
         # Get dividend data
@@ -146,7 +146,7 @@ async def get_total_dividends() -> dict[str, Any]:
             return {"result": {"error": "Authentication required", "status": "error"}}
 
         # Apply rate limiting
-        rate_limiter = get_rate_limiter()
+        rate_limiter = get_rate_limiter("robinhood")
         await rate_limiter.acquire()
 
         # Use robin_stocks built-in function
@@ -240,7 +240,7 @@ async def get_dividends_by_instrument(symbol: str) -> dict[str, Any]:
             return {"result": {"error": "Authentication required", "status": "error"}}
 
         # Apply rate limiting
-        rate_limiter = get_rate_limiter()
+        rate_limiter = get_rate_limiter("robinhood")
         await rate_limiter.acquire()
 
         # Get dividends by instrument
@@ -321,7 +321,7 @@ async def get_interest_payments() -> dict[str, Any]:
             return {"result": {"error": "Authentication required", "status": "error"}}
 
         # Apply rate limiting
-        rate_limiter = get_rate_limiter()
+        rate_limiter = get_rate_limiter("robinhood")
         await rate_limiter.acquire()
 
         # Get interest payments
@@ -395,7 +395,7 @@ async def get_stock_loan_payments() -> dict[str, Any]:
             return {"result": {"error": "Authentication required", "status": "error"}}
 
         # Apply rate limiting
-        rate_limiter = get_rate_limiter()
+        rate_limiter = get_rate_limiter("robinhood")
         await rate_limiter.acquire()
 
         # Get stock loan payments

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -412,6 +412,37 @@ class TestBrokerRegistry:
         assert all(results)
         assert refresh_count == 2
 
+    @pytest.mark.asyncio
+    async def test_get_rate_limiter_returns_stable_per_broker_instances(self, registry):
+        robinhood = registry.get_rate_limiter("robinhood")
+        schwab = registry.get_rate_limiter("schwab")
+
+        assert robinhood is registry.get_rate_limiter("RobinHood")
+        assert schwab is registry.get_rate_limiter(" SCHWAB ")
+        assert robinhood is not schwab
+        assert robinhood.calls_per_minute == 30
+        assert schwab.calls_per_minute >= 120
+
+    @pytest.mark.asyncio
+    async def test_broker_rate_limiters_are_independent(self, registry, monkeypatch):
+        monkeypatch.setattr("open_stocks_mcp.tools.rate_limiter.time.time", lambda: 1000.0)
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr("open_stocks_mcp.tools.rate_limiter.asyncio.sleep", fake_sleep)
+
+        robinhood = registry.get_rate_limiter("robinhood")
+        schwab = registry.get_rate_limiter("schwab")
+        robinhood.call_times.extend([999.5, 999.7, 999.9, 999.95, 999.99])
+
+        await schwab.acquire()
+
+        assert sleep_calls == []
+        assert len(robinhood.call_times) == 5
+        assert len(schwab.call_times) == 1
+
 
 class TestBrokerRegistrySingleton:
     """Test get_broker_registry singleton pattern."""

--- a/tests/unit/test_broker_request_policy.py
+++ b/tests/unit/test_broker_request_policy.py
@@ -1,9 +1,21 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
 from open_stocks_mcp.brokers.request_policy import install_robinhood_request_timeout
+
+
+@pytest.fixture(autouse=True)
+def _patch_broker_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    limiter = Mock()
+    limiter.acquire = AsyncMock(return_value=None)
+    registry = Mock()
+    registry.get_rate_limiter = Mock(return_value=limiter)
+    monkeypatch.setattr(
+        "open_stocks_mcp.brokers.registry.get_broker_registry",
+        AsyncMock(return_value=registry),
+    )
 
 
 class TestBrokerRequestPolicy(unittest.TestCase):
@@ -126,3 +138,25 @@ async def test_execute_broker_request_deadline():
     # Total would be 0.15s which exceeds 0.1s.
     assert mock_func.call_count <= 3
     assert elapsed < 0.2
+
+
+@pytest.mark.asyncio
+async def test_execute_broker_request_uses_broker_limiter(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from open_stocks_mcp.brokers.request_policy import execute_broker_request
+
+    limiter = Mock()
+    limiter.acquire = AsyncMock(return_value=None)
+    registry = Mock()
+    registry.get_rate_limiter = Mock(return_value=limiter)
+    monkeypatch.setattr(
+        "open_stocks_mcp.brokers.registry.get_broker_registry",
+        AsyncMock(return_value=registry),
+    )
+
+    fn = MagicMock(return_value="ok")
+    result = await execute_broker_request(fn, broker_name="schwab")
+    assert result == "ok"
+    registry.get_rate_limiter.assert_called_once_with("schwab")
+    limiter.acquire.assert_awaited_once()

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -12,7 +12,6 @@ from mcp.server.fastmcp import FastMCP
 
 from open_stocks_mcp.brokers import session_state as session_manager_module
 from open_stocks_mcp.server.app import mcp as production_mcp
-from open_stocks_mcp.tools import rate_limiter
 from open_stocks_mcp.tools.error_handling import (
     APIError,
     AuthenticationError,
@@ -46,7 +45,15 @@ def _patch_retry_dependencies(
     monkeypatch.setattr(
         session_manager_module, "get_session_manager", lambda: session_manager
     )
-    monkeypatch.setattr(rate_limiter, "get_rate_limiter", lambda: None)
+    limiter = Mock()
+    limiter.acquire = AsyncMock(return_value=None)
+    registry = Mock()
+    registry.get_rate_limiter = Mock(return_value=limiter)
+    registry.coordinated_refresh = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "open_stocks_mcp.brokers.registry.get_broker_registry",
+        AsyncMock(return_value=registry),
+    )
     breaker = Mock()
     breaker.before_request = AsyncMock(return_value=None)
     breaker.record_success = AsyncMock(return_value=None)
@@ -364,6 +371,15 @@ def retry_patch(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     fake_session.should_block_auth_retries = Mock(return_value=False)
 
     fake_rate_limiter = SimpleNamespace(acquire=AsyncMock())
+    fake_registry = Mock()
+    fake_registry.get_rate_limiter = Mock(return_value=fake_rate_limiter)
+
+    async def _coordinated_refresh(
+        *, broker_name: str, account_id: str | None, refresh_coro: Callable[[], Any]
+    ) -> bool:
+        return bool(await refresh_coro())
+
+    fake_registry.coordinated_refresh = AsyncMock(side_effect=_coordinated_refresh)
     fake_breaker = Mock()
     fake_breaker.before_request = AsyncMock(return_value=None)
     fake_breaker.record_success = AsyncMock(return_value=None)
@@ -375,8 +391,8 @@ def retry_patch(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         lambda: fake_session,
     )
     monkeypatch.setattr(
-        "open_stocks_mcp.tools.rate_limiter.get_rate_limiter",
-        lambda: fake_rate_limiter,
+        "open_stocks_mcp.brokers.registry.get_broker_registry",
+        AsyncMock(return_value=fake_registry),
     )
     monkeypatch.setattr(
         "open_stocks_mcp.tools.circuit_breaker.get_broker_circuit_breaker",
@@ -389,6 +405,7 @@ def retry_patch(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         "rate_limiter": fake_rate_limiter,
         "breaker": fake_breaker,
         "sleep": sleep_mock,
+        "registry": fake_registry,
     }
 
 
@@ -521,6 +538,9 @@ async def test_execute_with_retry_uses_registry_single_flight_for_auth_refresh()
         return bool(await refresh_coro())
 
     registry = Mock()
+    limiter = Mock()
+    limiter.acquire = AsyncMock(return_value=None)
+    registry.get_rate_limiter = Mock(return_value=limiter)
     registry.coordinated_refresh = AsyncMock(side_effect=coordinated_refresh)
     breaker = Mock()
     breaker.before_request = AsyncMock(return_value=None)
@@ -537,7 +557,6 @@ async def test_execute_with_retry_uses_registry_single_flight_for_auth_refresh()
             "open_stocks_mcp.brokers.session_state.get_session_manager",
             return_value=session,
         ),
-        patch("open_stocks_mcp.tools.rate_limiter.get_rate_limiter", return_value=None),
         patch(
             "open_stocks_mcp.tools.circuit_breaker.get_broker_circuit_breaker",
             return_value=breaker,
@@ -688,6 +707,31 @@ async def test_execute_with_retry_skips_rate_limiter_when_disabled(
 
     assert await execute_with_retry(ok, rate_limit=False) == "ok"
     get_rate_limiter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_uses_broker_specific_limiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retry_dependencies(monkeypatch)
+
+    limiter = Mock()
+    limiter.acquire = AsyncMock(return_value=None)
+    registry = Mock()
+    registry.get_rate_limiter = Mock(return_value=limiter)
+
+    monkeypatch.setattr(
+        "open_stocks_mcp.brokers.registry.get_broker_registry",
+        AsyncMock(return_value=registry),
+    )
+
+    async def ok() -> str:
+        return "ok"
+
+    result = await execute_with_retry(ok, broker_name="schwab")
+    assert result == "ok"
+    registry.get_rate_limiter.assert_called_once_with("schwab")
+    limiter.acquire.assert_awaited_once()
 
 
 @pytest.mark.parametrize("symbol", ["A", "AAPL", "GOOGL", "BRK", "abc", "BRK1"])

--- a/tests/unit/test_simple_rate_limiter.py
+++ b/tests/unit/test_simple_rate_limiter.py
@@ -8,6 +8,7 @@ import pytest
 
 from open_stocks_mcp.tools.rate_limiter import (
     RateLimiter,
+    get_broker_rate_limit_defaults,
     get_rate_limiter,
     rate_limited_call,
 )
@@ -261,6 +262,14 @@ def test_configure_global_rate_limiter_updates_singleton() -> None:
     assert get_rate_limiter() is limiter
 
 
+def test_get_broker_rate_limit_defaults() -> None:
+    robinhood = get_broker_rate_limit_defaults("robinhood")
+    schwab = get_broker_rate_limit_defaults("schwab")
+
+    assert robinhood == (30, 1000, 5)
+    assert schwab[0] >= 120
+
+
 class TestRequestCoordinator:
     """Test RequestCoordinator singleflight deduplication logic."""
 
@@ -421,3 +430,31 @@ async def test_rate_limited_call_runs_sync_function_without_deprecated_loop(
 
     result = await rate_limited_call(add, 2, 3)
     assert result == 5
+
+
+@pytest.mark.journey_system
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rate_limited_call_routes_to_broker_limiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    acquire_calls: list[str | None] = []
+
+    class StubLimiter:
+        async def acquire(self, endpoint: str | None = None) -> None:
+            acquire_calls.append(endpoint)
+
+    def fake_get_rate_limiter(broker_name: str | None = None) -> StubLimiter:
+        assert broker_name == "schwab"
+        return StubLimiter()
+
+    monkeypatch.setattr(
+        "open_stocks_mcp.tools.rate_limiter.get_rate_limiter", fake_get_rate_limiter
+    )
+
+    async def ok() -> str:
+        return "ok"
+
+    result = await rate_limited_call(ok, endpoint="/quote", broker_name="schwab")
+    assert result == "ok"
+    assert acquire_calls == ["/quote"]


### PR DESCRIPTION
Closes #230

## Changes
- add centralized broker rate-limit defaults in  (Robinhood 30/min, Schwab 120/min baseline) with env overrides
- add  and per-broker limiter cache
- route , , and  through broker-specific limiters
- update Robinhood dividend tools to request the Robinhood-specific limiter
- add unit coverage for per-broker limiter defaults, limiter independence, and retry/request-policy routing

## Test plan
- uv run pytest tests/unit/test_broker_registry.py tests/unit/test_simple_rate_limiter.py tests/unit/test_error_handling.py tests/unit/test_broker_request_policy.py -q
- uv run ruff check src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/brokers/registry.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/brokers/request_policy.py src/open_stocks_mcp/tools/robinhood_dividend_tools.py tests/unit/test_broker_registry.py tests/unit/test_broker_request_policy.py tests/unit/test_error_handling.py tests/unit/test_simple_rate_limiter.py
- uv run mypy src/open_stocks_mcp/tools/rate_limiter.py src/open_stocks_mcp/brokers/registry.py src/open_stocks_mcp/tools/retry.py src/open_stocks_mcp/brokers/request_policy.py