### PR TITLE
docs: add Schwab guidance to Claude docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@ Project guidance for Claude Code when working with the Open Stocks MCP server.
 
 ## Project Overview
 
-**Open Stocks MCP** - Model Context Protocol server providing stock market data through Robin Stocks API.
-- **Current Version**: v0.6.5 with enhanced authentication and session management
+**Open Stocks MCP** - Model Context Protocol server providing stock market data and trading tools through Robinhood and Charles Schwab broker APIs.
+- **Current Version**: v0.6.5 with multi-broker support, enhanced authentication, and session management
 - **Framework**: FastMCP for simplified MCP development
-- **API**: Robin Stocks for market data and trading
+- **APIs**: Robin Stocks for Robinhood plus schwab-py for Charles Schwab
 - **Transport**: HTTP with Server-Sent Events (SSE), configurable via `--port` (default 3000)
 - **Docker**: Production-ready with persistent session/log storage
 
@@ -49,6 +49,7 @@ pytest tests/unit/                                        # Unit tests (fast)
 pytest tests/integration/ -m integration                  # Integration (needs auth)
 pytest -m rate_limited                                    # Live rate-limited API tests
 RUN_RATE_LIMITED=1 pytest                                 # Include rate-limited tests in full run
+OPEN_STOCKS_RUN_LIVE_MARKET=1 RUN_RATE_LIMITED=1 ENABLED_BROKERS=schwab uv run pytest tests/integration/test_schwab_live_journeys.py -m "live_market and auth_required and rate_limited" --run-live-market -q
 
 # READ ONLY journeys (perfect for ADK evaluations)
 pytest -m "journey_account or journey_portfolio or journey_market_data or journey_research or journey_notifications or journey_system"
@@ -74,6 +75,8 @@ RUN_PERFORMANCE=1 uv run pytest      # Include performance tests in a full run
 - `rate_limited` - Live endpoint tests that may hit Robinhood or Schwab rate
   limits; skipped by default unless selected with `-m rate_limited` or
   `RUN_RATE_LIMITED=1`
+- `live_market` + `auth_required` - Schwab live journey tests remain blocked on
+  live credentials and a persisted Schwab OAuth token.
 - `performance` - Mocked benchmark tests for representative tool wrapper
   latency; skipped by default unless selected with `-m performance` or
   `RUN_PERFORMANCE=1`
@@ -111,6 +114,9 @@ curl http://localhost:3001/health  # Test health endpoint
 ## MCP Architecture
 
 ### Tool Structure
+The server currently exposes 152 active MCP tools across Robinhood and Schwab.
+Use [Tool Reference](docs/MCP_TOOLS_REFERENCE.md) for the generated breakdown.
+
 All tools return JSON with `result` field:
 ```python
 @mcp.tool()
@@ -123,25 +129,56 @@ async def get_stock_quote(symbol: str) -> dict:
 ```
 
 ### Key Patterns
-- **Async wrappers** for Robin Stocks (synchronous API)
+- **Async wrappers** around broker SDKs and synchronous API calls
 - **Retry logic** via `execute_with_retry`
 - **Error handling** via `@handle_robin_stocks_errors` 
 - **Rate limiting** via `get_rate_limiter()`
 - **Session management** for authentication
 
+### Multi-Broker Guidance
+Open Stocks MCP supports Robinhood and Charles Schwab in the same server. Keep
+Robinhood tool names stable for backward compatibility, and use the `schwab_`
+prefix for Schwab-specific tools such as `schwab_portfolio`,
+`schwab_quote`, and `schwab_buy_stock_market`.
+
+Schwab authentication uses an OAuth first-run flow through schwab-py. The token
+is persisted at `~/.tokens/schwab_token.json` by default and is refreshed by the
+library on subsequent runs. See [docs/SCHWAB_SETUP.md](docs/SCHWAB_SETUP.md)
+for operator setup and [docs/SCHWAB_INTEGRATION_PLAN.md](docs/SCHWAB_INTEGRATION_PLAN.md)
+for the multi-broker design plan.
+
+Schwab live journey tests are blocked on live credentials: `SCHWAB_API_KEY`,
+`SCHWAB_APP_SECRET`, a matching callback URL, and a valid token file. Do not
+treat Schwab live journey failures as CI regressions unless those credentials
+and `RUN_RATE_LIMITED=1 --run-live-market` were explicitly provided.
+
 ## Environment Variables
 
-### Required for Live Testing
+### Required for Robinhood Live Testing
 ```bash
 ROBINHOOD_USERNAME="email@example.com"
 ROBINHOOD_PASSWORD="password"
 ```
+
+### Required for Schwab Live Testing
+```bash
+SCHWAB_API_KEY="your-api-key"
+SCHWAB_APP_SECRET="your-app-secret"
+SCHWAB_CALLBACK_URL="https://127.0.0.1:8182/"
+SCHWAB_TOKEN_PATH="~/.tokens/schwab_token.json"
+ENABLED_BROKERS="robinhood,schwab"
+```
+
+The Schwab token path defaults to `~/.tokens/schwab_token.json`. The first
+server run opens the OAuth browser flow and writes the token; non-interactive
+Docker or CI runs should mount a token that was created interactively first.
 
 ### Required for ADK Evaluation  
 ```bash
 GOOGLE_API_KEY="your-google-api-key"
 ROBINHOOD_USERNAME="email@example.com" 
 ROBINHOOD_PASSWORD="password"
+# Include Schwab variables above when evaluating Schwab tools.
 ```
 
 ## Current Development Status

--- a/docs/MCP_TOOLS_REFERENCE.md
+++ b/docs/MCP_TOOLS_REFERENCE.md
@@ -1,6 +1,6 @@
 # Open Stocks MCP — Tool Reference
 
-Total tools: 150
+Total tools: 152
 
 ## account_details
 
@@ -693,6 +693,27 @@ Get option expiration dates for a symbol.
 
     Args:
         symbol: Stock ticker symbol
+
+
+## schwab_option_orders
+
+Get option orders for a Schwab account.
+
+    Args:
+        account_hash: Account hash from get_schwab_account_numbers()
+        max_results: Maximum number of orders to return (default: 50)
+        status: Optional order status filter (e.g. FILLED, WORKING, CANCELED)
+
+
+## schwab_option_quote
+
+Get a single option contract quote by expiration, strike, and type (Schwab).
+
+    Args:
+        symbol: Stock ticker symbol
+        expiration_date: Expiration date in YYYY-MM-DD format
+        strike: Strike price (e.g. 170.0)
+        option_type: 'CALL' or 'PUT'
 
 
 ## schwab_option_sell_to_close

--- a/tests/unit/test_claude_guidance_docs.py
+++ b/tests/unit/test_claude_guidance_docs.py
@@ -1,0 +1,70 @@
+"""Regression checks for the project guidance loaded by Claude Code."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CLAUDE = ROOT / "CLAUDE.md"
+SERVER_APP = ROOT / "src" / "open_stocks_mcp" / "server" / "app.py"
+SCHWAB_SETUP = ROOT / "docs" / "SCHWAB_SETUP.md"
+
+
+def _claude_text() -> str:
+    return CLAUDE.read_text(encoding="utf-8")
+
+
+def _active_mcp_tool_count() -> int:
+    app_text = SERVER_APP.read_text(encoding="utf-8")
+    return len(re.findall(r"^@mcp\.tool\(\)", app_text, re.MULTILINE))
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_claude_documents_multi_broker_guidance() -> None:
+    text = _claude_text()
+
+    assert "Multi-Broker" in text
+    assert "Robinhood" in text
+    assert "Charles Schwab" in text
+
+    for env_var in (
+        "ROBINHOOD_USERNAME",
+        "ROBINHOOD_PASSWORD",
+        "SCHWAB_API_KEY",
+        "SCHWAB_APP_SECRET",
+        "SCHWAB_CALLBACK_URL",
+        "SCHWAB_TOKEN_PATH",
+    ):
+        assert env_var in text
+
+    assert "OAuth" in text
+    assert "~/.tokens/schwab_token.json" in text
+    assert "schwab_" in text
+    assert "live credentials" in text
+    assert "Schwab live journey tests" in text
+    assert "docs/SCHWAB_INTEGRATION_PLAN.md" in text
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_claude_links_existing_schwab_setup_guide() -> None:
+    text = _claude_text()
+
+    if SCHWAB_SETUP.exists():
+        assert "docs/SCHWAB_SETUP.md" in text
+        assert "#102" not in text
+    else:
+        assert "docs/SCHWAB_SETUP.md" not in text
+        assert "#102" in text
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_claude_reflects_active_mcp_tool_count() -> None:
+    text = _claude_text()
+
+    assert str(_active_mcp_tool_count()) in text


### PR DESCRIPTION
Closes #231

## Changes
- Update CLAUDE.md from Robinhood-only guidance to multi-broker Robinhood and Schwab guidance.
- Document Schwab environment variables, OAuth token flow, setup/design links, schwab_ tool prefix, and live journey credential requirements.
- Add CLAUDE.md regression tests and refresh docs/MCP_TOOLS_REFERENCE.md to the current 152-tool registry.

## Test plan
- uv run pytest tests/unit/test_claude_guidance_docs.py tests/unit/test_rate_limited_marker.py -q
- uv run pytest tests/unit/test_docs_build_target.py -q
- uv run ruff check tests/unit/test_claude_guidance_docs.py
- uv run python -c "import pathlib, re; app = pathlib.Path('src/open_stocks_mcp/server/app.py').read_text(); claude = pathlib.Path('CLAUDE.md').read_text(); count = len(re.findall(r'^@mcp\\.tool\\(\\)', app, re.MULTILINE)); assert str(count) in claude; print(count)"