### PR TITLE
fix: make pytest collection find src package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+pythonpath = ["src"]
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,16 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
+try:
+    from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
+except ImportError:
+    print(
+        "\n\033[91mERROR: open_stocks_mcp is not importable.\033[0m\n"
+        "Run setup with:   uv sync\n"
+        "Run tests with:   uv run pytest\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 class MockBroker(BaseBroker):


### PR DESCRIPTION
Closes #263

## Changes
- Added `pythonpath = ["src"]` under `[tool.pytest.ini_options]` in `pyproject.toml` so bare pytest can import the src-layout package.
- Added a defensive import guard in `tests/conftest.py` for `open_stocks_mcp` that prints clear setup guidance (`uv sync`, `uv run pytest`) before exiting.

## Test plan
- `pytest --collect-only -q` (fails in system Python due to missing pytest-timeout plugin options in addopts)
- `pytest --collect-only -q -o addopts=''` (collects tests; no `open_stocks_mcp` import error)
- `uv run pytest --collect-only -q` (1303 selected tests collected; no collection errors)
- `uv run ruff check pyproject.toml tests/conftest.py` (passes)
- `uv run pytest -x -q --tb=line` (stops on unrelated pre-existing failure in `tests/unit/test_cache.py::TestCachedAsyncDecorator::test_cache_disabled_bypasses_cache_and_metrics`)
