### PR TITLE
fix: wire notebook 01 to MCP client session and guard bare tool calls

### DIFF
--- a/examples/notebooks/01_market_data_quickstart.ipynb
+++ b/examples/notebooks/01_market_data_quickstart.ipynb
@@ -4,12 +4,12 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Prerequisites & Safety\\n",
-        "\\n",
-        "Required environment variables:\\n",
-        "- ROBINHOOD_USERNAME\\n",
-        "- ROBINHOOD_PASSWORD\\n",
-        "\\n",
+        "# Prerequisites & Safety\n",
+        "\n",
+        "Required environment variables:\n",
+        "- ROBINHOOD_USERNAME\n",
+        "- ROBINHOOD_PASSWORD\n",
+        "\n",
         "This notebook uses read-only market and portfolio tools. No order placement calls are included."
       ]
     },
@@ -17,11 +17,11 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Connect to the MCP server\\n",
-        "\\n",
-        "Start the server first:\\n",
-        "```bash\\n",
-        "open-stocks-mcp-server --transport http --port 3001\\n",
+        "## Connect to the MCP server\n",
+        "\n",
+        "Start the server first:\n",
+        "```bash\n",
+        "open-stocks-mcp-server --transport http --port 3001\n",
         "```"
       ]
     },
@@ -31,11 +31,12 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import os\\n",
-        "from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StreamableHTTPConnectionParams\\n",
-        "\\n",
-        "http_url = os.environ.get(\"MCP_HTTP_URL\", \"http://localhost:3001/mcp\")\\n",
-        "toolset = MCPToolset(connection_params=StreamableHTTPConnectionParams(url=http_url))"
+        "import os\n",
+        "\n",
+        "from mcp import ClientSession\n",
+        "from mcp.client.streamable_http import streamablehttp_client\n",
+        "\n",
+        "mcp_http_url = os.environ.get(\"MCP_HTTP_URL\", \"http://localhost:3001/mcp\")"
       ]
     },
     {
@@ -44,19 +45,23 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Example read-only calls\\n",
-        "stock_price(\"AAPL\")\\n",
-        "market_hours()\\n",
-        "portfolio()"
+        "async with streamablehttp_client(mcp_http_url) as (read, write, _):\n",
+        "    async with ClientSession(read, write) as session:\n",
+        "        await session.initialize()\n",
+        "        aapl_quote = await session.call_tool(\"stock_price\", {\"symbol\": \"AAPL\"})\n",
+        "        market_status = await session.call_tool(\"market_hours\", {})\n",
+        "        portfolio_snapshot = await session.call_tool(\"portfolio\", {})\n",
+        "\n",
+        "aapl_quote, market_status, portfolio_snapshot"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Next steps\\n",
-        "\\n",
-        "- Review [tools.md](../../docs/api/tools.md) for full tool coverage.\\n",
+        "## Next steps\n",
+        "\n",
+        "- Review [tools.md](../../docs/api/tools.md) for full tool coverage.\n",
         "- Continue with `02_trading_safe_dry_run.ipynb` for safe trading payload patterns."
       ]
     }

--- a/tests/unit/test_example_notebooks.py
+++ b/tests/unit/test_example_notebooks.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import nbformat
@@ -11,6 +12,8 @@ _REPO_ROOT = Path(__file__).parents[2]
 NOTEBOOK_DIR = _REPO_ROOT / "examples" / "notebooks"
 PORTFOLIO_NOTEBOOK = NOTEBOOK_DIR / "portfolio_snapshot.ipynb"
 OPTIONS_NOTEBOOK = NOTEBOOK_DIR / "options_analysis.ipynb"
+QUICKSTART_NOTEBOOK = NOTEBOOK_DIR / "01_market_data_quickstart.ipynb"
+DRY_RUN_NOTEBOOK = NOTEBOOK_DIR / "02_trading_safe_dry_run.ipynb"
 
 
 async def get_registered_tool_names() -> set[str]:
@@ -62,3 +65,29 @@ async def test_notebook_structure(notebook_path: Path) -> None:
     assert has_registered_tool, (
         f"Notebook {notebook_path} missing a code cell referencing a registered MCP tool name"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "notebook_path",
+    [PORTFOLIO_NOTEBOOK, OPTIONS_NOTEBOOK, QUICKSTART_NOTEBOOK, DRY_RUN_NOTEBOOK],
+)
+async def test_notebook_no_bare_tool_calls(notebook_path: Path) -> None:
+    """No code cell line may begin with a bare MCP tool name followed by '('."""
+    assert notebook_path.exists(), f"Notebook {notebook_path} does not exist"
+    nb = nbformat.read(notebook_path, as_version=4)  # type: ignore[no-untyped-call]
+    live_tool_names = await get_registered_tool_names()
+    code_cells = [cell for cell in nb.cells if cell.cell_type == "code"]
+
+    for cell in code_cells:
+        # Notebooks may store newlines as literal \n or as actual newlines; handle both.
+        lines = re.split(r"\\n|\n", cell.source)
+        for line in lines:
+            stripped = line.strip()
+            for name in live_tool_names:
+                if re.match(rf"{re.escape(name)}\s*\(", stripped):
+                    pytest.fail(
+                        f"Notebook {notebook_path}: bare tool call '{name}(' in code cell. "
+                        f"Use session.call_tool('{name}', ...) instead.\n"
+                        f"  Line: {line!r}"
+                    )


### PR DESCRIPTION
Closes #248

## Changes
- Rewrote `examples/notebooks/01_market_data_quickstart.ipynb` to use `streamablehttp_client` + `ClientSession` pattern (same as `02_trading_safe_dry_run.ipynb`), replacing the broken `MCPToolset` import and bare `stock_price("AAPL")` / `market_hours()` / `portfolio()` calls with `await session.call_tool(...)` invocations
- Extended `tests/unit/test_example_notebooks.py` with `QUICKSTART_NOTEBOOK` and `DRY_RUN_NOTEBOOK` constants and a new `test_notebook_no_bare_tool_calls` test parametrized over all four notebooks; the test splits cell source on both literal `\n` and actual newlines to handle the notebook storage format, then fails if any stripped line starts with a registered MCP tool name followed by `(`

## Test plan
- `uv run pytest tests/unit/test_example_notebooks.py -q` — 6 passed
- `uv run python -c "import nbformat; nbformat.read('examples/notebooks/01_market_data_quickstart.ipynb', as_version=4)"` — valid nbformat v4
- `uv run jupyter nbconvert --to notebook --stdout examples/notebooks/01_market_data_quickstart.ipynb >/dev/null` — exit 0
- `uv run ruff check tests/unit/test_example_notebooks.py` — no lint errors