### PR TITLE
docs: fix MIT License references to Apache License 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and debugging recip
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
+Apache License 2.0 - see [LICENSE](LICENSE) file for details.
 
 ## Security
 

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -144,4 +144,4 @@ RUN_RATE_LIMITED=1 pytest        # Include rate-limited tests in a full run
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0.


### PR DESCRIPTION
Closes #261

## Changes
- Updated `README.md` License section: \"MIT License\" → \"Apache License 2.0\"
- Updated `contributing/README.md` contributor agreement: \"MIT License\" → \"Apache License 2.0\"

## Test plan
- `grep -rn 'MIT License' . --include='*.md'` returns zero matches
- `head -2 LICENSE` shows \"Apache License, Version 2.0\"
- `grep 'Apache Software License' pyproject.toml` confirms Apache classifier still present