### PR TITLE
docs: document percentile calculation change (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Open Stocks MCP project will be documented in this fi
 
 ### Changed
 - Bumped version to 0.6.5
+- **Percentile calculation**: Global `p50/p95/p99_response_time_ms` values in
+  `get_metrics()` now use ceil-rank (`math.ceil(quantile * len)`) instead of the
+  previous truncated-index (`int(len * quantile)`) for percentile computation,
+  introduced in PR #296. Values may differ by one rank position for small or
+  even-length sample windows (e.g., 4 samples at p50: old=30.0, new=20.0).
 - Code cleanup for release (release cleanup)
 - Updated all dependencies to latest versions
 - Added open source community infrastructure

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -244,6 +244,28 @@ async def test_alert_dedup_cleanup_avoids_memory_growth() -> None:
     assert "test_signal" not in collector._last_alert_at
 
 
+def test_percentile_uses_ceil_rank_for_short_and_even_lists() -> None:
+    p = MetricsCollector._percentile
+
+    assert p([], 0.50) == 0.0
+
+    assert p([10.0], 0.50) == 10.0
+
+    # 2-element list: ceil-rank gives index 0 (10.0);
+    # old truncated-index int(2*0.5)=1 would give 20.0
+    assert p([10.0, 20.0], 0.50) == 10.0
+    assert p([10.0, 20.0], 0.95) == 20.0
+
+    # 4-element list at p50: ceil(4*0.5)=2 → index 1 → 20.0;
+    # old int(4*0.5)=2 → index 2 → 30.0 (key divergence)
+    assert p([10.0, 20.0, 30.0, 40.0], 0.50) == 20.0
+    assert p([10.0, 20.0, 30.0, 40.0], 0.95) == 40.0
+    assert p([10.0, 20.0, 30.0, 40.0], 0.99) == 40.0
+
+    assert p([10.0, 20.0, 30.0], 0.50) == 20.0
+    assert p([10.0, 20.0, 30.0], 0.99) == 30.0
+
+
 @pytest.mark.asyncio
 async def test_monitored_tool_wraps_exception_with_explicit_cause_and_records_metric() -> (
     None


### PR DESCRIPTION
Closes #304

## Changes
- Added CHANGELOG entry under `[0.6.5]` documenting the behavioral change from truncated-index (`int(len * quantile)`) to ceil-rank (`math.ceil(quantile * len)`) for global `p50/p95/p99_response_time_ms` keys in `get_metrics()`, introduced in PR #296.
- Added `test_percentile_uses_ceil_rank_for_short_and_even_lists()` to `tests/unit/test_monitoring.py` pinning ceil-rank behavior on empty, single-element, even-length (2 elements), and short (3–4 element) sample lists, including a case demonstrating divergence from the old formula (4 elements at p50: old=30.0, new=20.0).

## Test plan
- `uv run pytest tests/unit/test_monitoring.py -q` — all 11 tests pass including new regression test
- `uv run ruff check CHANGELOG.md tests/unit/test_monitoring.py` — clean
- Pre-existing mypy issue on `failing_func` unrelated to this change