### PR TITLE
fix: add integration marker to multi-broker tests

### DIFF
--- a/tests/integration/test_multi_broker.py
+++ b/tests/integration/test_multi_broker.py
@@ -21,6 +21,8 @@ from open_stocks_mcp.server.tool_helpers import (
 )
 from tests.conftest import MockBroker
 
+pytestmark = pytest.mark.integration
+
 
 class TestMultiBrokerIntegration:
     """Test multi-broker scenarios."""


### PR DESCRIPTION
Closes #274

## Changes
- Added `pytestmark = pytest.mark.integration` to `tests/integration/test_multi_broker.py` so that the 26 multi-broker integration tests are properly excluded by marker-based filters (`-m "not integration"`)

## Context
The 8 test failures described in #274 (registry API drift, broker attribute drift, Schwab module import path) have already been fixed on `main`. The remaining issue was marker hygiene: the file lacked `@pytest.mark.integration`, causing these integration tests to run even when explicitly excluded.

## Test plan
- `uv run pytest tests/integration/test_multi_broker.py -v --timeout=15 -o "addopts="` — all 26 tests pass
- `uv run pytest tests/integration/test_multi_broker.py --collect-only -q -m "not integration" -o "addopts="` — 26 deselected, none collected
- `uv run pytest tests/unit/test_broker_registry.py tests/unit/test_broker_base.py tests/unit/test_schwab_broker.py -q -o "addopts="` — 79 related tests pass
- `uv run ruff check tests/integration/test_multi_broker.py` — clean