### PR TITLE
chore: resolve remaining ruff violations

### DIFF
--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -1,9 +1,8 @@
 """Robinhood broker implementation using existing robin-stocks integration."""
 
+import math
 from datetime import datetime
 from typing import Any
-
-import math
 
 import robin_stocks.robinhood as rh
 

--- a/tests/unit/test_robinhood_broker.py
+++ b/tests/unit/test_robinhood_broker.py
@@ -491,7 +491,7 @@ class TestRobinhoodGetPortfolioSnapshotEnrichment:
                 new=AsyncMock(return_value=rh_quotes),
             ),
         ):
-            summary, positions = await broker.get_portfolio_snapshot()
+            _, positions = await broker.get_portfolio_snapshot()
 
         assert len(positions) == 1
         assert positions[0]["symbol"] == "AAPL"
@@ -525,7 +525,7 @@ class TestRobinhoodGetPortfolioSnapshotEnrichment:
                 new=AsyncMock(return_value=rh_quotes),
             ),
         ):
-            summary, positions = await broker.get_portfolio_snapshot()
+            _, positions = await broker.get_portfolio_snapshot()
 
         assert len(positions) == 1
         assert positions[0]["market_value"] is None
@@ -557,7 +557,7 @@ class TestRobinhoodGetPortfolioSnapshotEnrichment:
                 new=AsyncMock(side_effect=RuntimeError("quote fetch failed")),
             ),
         ):
-            summary, positions = await broker.get_portfolio_snapshot()
+            _, positions = await broker.get_portfolio_snapshot()
 
         assert len(positions) == 1
         assert positions[0]["market_value"] is None
@@ -594,7 +594,7 @@ class TestRobinhoodGetPortfolioSnapshotEnrichment:
                 new=AsyncMock(return_value=rh_quotes),
             ),
         ):
-            summary, positions = await broker.get_portfolio_snapshot()
+            _, positions = await broker.get_portfolio_snapshot()
 
         by_symbol = {p["symbol"]: p for p in positions}
         assert by_symbol["AAPL"]["market_value"] == pytest.approx(1755.0)


### PR DESCRIPTION
Closes #282

## Changes
- fix import ordering in `src/open_stocks_mcp/brokers/robinhood.py` to satisfy Ruff `I001`
- replace unused unpacked `summary` variables with `_` in `tests/unit/test_robinhood_broker.py` for Ruff `RUF059`
- keep scope strictly to files reported by `uv run ruff check .`

## Test plan
- uv run ruff check .
- uv run pytest tests/unit/test_robinhood_broker.py -q --tb=line
- git diff --check