### PR TITLE
chore: ignore foreman agent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,6 +388,7 @@ timelapse-runs/
 .dolt/
 .beads-credential-key
 .agentshore/
+.foreman/
 .agents/
 .beads/
 agentshore.yaml


### PR DESCRIPTION
Closes #281

## Changes
- Added .foreman/ to the repository .gitignore alongside other local agent state directories.

## Test plan
- git check-ignore -v .foreman/contexts/example/play-1.json
- git ls-files .foreman
- git diff --name-only origin/main...HEAD
- git diff --check origin/main...HEAD