### PR TITLE
fix: drop redundant auth retry override

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -181,7 +181,6 @@ class RetryConfig:
     initial_delay: float = 1.0
     backoff_factor: float = 2.0
     auth_max_retries: int = 1
-    authentication_max_retries: int | None = None
     network_max_retries: int | None = None
     rate_limit_max_retries: int | None = None
     api_max_retries: int | None = None
@@ -189,7 +188,6 @@ class RetryConfig:
 
     def max_retries_for(self, error_type: str) -> int:
         overrides = {
-            "authentication": self.authentication_max_retries,
             "network": self.network_max_retries,
             "rate_limit": self.rate_limit_max_retries,
             "api": self.api_max_retries,
@@ -499,9 +497,6 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
             auth_max_retries=_parse_int(
                 os.getenv("OPEN_STOCKS_MCP_RETRY_AUTH_MAX_RETRIES", "1"),
                 "OPEN_STOCKS_MCP_RETRY_AUTH_MAX_RETRIES",
-            ),
-            authentication_max_retries=_env_optional_int(
-                "OPEN_STOCKS_MCP_RETRY_AUTHENTICATION_MAX_RETRIES"
             ),
             network_max_retries=_env_optional_int(
                 "OPEN_STOCKS_MCP_RETRY_NETWORK_MAX_RETRIES"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import fields
 from pathlib import Path
 
 import pytest
 
-from open_stocks_mcp.config import ConfigError, load_config
+from open_stocks_mcp.config import ConfigError, RetryConfig, load_config
 
 
 @pytest.mark.unit
@@ -159,6 +160,25 @@ def test_missing_file_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.cache.ttl_account_seconds > 0
     assert cfg.cache.max_size > 0
     assert cfg.feature_flags.enable_cache is True
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_authentication_retry_count_uses_generic_max_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    retry_fields = {field.name for field in fields(RetryConfig)}
+    retry = RetryConfig(max_retries=3)
+
+    assert "authentication_max_retries" not in retry_fields
+    assert retry.max_retries_for("authentication") == 3
+
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_MAX_RETRIES", "3")
+    monkeypatch.setenv("OPEN_STOCKS_MCP_RETRY_AUTHENTICATION_MAX_RETRIES", "9")
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.retry.max_retries_for("authentication") == 3
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #257

## Changes
- Removed the dead `RetryConfig.authentication_max_retries` field and authentication-specific retry override.
- Stopped reading `OPEN_STOCKS_MCP_RETRY_AUTHENTICATION_MAX_RETRIES` in `load_config()`.
- Added a regression test covering field removal and authentication fallback to generic `max_retries`.

## Test plan
- `uv run pytest tests/unit/test_config.py -q --tb=short`
- `uv run ruff check src/open_stocks_mcp/config.py tests/unit/test_config.py`
- `uv run mypy src/open_stocks_mcp/config.py --show-error-codes --no-error-summary`
- `uv run pytest tests/unit/test_error_handling.py -q --tb=short`

## Notes
- `uv run pytest tests/unit/ -q --tb=short` was run and currently fails in unrelated cache, dependency pin, missing `SCHWAB_STATUS.md`, and docs reference checks; this PR only changes retry config and config tests.