### PR TITLE
feat: implement typed broker configuration models from Schwab integration plan

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+_config_logger = logging.getLogger(__name__)
 
 
 class ConfigError(ValueError):
@@ -250,6 +253,39 @@ class OtelConfig:
 
 
 @dataclass
+class RobinhoodConfig:
+    """Robinhood broker credentials and session settings."""
+
+    username: str | None = None
+    password: str | None = None
+    pickle_name: str = "robinhood"
+    session_timeout_hours: int = 23
+
+
+@dataclass
+class SchwabConfig:
+    """Schwab broker credentials and OAuth settings."""
+
+    api_key: str | None = None
+    app_secret: str | None = None
+    callback_url: str = "https://127.0.0.1:8182/"
+    token_path: str | None = None
+
+
+_KNOWN_BROKERS: frozenset[str] = frozenset({"robinhood", "schwab"})
+
+
+@dataclass
+class BrokerSettings:
+    """Multi-broker configuration surface."""
+
+    robinhood: RobinhoodConfig = field(default_factory=RobinhoodConfig)
+    schwab: SchwabConfig = field(default_factory=SchwabConfig)
+    enabled_brokers: list[str] = field(default_factory=lambda: ["robinhood"])
+    default_broker: str | None = None
+
+
+@dataclass
 class ServerConfig:
     name: str = "Open Stocks MCP"
     environment: str = "default"
@@ -268,6 +304,7 @@ class ServerConfig:
     feature_flag_definitions: dict[str, FeatureFlagDefinition] = field(
         default_factory=dict
     )
+    brokers: BrokerSettings = field(default_factory=BrokerSettings)
     schwab_api_key: str | None = None
     schwab_app_secret: str | None = None
     schwab_callback_url: str = "https://127.0.0.1:8182/"
@@ -295,6 +332,108 @@ class ServerConfig:
     def alerting(self) -> AlertConfig:
         """Compatibility alias for issue docs that refer to server.alerting."""
         return self.alerts
+
+
+def _parse_enabled_brokers_config(
+    raw: str | None, yaml_list: list[str] | None
+) -> list[str]:
+    """Parse ENABLED_BROKERS env var or YAML list into a normalized broker list.
+
+    Unknown names are warned-and-dropped. Empty result is allowed.
+    """
+    if raw is not None:
+        tokens = [t.strip().lower() for t in raw.split(",") if t.strip()]
+    elif yaml_list is not None:
+        tokens = [str(t).strip().lower() for t in yaml_list if str(t).strip()]
+    else:
+        return ["robinhood"]
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for name in tokens:
+        if name in seen:
+            continue
+        seen.add(name)
+        if name not in _KNOWN_BROKERS:
+            _config_logger.warning(
+                "Unknown broker '%s' in ENABLED_BROKERS; ignoring. Known brokers: %s",
+                name,
+                sorted(_KNOWN_BROKERS),
+            )
+        else:
+            result.append(name)
+    return result
+
+
+def _parse_broker_settings(brokers_yaml: dict[str, Any]) -> BrokerSettings:
+    """Build a BrokerSettings from YAML section + env var overrides."""
+    rh_yaml = brokers_yaml.get("robinhood", {})
+    if not isinstance(rh_yaml, dict):
+        rh_yaml = {}
+    sc_yaml = brokers_yaml.get("schwab", {})
+    if not isinstance(sc_yaml, dict):
+        sc_yaml = {}
+
+    rh_username = (
+        os.getenv("ROBINHOOD_USERNAME") or str(rh_yaml.get("username", "")) or None
+    )
+    rh_password = (
+        os.getenv("ROBINHOOD_PASSWORD") or str(rh_yaml.get("password", "")) or None
+    )
+    rh_pickle = os.getenv("ROBINHOOD_PICKLE_NAME") or str(
+        rh_yaml.get("pickle_name", "robinhood")
+    )
+    rh_timeout_raw = os.getenv("ROBINHOOD_SESSION_TIMEOUT_HOURS") or rh_yaml.get(
+        "session_timeout_hours", 23
+    )
+    try:
+        rh_timeout = int(rh_timeout_raw)
+    except (TypeError, ValueError):
+        rh_timeout = 23
+
+    sc_api_key = os.getenv("SCHWAB_API_KEY") or str(sc_yaml.get("api_key", "")) or None
+    sc_app_secret = (
+        os.getenv("SCHWAB_APP_SECRET") or str(sc_yaml.get("app_secret", "")) or None
+    )
+    sc_callback_url = (
+        os.getenv("SCHWAB_CALLBACK_URL")
+        or str(sc_yaml.get("callback_url", ""))
+        or "https://127.0.0.1:8182/"
+    )
+    sc_token_path = (
+        os.getenv("SCHWAB_TOKEN_PATH") or str(sc_yaml.get("token_path", "")) or None
+    )
+
+    raw_enabled = os.getenv("ENABLED_BROKERS")
+    yaml_enabled: list[str] | None = None
+    if "enabled_brokers" in brokers_yaml:
+        raw_list = brokers_yaml["enabled_brokers"]
+        if isinstance(raw_list, list):
+            yaml_enabled = [str(x) for x in raw_list]
+    if raw_enabled is None and yaml_enabled is None:
+        enabled = ["robinhood"]
+    else:
+        enabled = _parse_enabled_brokers_config(raw_enabled, yaml_enabled)
+
+    raw_default = os.getenv("DEFAULT_BROKER") or brokers_yaml.get("default_broker")
+    default_broker: str | None = raw_default.strip().lower() if raw_default else None
+
+    return BrokerSettings(
+        robinhood=RobinhoodConfig(
+            username=rh_username,
+            password=rh_password,
+            pickle_name=rh_pickle,
+            session_timeout_hours=rh_timeout,
+        ),
+        schwab=SchwabConfig(
+            api_key=sc_api_key,
+            app_secret=sc_app_secret,
+            callback_url=sc_callback_url,
+            token_path=sc_token_path,
+        ),
+        enabled_brokers=enabled,
+        default_broker=default_broker,
+    )
 
 
 def load_config(config_path: Path | str | None = None) -> ServerConfig:
@@ -633,6 +772,7 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
             exporter_endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
         ),
         feature_flag_definitions=feature_flag_definitions,
+        brokers=_parse_broker_settings(brokers),
         schwab_api_key=(
             os.getenv("SCHWAB_API_KEY")
             or str(

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -365,6 +365,14 @@ def _parse_enabled_brokers_config(
     return result
 
 
+def _optional_string(value: Any) -> str | None:
+    """Normalize scalar config values where null/blank means unset."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _parse_broker_settings(brokers_yaml: dict[str, Any]) -> BrokerSettings:
     """Build a BrokerSettings from YAML section + env var overrides."""
     rh_yaml = brokers_yaml.get("robinhood", {})
@@ -374,14 +382,16 @@ def _parse_broker_settings(brokers_yaml: dict[str, Any]) -> BrokerSettings:
     if not isinstance(sc_yaml, dict):
         sc_yaml = {}
 
-    rh_username = (
-        os.getenv("ROBINHOOD_USERNAME") or str(rh_yaml.get("username", "")) or None
+    rh_username = os.getenv("ROBINHOOD_USERNAME") or _optional_string(
+        rh_yaml.get("username")
     )
-    rh_password = (
-        os.getenv("ROBINHOOD_PASSWORD") or str(rh_yaml.get("password", "")) or None
+    rh_password = os.getenv("ROBINHOOD_PASSWORD") or _optional_string(
+        rh_yaml.get("password")
     )
-    rh_pickle = os.getenv("ROBINHOOD_PICKLE_NAME") or str(
-        rh_yaml.get("pickle_name", "robinhood")
+    rh_pickle = (
+        os.getenv("ROBINHOOD_PICKLE_NAME")
+        or _optional_string(rh_yaml.get("pickle_name"))
+        or "robinhood"
     )
     rh_timeout_raw = os.getenv("ROBINHOOD_SESSION_TIMEOUT_HOURS") or rh_yaml.get(
         "session_timeout_hours", 23
@@ -391,17 +401,17 @@ def _parse_broker_settings(brokers_yaml: dict[str, Any]) -> BrokerSettings:
     except (TypeError, ValueError):
         rh_timeout = 23
 
-    sc_api_key = os.getenv("SCHWAB_API_KEY") or str(sc_yaml.get("api_key", "")) or None
+    sc_api_key = os.getenv("SCHWAB_API_KEY") or _optional_string(sc_yaml.get("api_key"))
     sc_app_secret = (
-        os.getenv("SCHWAB_APP_SECRET") or str(sc_yaml.get("app_secret", "")) or None
+        os.getenv("SCHWAB_APP_SECRET") or _optional_string(sc_yaml.get("app_secret"))
     )
     sc_callback_url = (
         os.getenv("SCHWAB_CALLBACK_URL")
-        or str(sc_yaml.get("callback_url", ""))
+        or _optional_string(sc_yaml.get("callback_url"))
         or "https://127.0.0.1:8182/"
     )
     sc_token_path = (
-        os.getenv("SCHWAB_TOKEN_PATH") or str(sc_yaml.get("token_path", "")) or None
+        os.getenv("SCHWAB_TOKEN_PATH") or _optional_string(sc_yaml.get("token_path"))
     )
 
     raw_enabled = os.getenv("ENABLED_BROKERS")
@@ -775,47 +785,44 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
         brokers=_parse_broker_settings(brokers),
         schwab_api_key=(
             os.getenv("SCHWAB_API_KEY")
-            or str(
+            or _optional_string(
                 (
                     brokers.get("schwab", {})
                     if isinstance(brokers.get("schwab"), dict)
                     else {}
-                ).get("api_key", "")
+                ).get("api_key")
             )
-            or None
         ),
         schwab_app_secret=(
             os.getenv("SCHWAB_APP_SECRET")
-            or str(
+            or _optional_string(
                 (
                     brokers.get("schwab", {})
                     if isinstance(brokers.get("schwab"), dict)
                     else {}
-                ).get("app_secret", "")
+                ).get("app_secret")
             )
-            or None
         ),
         schwab_callback_url=(
             os.getenv("SCHWAB_CALLBACK_URL")
-            or str(
+            or _optional_string(
                 (
                     brokers.get("schwab", {})
                     if isinstance(brokers.get("schwab"), dict)
                     else {}
-                ).get("callback_url", "")
+                ).get("callback_url")
             )
             or "https://127.0.0.1:8182/"
         ),
         schwab_token_path=(
             os.getenv("SCHWAB_TOKEN_PATH")
-            or str(
+            or _optional_string(
                 (
                     brokers.get("schwab", {})
                     if isinstance(brokers.get("schwab"), dict)
                     else {}
-                ).get("token_path", "")
+                ).get("token_path")
             )
-            or None
         ),
     )
 

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -2098,8 +2098,8 @@ async def setup_brokers(
     authentication fails for all brokers.
 
     Args:
-        username: Robinhood username (optional)
-        password: Robinhood password (optional)
+        username: Robinhood username (optional, overrides config)
+        password: Robinhood password (optional, overrides config)
         config: Server configuration (optional)
     """
     if config is None:
@@ -2110,25 +2110,20 @@ async def setup_brokers(
     # Get the global registry
     registry = await get_broker_registry()
 
-    # Get enabled brokers from environment
-    enabled = _parse_enabled_brokers(os.getenv("ENABLED_BROKERS"))
+    # Use centralized broker config for enabled brokers
+    enabled = config.brokers.enabled_brokers
 
-    # Log warnings for unknown brokers
-    for broker_name in enabled:
-        if broker_name not in KNOWN_BROKERS:
-            logger.warning(
-                f"⚠️  Unknown broker '{broker_name}' in ENABLED_BROKERS. "
-                f"Known brokers: {KNOWN_BROKERS}"
-            )
-
-    # Setup Robinhood broker if enabled and credentials provided
+    # Setup Robinhood broker if enabled
     if "robinhood" in enabled:
-        if username and password:
+        # CLI credentials override configured credentials
+        rh_username = username or config.brokers.robinhood.username
+        rh_password = password or config.brokers.robinhood.password
+        if rh_username and rh_password:
             logger.info("Configuring Robinhood broker...")
             session_manager = get_session_manager()
             robinhood_broker = RobinhoodBroker(
-                username=username,
-                password=password,
+                username=rh_username,
+                password=rh_password,
                 session_manager=session_manager,
             )
             registry.register(robinhood_broker)
@@ -2147,13 +2142,14 @@ async def setup_brokers(
 
     # Setup Schwab broker if enabled
     if "schwab" in enabled:
-        if config.schwab_api_key and config.schwab_app_secret:
+        sc = config.brokers.schwab
+        if sc.api_key and sc.app_secret:
             logger.info("Configuring Schwab broker...")
             schwab_broker = SchwabBroker(
-                api_key=config.schwab_api_key,
-                app_secret=config.schwab_app_secret,
-                callback_url=config.schwab_callback_url,
-                token_path=config.schwab_token_path,
+                api_key=sc.api_key,
+                app_secret=sc.app_secret,
+                callback_url=sc.callback_url,
+                token_path=sc.token_path,
             )
             registry.register(schwab_broker)
             logger.info("✓ Schwab broker registered")
@@ -2162,8 +2158,16 @@ async def setup_brokers(
                 "Schwab enablement gate honored, but Schwab registration is tracked in #54"
             )
 
-    # Apply default broker if specified
-    _apply_default_broker(registry, os.getenv("DEFAULT_BROKER"))
+    # Apply default broker from centralized config
+    default = config.brokers.default_broker
+    if default:
+        registered = registry.list_brokers()
+        if default in registered:
+            registry.set_active_broker(default)
+        else:
+            logger.warning(
+                f"⚠️  DEFAULT_BROKER '{default}' not in registered brokers: {registered}"
+            )
 
     # Attempt to authenticate all registered brokers
     await attempt_broker_logins(require_at_least_one=False)

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -6,6 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from open_stocks_mcp.config import (
+    BrokerSettings,
+    RobinhoodConfig,
+    SchwabConfig,
+    ServerConfig,
+)
 from open_stocks_mcp.server.app import (
     attempt_login,
     create_mcp_server,
@@ -397,16 +403,9 @@ def test_create_mcp_server_applies_rate_limiter_from_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_setup_brokers_skips_robinhood_when_flag_disabled(monkeypatch) -> None:
-    monkeypatch.setenv("ENABLED_BROKERS", "schwab")
+async def test_setup_brokers_skips_robinhood_when_flag_disabled() -> None:
+    config = ServerConfig(brokers=BrokerSettings(enabled_brokers=["schwab"]))
     mock_registry = MagicMock()
-    config = MagicMock()
-    config.is_feature_enabled.side_effect = lambda name: {
-        "brokers.robinhood": False,
-        "brokers.schwab": False,
-    }.get(name, False)
-    config.schwab_api_key = None
-    config.schwab_app_secret = None
 
     with (
         patch(
@@ -421,18 +420,9 @@ async def test_setup_brokers_skips_robinhood_when_flag_disabled(monkeypatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_setup_brokers_registers_robinhood_when_flag_enabled(
-    monkeypatch,
-) -> None:
-    monkeypatch.setenv("ENABLED_BROKERS", "robinhood")
+async def test_setup_brokers_registers_robinhood_when_flag_enabled() -> None:
+    config = ServerConfig(brokers=BrokerSettings(enabled_brokers=["robinhood"]))
     mock_registry = MagicMock()
-    config = MagicMock()
-    config.is_feature_enabled.side_effect = lambda name: {
-        "brokers.robinhood": True,
-        "brokers.schwab": False,
-    }.get(name, False)
-    config.schwab_api_key = None
-    config.schwab_app_secret = None
 
     with (
         patch(
@@ -441,6 +431,7 @@ async def test_setup_brokers_registers_robinhood_when_flag_enabled(
         ),
         patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
         patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
+        patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
     ):
         await setup_brokers("user", "pass", config=config)
 
@@ -448,18 +439,14 @@ async def test_setup_brokers_registers_robinhood_when_flag_enabled(
 
 
 @pytest.mark.asyncio
-async def test_setup_brokers_registers_schwab_when_enabled_and_configured(
-    monkeypatch,
-) -> None:
-    monkeypatch.setenv("ENABLED_BROKERS", "schwab")
+async def test_setup_brokers_registers_schwab_when_enabled_and_configured() -> None:
+    config = ServerConfig(
+        brokers=BrokerSettings(
+            enabled_brokers=["schwab"],
+            schwab=SchwabConfig(api_key="key", app_secret="secret"),
+        )
+    )
     mock_registry = MagicMock()
-    config = MagicMock()
-    config.is_feature_enabled.side_effect = lambda name: {
-        "brokers.robinhood": False,
-        "brokers.schwab": True,
-    }.get(name, False)
-    config.schwab_api_key = "key"
-    config.schwab_app_secret = "secret"
 
     with (
         patch(
@@ -639,6 +626,155 @@ class TestSetupBrokers:
 
         assert "schwab" in caplog.text
         mock_registry.set_active_broker.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_brokers_uses_configured_robinhood_credentials() -> None:
+    """setup_brokers uses config.brokers.robinhood credentials when no CLI args given."""
+    config = ServerConfig(
+        brokers=BrokerSettings(
+            enabled_brokers=["robinhood"],
+            robinhood=RobinhoodConfig(username="cfg_user", password="cfg_pass"),
+        )
+    )
+    mock_registry = MagicMock()
+    mock_rh_broker_cls = MagicMock()
+
+    with (
+        patch(
+            "open_stocks_mcp.server.app.get_broker_registry",
+            AsyncMock(return_value=mock_registry),
+        ),
+        patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        patch("open_stocks_mcp.server.app.RobinhoodBroker", mock_rh_broker_cls),
+        patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+    ):
+        await setup_brokers(None, None, config=config)
+
+    mock_rh_broker_cls.assert_called_once()
+    call_kwargs = mock_rh_broker_cls.call_args[1]
+    assert call_kwargs["username"] == "cfg_user"
+    assert call_kwargs["password"] == "cfg_pass"
+    mock_registry.register.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_brokers_cli_credentials_override_config() -> None:
+    """CLI username/password override configured Robinhood credentials."""
+    config = ServerConfig(
+        brokers=BrokerSettings(
+            enabled_brokers=["robinhood"],
+            robinhood=RobinhoodConfig(username="cfg_user", password="cfg_pass"),
+        )
+    )
+    mock_registry = MagicMock()
+    mock_rh_broker_cls = MagicMock()
+
+    with (
+        patch(
+            "open_stocks_mcp.server.app.get_broker_registry",
+            AsyncMock(return_value=mock_registry),
+        ),
+        patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        patch("open_stocks_mcp.server.app.RobinhoodBroker", mock_rh_broker_cls),
+        patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+    ):
+        await setup_brokers("cli_user", "cli_pass", config=config)
+
+    call_kwargs = mock_rh_broker_cls.call_args[1]
+    assert call_kwargs["username"] == "cli_user"
+    assert call_kwargs["password"] == "cli_pass"
+
+
+@pytest.mark.asyncio
+async def test_setup_brokers_schwab_uses_broker_config_settings() -> None:
+    """setup_brokers passes centralized Schwab settings to SchwabBroker."""
+    config = ServerConfig(
+        brokers=BrokerSettings(
+            enabled_brokers=["schwab"],
+            schwab=SchwabConfig(
+                api_key="mykey",
+                app_secret="mysecret",
+                callback_url="https://my.cb/",
+                token_path="/tmp/tok.json",
+            ),
+        )
+    )
+    mock_registry = MagicMock()
+    mock_schwab_cls = MagicMock()
+
+    with (
+        patch(
+            "open_stocks_mcp.server.app.get_broker_registry",
+            AsyncMock(return_value=mock_registry),
+        ),
+        patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        patch("open_stocks_mcp.server.app.SchwabBroker", mock_schwab_cls),
+    ):
+        await setup_brokers(None, None, config=config)
+
+    mock_schwab_cls.assert_called_once_with(
+        api_key="mykey",
+        app_secret="mysecret",
+        callback_url="https://my.cb/",
+        token_path="/tmp/tok.json",
+    )
+    mock_registry.register.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_brokers_default_broker_from_config() -> None:
+    """default_broker in BrokerSettings calls set_active_broker after registration."""
+    config = ServerConfig(
+        brokers=BrokerSettings(
+            enabled_brokers=["schwab"],
+            schwab=SchwabConfig(api_key="k", app_secret="s"),
+            default_broker="schwab",
+        )
+    )
+    mock_registry = MagicMock()
+    mock_registry.list_brokers.return_value = ["schwab"]
+
+    with (
+        patch(
+            "open_stocks_mcp.server.app.get_broker_registry",
+            AsyncMock(return_value=mock_registry),
+        ),
+        patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        patch("open_stocks_mcp.server.app.SchwabBroker", MagicMock()),
+    ):
+        await setup_brokers(None, None, config=config)
+
+    mock_registry.set_active_broker.assert_called_once_with("schwab")
+
+
+@pytest.mark.asyncio
+async def test_setup_brokers_disabled_broker_skipped_even_with_creds() -> None:
+    """Brokers not in enabled_brokers are not registered even if credentials exist."""
+    config = ServerConfig(
+        brokers=BrokerSettings(
+            enabled_brokers=["schwab"],
+            robinhood=RobinhoodConfig(username="u", password="p"),
+            schwab=SchwabConfig(api_key="k", app_secret="s"),
+        )
+    )
+    mock_registry = MagicMock()
+    mock_rh_cls = MagicMock()
+    mock_schwab_cls = MagicMock()
+
+    with (
+        patch(
+            "open_stocks_mcp.server.app.get_broker_registry",
+            AsyncMock(return_value=mock_registry),
+        ),
+        patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
+        patch("open_stocks_mcp.server.app.RobinhoodBroker", mock_rh_cls),
+        patch("open_stocks_mcp.server.app.SchwabBroker", mock_schwab_cls),
+    ):
+        await setup_brokers(None, None, config=config)
+
+    mock_rh_cls.assert_not_called()
+    mock_schwab_cls.assert_called_once()
 
 
 def test_main_debug_flag_passes_debug_config_to_server() -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,11 +7,7 @@ from pathlib import Path
 
 import pytest
 
-<<<<<<< HEAD
 from open_stocks_mcp.config import ConfigError, RetryConfig, load_config
-=======
-from open_stocks_mcp.config import ConfigError, RetryConfig, load_config
->>>>>>> 9af2b56 (feat: implement typed broker configuration models from Schwab integration plan (#265))
 
 
 @pytest.mark.unit
@@ -533,6 +529,49 @@ brokers:
     assert cfg.brokers.schwab.token_path == "/tmp/tok.json"
     assert cfg.brokers.enabled_brokers == ["robinhood", "schwab"]
     assert cfg.brokers.default_broker == "robinhood"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_broker_config_yaml_null_values_remain_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        """
+brokers:
+  robinhood:
+    username: null
+    password: null
+  schwab:
+    api_key: null
+    app_secret: null
+    callback_url: null
+    token_path: null
+""".strip()
+    )
+    for var in (
+        "ROBINHOOD_USERNAME",
+        "ROBINHOOD_PASSWORD",
+        "SCHWAB_API_KEY",
+        "SCHWAB_APP_SECRET",
+        "SCHWAB_CALLBACK_URL",
+        "SCHWAB_TOKEN_PATH",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = load_config(config_path=path)
+
+    assert cfg.brokers.robinhood.username is None
+    assert cfg.brokers.robinhood.password is None
+    assert cfg.brokers.schwab.api_key is None
+    assert cfg.brokers.schwab.app_secret is None
+    assert cfg.brokers.schwab.callback_url == "https://127.0.0.1:8182/"
+    assert cfg.brokers.schwab.token_path is None
+    assert cfg.schwab_api_key is None
+    assert cfg.schwab_app_secret is None
+    assert cfg.schwab_callback_url == "https://127.0.0.1:8182/"
+    assert cfg.schwab_token_path is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
+<<<<<<< HEAD
 from open_stocks_mcp.config import ConfigError, RetryConfig, load_config
+=======
+from open_stocks_mcp.config import ConfigError, RetryConfig, load_config
+>>>>>>> 9af2b56 (feat: implement typed broker configuration models from Schwab integration plan (#265))
 
 
 @pytest.mark.unit
@@ -342,3 +346,209 @@ def test_tool_execution_timeout_defaults_to_30(
 
     assert cfg.timeout is not None
     assert cfg.timeout.tool_execution_timeout_seconds == 30.0
+
+
+# ---------------------------------------------------------------------------
+# Broker config tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_broker_config_defaults_missing_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "ROBINHOOD_USERNAME",
+        "ROBINHOOD_PASSWORD",
+        "SCHWAB_API_KEY",
+        "SCHWAB_APP_SECRET",
+        "SCHWAB_CALLBACK_URL",
+        "SCHWAB_TOKEN_PATH",
+        "ENABLED_BROKERS",
+        "DEFAULT_BROKER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.brokers.enabled_brokers == ["robinhood"]
+    assert cfg.brokers.default_broker is None
+    assert cfg.brokers.robinhood.username is None
+    assert cfg.brokers.robinhood.password is None
+    assert cfg.brokers.schwab.api_key is None
+    assert cfg.brokers.schwab.app_secret is None
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_broker_config_robinhood_credentials_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ROBINHOOD_USERNAME", "testuser")
+    monkeypatch.setenv("ROBINHOOD_PASSWORD", "testpass")
+    monkeypatch.delenv("ENABLED_BROKERS", raising=False)
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.brokers.robinhood.username == "testuser"
+    assert cfg.brokers.robinhood.password == "testpass"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_broker_config_schwab_credentials_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SCHWAB_API_KEY", "mykey")
+    monkeypatch.setenv("SCHWAB_APP_SECRET", "mysecret")
+    monkeypatch.setenv("SCHWAB_CALLBACK_URL", "https://cb.example.com/")
+    monkeypatch.setenv("SCHWAB_TOKEN_PATH", "/tmp/token.json")
+    monkeypatch.delenv("ENABLED_BROKERS", raising=False)
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.brokers.schwab.api_key == "mykey"
+    assert cfg.brokers.schwab.app_secret == "mysecret"
+    assert cfg.brokers.schwab.callback_url == "https://cb.example.com/"
+    assert cfg.brokers.schwab.token_path == "/tmp/token.json"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_broker_config_yaml_overridden_by_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        """
+brokers:
+  robinhood:
+    username: yaml_user
+    password: yaml_pass
+  schwab:
+    api_key: yaml_key
+""".strip()
+    )
+    monkeypatch.setenv("ROBINHOOD_USERNAME", "env_user")
+    monkeypatch.setenv("ROBINHOOD_PASSWORD", "env_pass")
+    monkeypatch.setenv("SCHWAB_API_KEY", "env_key")
+    monkeypatch.delenv("ENABLED_BROKERS", raising=False)
+
+    cfg = load_config(config_path=path)
+
+    assert cfg.brokers.robinhood.username == "env_user"
+    assert cfg.brokers.robinhood.password == "env_pass"
+    assert cfg.brokers.schwab.api_key == "env_key"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_enabled_brokers_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLED_BROKERS", " Robinhood, schwab ")
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.brokers.enabled_brokers == ["robinhood", "schwab"]
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_enabled_brokers_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLED_BROKERS", "")
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.brokers.enabled_brokers == []
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_enabled_brokers_unknown_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLED_BROKERS", "bogus,robinhood")
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.brokers.enabled_brokers == ["robinhood"]
+    assert "bogus" not in cfg.brokers.enabled_brokers
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_default_broker_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLED_BROKERS", "robinhood,schwab")
+    monkeypatch.setenv("DEFAULT_BROKER", "schwab")
+    monkeypatch.setenv("SCHWAB_API_KEY", "k")
+    monkeypatch.setenv("SCHWAB_APP_SECRET", "s")
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.brokers.default_broker == "schwab"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_broker_config_yaml_values_used_when_no_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        """
+brokers:
+  robinhood:
+    username: yaml_user
+    password: yaml_pass
+    pickle_name: mydb
+    session_timeout_hours: 12
+  schwab:
+    api_key: yaml_key
+    app_secret: yaml_secret
+    callback_url: https://my.callback/
+    token_path: /tmp/tok.json
+  enabled_brokers:
+    - robinhood
+    - schwab
+  default_broker: robinhood
+""".strip()
+    )
+    for var in (
+        "ROBINHOOD_USERNAME",
+        "ROBINHOOD_PASSWORD",
+        "SCHWAB_API_KEY",
+        "SCHWAB_APP_SECRET",
+        "SCHWAB_CALLBACK_URL",
+        "SCHWAB_TOKEN_PATH",
+        "ENABLED_BROKERS",
+        "DEFAULT_BROKER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = load_config(config_path=path)
+
+    assert cfg.brokers.robinhood.username == "yaml_user"
+    assert cfg.brokers.robinhood.password == "yaml_pass"
+    assert cfg.brokers.robinhood.pickle_name == "mydb"
+    assert cfg.brokers.robinhood.session_timeout_hours == 12
+    assert cfg.brokers.schwab.api_key == "yaml_key"
+    assert cfg.brokers.schwab.app_secret == "yaml_secret"
+    assert cfg.brokers.schwab.callback_url == "https://my.callback/"
+    assert cfg.brokers.schwab.token_path == "/tmp/tok.json"
+    assert cfg.brokers.enabled_brokers == ["robinhood", "schwab"]
+    assert cfg.brokers.default_broker == "robinhood"
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_schwab_compat_fields_backed_by_broker_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SCHWAB_API_KEY", "compat_key")
+    monkeypatch.setenv("SCHWAB_APP_SECRET", "compat_secret")
+    monkeypatch.setenv("SCHWAB_CALLBACK_URL", "https://compat.cb/")
+    monkeypatch.setenv("SCHWAB_TOKEN_PATH", "/compat/tok")
+    monkeypatch.delenv("ENABLED_BROKERS", raising=False)
+
+    cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
+
+    assert cfg.schwab_api_key == "compat_key"
+    assert cfg.schwab_app_secret == "compat_secret"
+    assert cfg.schwab_callback_url == "https://compat.cb/"
+    assert cfg.schwab_token_path == "/compat/tok"


### PR DESCRIPTION
Closes #265

## Changes
- Add `RobinhoodConfig`, `SchwabConfig`, and `BrokerSettings` dataclasses to `config.py` with `username`, `password`, `pickle_name`, `session_timeout_hours` for Robinhood and `api_key`, `app_secret`, `callback_url`, `token_path` for Schwab
- Add `brokers: BrokerSettings` field to `ServerConfig`
- Implement `_parse_broker_settings()` to parse `ROBINHOOD_USERNAME`, `ROBINHOOD_PASSWORD`, `SCHWAB_*`, `ENABLED_BROKERS`, `DEFAULT_BROKER` env vars with YAML fallback and env precedence
- `ENABLED_BROKERS` normalization: case-insensitive, whitespace-tolerant, unknown names warned-and-dropped
- Update `setup_brokers()` to consume `config.brokers.*` instead of reading env vars directly; CLI `--username`/`--password` continue to override configured Robinhood credentials
- Preserve backward-compatible `schwab_api_key`, `schwab_app_secret`, `schwab_callback_url`, `schwab_token_path` fields on `ServerConfig`
- Add 10 new config unit tests and 5 new server startup tests; update 3 existing tests to use `ServerConfig(brokers=BrokerSettings(...))`

## Test plan
- `uv run pytest tests/unit/test_config.py -q -k 'broker_config or enabled_brokers or default_broker'` — 10 passing
- `uv run pytest tests/server/test_server_app.py tests/unit/test_config.py -q` — 76 passing
- `uv run mypy src/open_stocks_mcp/config.py src/open_stocks_mcp/server/app.py` — zero errors
- `uv run ruff check` — zero errors