### PR TITLE
test: mark slow subprocess tests with @pytest.mark.slow

### DIFF
--- a/tests/unit/test_rate_limited_marker.py
+++ b/tests/unit/test_rate_limited_marker.py
@@ -141,6 +141,7 @@ def test_rate_limited_tests_are_not_skipped_when_explicitly_selected(
 
 @pytest.mark.unit
 @pytest.mark.journey_system
+@pytest.mark.slow
 def test_rate_limited_collection_finds_live_api_tests() -> None:
     result = subprocess.run(
         [
@@ -167,6 +168,7 @@ def test_rate_limited_collection_finds_live_api_tests() -> None:
 
 @pytest.mark.unit
 @pytest.mark.journey_system
+@pytest.mark.slow
 def test_rate_limited_collection_nodeids() -> None:
     """Assert the exact set of live-API tests selected by -m rate_limited."""
     result = subprocess.run(
@@ -220,6 +222,7 @@ def test_rate_limited_docs_are_present() -> None:
 
 @pytest.mark.unit
 @pytest.mark.journey_system
+@pytest.mark.slow
 def test_run_rate_limited_env_can_include_marked_tests() -> None:
     env = {**os.environ, "RUN_RATE_LIMITED": "1"}
     result = subprocess.run(
@@ -279,3 +282,20 @@ def test_pytester_explicit_m_not_rate_limited_selects_unmarked(
     result = pytester.runpytest("-m", "not rate_limited")
 
     result.assert_outcomes(passed=1, deselected=1)
+
+@pytest.mark.unit
+def test_subprocess_rate_limited_marker_tests_are_marked_slow() -> None:
+    """Ensure subprocess tests are marked slow to avoid running in fast sessions."""
+    from tests.unit.test_rate_limited_marker import (
+        test_rate_limited_collection_finds_live_api_tests,
+        test_rate_limited_collection_nodeids,
+        test_run_rate_limited_env_can_include_marked_tests,
+    )
+
+    for test_func in [
+        test_rate_limited_collection_finds_live_api_tests,
+        test_rate_limited_collection_nodeids,
+        test_run_rate_limited_env_can_include_marked_tests,
+    ]:
+        markers = {m.name for m in getattr(test_func, "pytestmark", [])}
+        assert "slow" in markers, f"{test_func.__name__} is missing @pytest.mark.slow"


### PR DESCRIPTION
Closes #251

## Changes
- Added `@pytest.mark.slow` to three subprocess-based tests in `tests/unit/test_rate_limited_marker.py`:
  - `test_rate_limited_collection_finds_live_api_tests`
  - `test_rate_limited_collection_nodeids`
  - `test_run_rate_limited_env_can_include_marked_tests`
- Added a marker-regression test `test_subprocess_rate_limited_marker_tests_are_marked_slow` to ensure these tests remain marked as slow.

## Test plan
- Verified that `test_subprocess_rate_limited_marker_tests_are_marked_slow` fails before adding the markers and passes after.
- Verified that `uv run pytest -m "not slow and not exception_test" tests/unit/test_rate_limited_marker.py --collect-only -q` now correctly deselects the three slow tests.
- Verified that the full test file `tests/unit/test_rate_limited_marker.py` still passes.