### PR TITLE
perf: cache retry config in execute_with_retry (#258)

### DIFF
--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -5,7 +5,7 @@ import functools
 from collections.abc import Callable
 from typing import Any
 
-from open_stocks_mcp.config import load_config
+from open_stocks_mcp.config import RetryConfig, load_config
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.exceptions import (
     AuthenticationError,
@@ -15,6 +15,14 @@ from open_stocks_mcp.tools.exceptions import (
 )
 
 DEFAULT_MAX_RETRIES = 3
+
+
+@functools.lru_cache(maxsize=1)
+def _get_retry_config() -> RetryConfig:
+    config = load_config().retry
+    if config is None:
+        raise RuntimeError("Retry configuration unavailable")
+    return config
 
 
 async def execute_with_retry(
@@ -65,9 +73,7 @@ async def execute_with_retry(
     from open_stocks_mcp.brokers.session_state import get_session_manager
     from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
     last_exception = None
-    retry_config = load_config().retry
-    if retry_config is None:
-        raise RuntimeError("Retry configuration unavailable")
+    retry_config = _get_retry_config()
     configured_max_retries = (
         retry_config.max_retries if max_retries is None else max_retries
     )

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -10,7 +10,9 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 from mcp.server.fastmcp import FastMCP
 
+import open_stocks_mcp.tools.retry as retry_module
 from open_stocks_mcp.brokers import session_state as session_manager_module
+from open_stocks_mcp.config import RetryConfig
 from open_stocks_mcp.server.app import mcp as production_mcp
 from open_stocks_mcp.tools.error_handling import (
     APIError,
@@ -41,6 +43,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.journey_system]
 def _patch_retry_dependencies(
     monkeypatch: pytest.MonkeyPatch,
 ) -> list[float]:
+    retry_module._get_retry_config.cache_clear()
     session_manager = Mock()
     session_manager.update_last_successful_call = Mock()
     session_manager.refresh_session = Mock()
@@ -531,6 +534,26 @@ async def test_execute_with_retry_explicit_arguments_override_config(
 
     assert len(attempts) == 1
     assert sleep_calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_caches_retry_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    retry_module._get_retry_config.cache_clear()
+    mock_load_config = Mock(
+        return_value=SimpleNamespace(retry=RetryConfig(max_retries=0, initial_delay=0.01, backoff_factor=2.0))
+    )
+    monkeypatch.setattr("open_stocks_mcp.tools.retry.load_config", mock_load_config)
+    _patch_retry_dependencies(monkeypatch)
+
+    def ok() -> str:
+        return "ok"
+
+    await execute_with_retry(ok)
+    await execute_with_retry(ok)
+
+    mock_load_config.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #258

## Changes
- Added `_get_retry_config()` helper in `src/open_stocks_mcp/tools/retry.py` decorated with `@functools.lru_cache(maxsize=1)` that wraps `load_config().retry` and raises `RuntimeError` if the retry section is absent
- Replaced the inline `load_config().retry` call and its `None` guard in `execute_with_retry` with a call to `_get_retry_config()`, so retry defaults are read from env vars once per process instead of on every invocation
- Updated `_patch_retry_dependencies` in `tests/unit/test_error_handling.py` to call `_get_retry_config.cache_clear()` so env-mutating tests pick up fresh config
- Added `test_execute_with_retry_caches_retry_config` proving that two back-to-back `execute_with_retry` calls result in exactly one `load_config` invocation

## Test plan
- `uv run pytest tests/unit/test_error_handling.py -k "configured_retry_defaults or per_error_class_retry_override or explicit_arguments_override_config or caches_retry_config" -q --tb=line` — 4 passed
- `uv run pytest tests/unit/test_error_handling.py tests/unit/test_circuit_breaker.py -q --tb=line` — 111 passed
- `uv run ruff check src/open_stocks_mcp/tools/retry.py tests/unit/test_error_handling.py` — clean
- `uv run mypy src/open_stocks_mcp/tools/retry.py` — no issues