### PR TITLE
feat: add MCP tool execution limits and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ The `/metrics` endpoint exposes:
 Distributed tracing setup (OpenTelemetry, Jaeger, Tempo):
 - [docs/OPENTELEMETRY_TRACING.md](docs/OPENTELEMETRY_TRACING.md)
 
+### MCP Tool Execution Timeout
+
+Each MCP `tools/call` invocation is bounded by a configurable deadline. Tools that exceed the
+deadline return a structured JSON error instead of blocking the server indefinitely.
+
+- **YAML key**: `timeout.tool_execution_timeout_seconds` (default: `30`)
+- **Environment override**: `OPEN_STOCKS_MCP_TOOL_EXECUTION_TIMEOUT_SECONDS` (e.g., `60`)
+
+When a tool times out its response body is:
+```json
+{
+  "status": "error",
+  "error_type": "ToolExecutionTimeout",
+  "failure_class": "timeout",
+  "tool": "<tool_name>",
+  "timeout_seconds": 30,
+  "error": "Tool '...' exceeded the 30s execution limit"
+}
+```
+The MCP result has `isError: true`; HTTP `/mcp` returns status 200 (not 500) so the
+client can inspect the structured error. Broker-level request timeouts (Robinhood 16 s,
+Schwab 30 s) remain in effect independently and count toward this deadline.
+
 ### Operational Circuit Breaker Defaults
 
 Broker call protection is enabled by default and reports state in MCP `health_check`,

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -25,6 +25,11 @@ cache:
   ttl_account_seconds: 60
   max_size: 1024
 
+timeout:
+  # Maximum seconds a single MCP tool call may run before returning a structured
+  # timeout error. Override at runtime with OPEN_STOCKS_MCP_TOOL_EXECUTION_TIMEOUT_SECONDS.
+  tool_execution_timeout_seconds: 30
+
 circuit_breaker:
   enabled: true
   failure_threshold: 5

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -204,6 +204,7 @@ class RetryConfig:
 @dataclass
 class TimeoutConfig:
     request_timeout_seconds: float = 120.0
+    tool_execution_timeout_seconds: float = 30.0
 
 
 @dataclass
@@ -518,7 +519,20 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
             request_timeout_seconds=_parse_float(
                 os.getenv("OPEN_STOCKS_MCP_HTTP_REQUEST_TIMEOUT_SECONDS", "120.0"),
                 "OPEN_STOCKS_MCP_HTTP_REQUEST_TIMEOUT_SECONDS",
-            )
+            ),
+            tool_execution_timeout_seconds=_parse_float(
+                os.getenv(
+                    "OPEN_STOCKS_MCP_TOOL_EXECUTION_TIMEOUT_SECONDS",
+                    str(
+                        (
+                            raw.get("timeout", {})
+                            if isinstance(raw.get("timeout"), dict)
+                            else {}
+                        ).get("tool_execution_timeout_seconds", 30.0)
+                    ),
+                ),
+                "OPEN_STOCKS_MCP_TOOL_EXECUTION_TIMEOUT_SECONDS",
+            ),
         ),
         circuit_breaker=CircuitBreakerConfig(
             enabled=_parse_bool(

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -15,6 +15,7 @@ from open_stocks_mcp.brokers.robinhood import RobinhoodBroker
 from open_stocks_mcp.brokers.schwab import SchwabBroker
 from open_stocks_mcp.config import ServerConfig, load_config
 from open_stocks_mcp.logging_config import logger, setup_logging
+from open_stocks_mcp.server.tool_execution_limits import install_tool_execution_limit
 from open_stocks_mcp.server.tool_helpers import (
     get_broker_status_data,
     get_health_check_data,
@@ -2040,6 +2041,8 @@ def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:
     )
     setup_tracing(config)
     instrument_mcp_tool_calls(mcp)
+    if config.timeout is not None:
+        install_tool_execution_limit(mcp, config.timeout.tool_execution_timeout_seconds)
     return mcp
 
 

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -127,6 +127,20 @@ READ_ONLY_HTTP_TOOL_NAMES = frozenset(
 )
 
 
+def _tool_result_error_type(result: dict[str, Any]) -> str:
+    """Extract error_type from a serialized tool result's content."""
+    content_list = result.get("content", [])
+    if content_list:
+        text = content_list[0].get("text", "")
+        try:
+            data = json.loads(text)
+            if isinstance(data, dict) and "error_type" in data:
+                return str(data["error_type"])
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            pass
+    return "ToolExecutionError"
+
+
 def _mcp_log_value(value: object) -> str:
     if value is None:
         return "null"
@@ -721,11 +735,12 @@ def create_http_server(
 
                     duration = time.perf_counter() - start
                     is_error = bool(result.get("isError", False))
+                    error_type = _tool_result_error_type(result) if is_error else None
                     await metrics_collector.record_api_call(
                         tool_name=tool_name,
                         duration=duration,
                         success=not is_error,
-                        error_type="ToolExecutionError" if is_error else None,
+                        error_type=error_type,
                     )
 
                 elif method == "notifications/initialized":

--- a/src/open_stocks_mcp/server/tool_execution_limits.py
+++ b/src/open_stocks_mcp/server/tool_execution_limits.py
@@ -10,6 +10,7 @@ import mcp.types
 from mcp.server.fastmcp import FastMCP
 
 _WRAPPER_ATTR = "_tool_execution_limit_installed"
+_TIMEOUT_ATTR = "_tool_execution_limit_timeout_seconds"
 
 
 def install_tool_execution_limit(mcp_server: FastMCP, timeout_seconds: float) -> None:
@@ -18,15 +19,18 @@ def install_tool_execution_limit(mcp_server: FastMCP, timeout_seconds: float) ->
     Idempotent: calling this more than once does not stack wrappers.
     """
     if getattr(mcp_server, _WRAPPER_ATTR, False):
+        setattr(mcp_server, _TIMEOUT_ATTR, timeout_seconds)
         return
 
+    setattr(mcp_server, _TIMEOUT_ATTR, timeout_seconds)
     original_call_tool = mcp_server.call_tool
 
     async def _bounded_call_tool(tool_name: str, arguments: dict[str, Any]) -> Any:
+        active_timeout = float(getattr(mcp_server, _TIMEOUT_ATTR, timeout_seconds))
         try:
             return await asyncio.wait_for(
                 original_call_tool(tool_name, arguments),
-                timeout=timeout_seconds,
+                timeout=active_timeout,
             )
         except TimeoutError:
             error_data = {
@@ -34,10 +38,10 @@ def install_tool_execution_limit(mcp_server: FastMCP, timeout_seconds: float) ->
                 "error_type": "ToolExecutionTimeout",
                 "failure_class": "timeout",
                 "tool": tool_name,
-                "timeout_seconds": timeout_seconds,
+                "timeout_seconds": active_timeout,
                 "error": (
                     f"Tool '{tool_name}' exceeded the "
-                    f"{timeout_seconds}s execution limit"
+                    f"{active_timeout}s execution limit"
                 ),
             }
             return mcp.types.CallToolResult(

--- a/src/open_stocks_mcp/server/tool_execution_limits.py
+++ b/src/open_stocks_mcp/server/tool_execution_limits.py
@@ -1,0 +1,54 @@
+"""MCP tool execution deadline enforcement."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import mcp.types
+from mcp.server.fastmcp import FastMCP
+
+_WRAPPER_ATTR = "_tool_execution_limit_installed"
+
+
+def install_tool_execution_limit(mcp_server: FastMCP, timeout_seconds: float) -> None:
+    """Wrap call_tool to apply a per-call asyncio deadline.
+
+    Idempotent: calling this more than once does not stack wrappers.
+    """
+    if getattr(mcp_server, _WRAPPER_ATTR, False):
+        return
+
+    original_call_tool = mcp_server.call_tool
+
+    async def _bounded_call_tool(tool_name: str, arguments: dict[str, Any]) -> Any:
+        try:
+            return await asyncio.wait_for(
+                original_call_tool(tool_name, arguments),
+                timeout=timeout_seconds,
+            )
+        except TimeoutError:
+            error_data = {
+                "status": "error",
+                "error_type": "ToolExecutionTimeout",
+                "failure_class": "timeout",
+                "tool": tool_name,
+                "timeout_seconds": timeout_seconds,
+                "error": (
+                    f"Tool '{tool_name}' exceeded the "
+                    f"{timeout_seconds}s execution limit"
+                ),
+            }
+            return mcp.types.CallToolResult(
+                content=[
+                    mcp.types.TextContent(
+                        type="text",
+                        text=json.dumps(error_data),
+                    )
+                ],
+                isError=True,
+            )
+
+    mcp_server.call_tool = _bounded_call_tool  # type: ignore[assignment]
+    setattr(mcp_server, _WRAPPER_ATTR, True)

--- a/tests/server/test_tool_execution_limits.py
+++ b/tests/server/test_tool_execution_limits.py
@@ -63,6 +63,20 @@ async def test_install_is_idempotent(slow_mcp_server: FastMCP) -> None:
 
 @pytest.mark.unit
 @pytest.mark.journey_system
+async def test_reinstall_updates_timeout_value(slow_mcp_server: FastMCP) -> None:
+    install_tool_execution_limit(slow_mcp_server, timeout_seconds=20.0)
+    install_tool_execution_limit(slow_mcp_server, timeout_seconds=0.05)
+
+    result = await slow_mcp_server.call_tool("account_info", {})
+
+    assert result.isError is True
+    data = json.loads(result.content[0].text)
+    assert data["error_type"] == "ToolExecutionTimeout"
+    assert data["timeout_seconds"] == 0.05
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
 async def test_fast_tool_completes_normally() -> None:
     server = FastMCP("FastTest")
 

--- a/tests/server/test_tool_execution_limits.py
+++ b/tests/server/test_tool_execution_limits.py
@@ -1,0 +1,80 @@
+"""Tests for MCP tool execution deadline enforcement."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import mcp.types
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from open_stocks_mcp.server.tool_execution_limits import install_tool_execution_limit
+
+
+@pytest.fixture
+def slow_mcp_server() -> FastMCP:
+    server = FastMCP("SlowTest")
+
+    @server.tool()
+    async def account_info() -> dict[str, Any]:
+        await asyncio.sleep(10.0)
+        return {"result": {"status": "ok"}}
+
+    return server
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+async def test_slow_tool_returns_structured_timeout_error(
+    slow_mcp_server: FastMCP,
+) -> None:
+    install_tool_execution_limit(slow_mcp_server, timeout_seconds=0.05)
+
+    result = await slow_mcp_server.call_tool("account_info", {})
+
+    assert result.isError is True
+    assert len(result.content) == 1
+    data = json.loads(result.content[0].text)
+    assert data["error_type"] == "ToolExecutionTimeout"
+    assert data["tool"] == "account_info"
+    assert data["timeout_seconds"] == 0.05
+    assert data["status"] == "error"
+    assert data["failure_class"] == "timeout"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+async def test_install_is_idempotent(slow_mcp_server: FastMCP) -> None:
+    install_tool_execution_limit(slow_mcp_server, timeout_seconds=0.05)
+    install_tool_execution_limit(slow_mcp_server, timeout_seconds=0.05)
+
+    result = await slow_mcp_server.call_tool("account_info", {})
+
+    assert result.isError is True
+    content_text = result.content[0].text
+    data = json.loads(content_text)
+    # Exactly one timeout error, not a nested/doubled result
+    assert data["error_type"] == "ToolExecutionTimeout"
+    # The text should parse as flat dict, not nested
+    assert "content" not in data
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+async def test_fast_tool_completes_normally() -> None:
+    server = FastMCP("FastTest")
+
+    @server.tool()
+    async def account_info() -> dict[str, Any]:
+        return {"result": {"status": "ok"}}
+
+    install_tool_execution_limit(server, timeout_seconds=5.0)
+
+    result = await server.call_tool("account_info", {})
+
+    # Fast tool returns the normal call_tool result (not a timeout CallToolResult)
+    assert not (
+        isinstance(result, mcp.types.CallToolResult) and result.isError is True
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -280,3 +280,45 @@ feature_flags:
 
     with pytest.raises(ConfigError, match=r"brokers\.robinhood"):
         load_config(config_path=path)
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_timeout_tool_execution_timeout_seconds_parsed_from_yaml(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text("timeout:\n  tool_execution_timeout_seconds: 45.0")
+
+    cfg = load_config(config_path=path)
+
+    assert cfg.timeout is not None
+    assert cfg.timeout.tool_execution_timeout_seconds == 45.0
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_tool_execution_timeout_env_overrides_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text("timeout:\n  tool_execution_timeout_seconds: 45.0")
+    monkeypatch.setenv("OPEN_STOCKS_MCP_TOOL_EXECUTION_TIMEOUT_SECONDS", "99.0")
+
+    cfg = load_config(config_path=path)
+
+    assert cfg.timeout is not None
+    assert cfg.timeout.tool_execution_timeout_seconds == 99.0
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_tool_execution_timeout_defaults_to_30(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPEN_STOCKS_MCP_TOOL_EXECUTION_TIMEOUT_SECONDS", raising=False)
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.timeout is not None
+    assert cfg.timeout.tool_execution_timeout_seconds == 30.0

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -1,8 +1,10 @@
 """Fast unit tests for HTTP transport JSON-RPC and endpoint behavior."""
 
+import asyncio
+import json
 from collections.abc import Iterator
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -13,6 +15,7 @@ from open_stocks_mcp.server.http_transport import (
     MAX_MCP_REQUEST_BODY_SIZE,
     create_http_server,
 )
+from open_stocks_mcp.server.tool_execution_limits import install_tool_execution_limit
 
 
 @pytest.fixture(scope="session")
@@ -179,3 +182,79 @@ class TestHttpTransportUnit:
         )
         assert response.status_code in {200, 204}
         assert "POST" in response.headers["access-control-allow-methods"]
+
+
+@pytest.fixture(scope="module")
+def slow_timeout_mcp_server() -> FastMCP:
+    """FastMCP server with a slow account_info tool and tiny execution timeout."""
+    server = FastMCP("SlowTimeoutTest")
+
+    @server.tool()
+    async def account_info() -> dict[str, Any]:
+        await asyncio.sleep(10.0)
+        return {"result": {"status": "ok"}}
+
+    install_tool_execution_limit(server, timeout_seconds=0.05)
+    return server
+
+
+@pytest.fixture
+def timeout_client(slow_timeout_mcp_server: FastMCP) -> Iterator[TestClient]:
+    with TestClient(create_http_server(slow_timeout_mcp_server)) as test_client:
+        yield test_client
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+class TestHttpTransportToolTimeout:
+    def test_tools_call_timeout_returns_200_with_is_error_true(
+        self, timeout_client: TestClient
+    ) -> None:
+        mock_collector = AsyncMock()
+        with patch(
+            "open_stocks_mcp.server.http_transport.get_metrics_collector",
+            return_value=mock_collector,
+        ):
+            response = timeout_client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {"name": "account_info", "arguments": {}},
+                    "id": 1,
+                },
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "error" not in body, f"Unexpected JSON-RPC error: {body}"
+        assert body["result"]["isError"] is True
+        content = body["result"]["content"]
+        assert len(content) >= 1
+        data = json.loads(content[0]["text"])
+        assert data["error_type"] == "ToolExecutionTimeout"
+        assert data["tool"] == "account_info"
+        assert data["failure_class"] == "timeout"
+
+    def test_tools_call_timeout_records_metrics_as_failure(
+        self, timeout_client: TestClient
+    ) -> None:
+        mock_collector = AsyncMock()
+        with patch(
+            "open_stocks_mcp.server.http_transport.get_metrics_collector",
+            return_value=mock_collector,
+        ):
+            timeout_client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {"name": "account_info", "arguments": {}},
+                    "id": 2,
+                },
+            )
+
+        mock_collector.record_api_call.assert_awaited_once()
+        call_kwargs = mock_collector.record_api_call.call_args.kwargs
+        assert call_kwargs["success"] is False
+        assert call_kwargs["error_type"] == "ToolExecutionTimeout"


### PR DESCRIPTION
Closes #210

## Changes
- Add `TimeoutConfig.tool_execution_timeout_seconds` (default 30s) to config with YAML (`timeout.tool_execution_timeout_seconds`) and env (`OPEN_STOCKS_MCP_TOOL_EXECUTION_TIMEOUT_SECONDS`) support
- Add `src/open_stocks_mcp/server/tool_execution_limits.py` with idempotent `install_tool_execution_limit` that wraps `FastMCP.call_tool` with `asyncio.wait_for` and returns a structured `CallToolResult` timeout error (`isError=True`, `error_type="ToolExecutionTimeout"`) instead of blocking indefinitely
- Wire the wrapper into `create_mcp_server()` in `app.py` using the configured timeout
- Update HTTP transport to extract `error_type` from structured content, reporting `"ToolExecutionTimeout"` in metrics for timed-out tool calls (instead of the generic `"ToolExecutionError"`)
- Document `timeout.tool_execution_timeout_seconds` in `README.md` and `config.yaml.example`

## Test plan
- `uv run pytest tests/unit/test_config.py tests/server/test_tool_execution_limits.py tests/unit/test_http_transport.py -q` — 45 tests pass covering config parsing, direct MCP call timeout enforcement, and HTTP JSON-RPC timeout response behavior
- `uv run ruff check src/open_stocks_mcp/config.py src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_execution_limits.py` — no lint errors
- `uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/server/app.py src/open_stocks_mcp/server/http_transport.py src/open_stocks_mcp/server/tool_execution_limits.py` — 0 errors
- `uv run pytest -m "not slow and not exception_test" -q` — 1166 passed, 10 pre-existing failures unchanged