### PR TITLE
fix: rename windowed calls-per-minute metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ uv run mcp dev src/open_stocks_mcp/server/app.py
 
 The `/metrics` endpoint exposes:
 - `open_stocks_mcp_tool_calls_total` (counter by tool)
-- `open_stocks_mcp_tool_calls_per_minute` (gauge by tool)
+- `open_stocks_mcp_tool_avg_calls_per_minute` (gauge by tool; average over the rolling window)
 - `open_stocks_mcp_tool_latency_ms` (gauge by tool and quantile: `0.50`, `0.95`, `0.99`)
 
 Distributed tracing setup (OpenTelemetry, Jaeger, Tempo):

--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -277,7 +277,7 @@ class MetricsCollector:
                 tool_stats[tool] = {
                     "calls": total,
                     "success_rate": (successful / total * 100.0) if total > 0 else 0.0,
-                    "calls_per_minute": (
+                    "avg_calls_per_minute": (
                         round(total / (self.window_size.total_seconds() / 60), 2)
                         if total > 0
                         else 0.0
@@ -420,8 +420,8 @@ class MetricsCollector:
             f"open_stocks_mcp_errors_in_window {metrics['errors_in_window']}",
             "# HELP open_stocks_mcp_tool_calls_total Total calls per tool.",
             "# TYPE open_stocks_mcp_tool_calls_total counter",
-            "# HELP open_stocks_mcp_tool_calls_per_minute Calls per minute per tool.",
-            "# TYPE open_stocks_mcp_tool_calls_per_minute gauge",
+            "# HELP open_stocks_mcp_tool_avg_calls_per_minute Average calls per minute over the rolling window.",
+            "# TYPE open_stocks_mcp_tool_avg_calls_per_minute gauge",
             "# HELP open_stocks_mcp_tool_latency_ms Tool latency percentile in milliseconds.",
             "# TYPE open_stocks_mcp_tool_latency_ms gauge",
         ]
@@ -433,8 +433,8 @@ class MetricsCollector:
                 f"{tool_metrics['calls']}"
             )
             lines.append(
-                f'open_stocks_mcp_tool_calls_per_minute{{tool="{escaped_tool}"}} '
-                f"{tool_metrics['calls_per_minute']}"
+                f'open_stocks_mcp_tool_avg_calls_per_minute{{tool="{escaped_tool}"}} '
+                f"{tool_metrics['avg_calls_per_minute']}"
             )
             lines.append(
                 f'open_stocks_mcp_tool_latency_ms{{tool="{escaped_tool}",quantile="0.50"}} '

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -136,7 +136,7 @@ class TestMetricsEndpoint:
             in metrics_response.text
         )
         assert (
-            'open_stocks_mcp_tool_calls_per_minute{tool="account_info"} '
+            'open_stocks_mcp_tool_avg_calls_per_minute{tool="account_info"} '
             in metrics_response.text
         )
         assert (

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -85,12 +85,12 @@ async def test_get_metrics_includes_per_tool_latency_and_throughput() -> None:
     assert "tool_b" in tool_usage
     assert tool_usage["tool_a"]["calls"] == 3
     assert tool_usage["tool_a"]["success_rate"] == pytest.approx(66.666, rel=1e-2)
-    assert tool_usage["tool_a"]["calls_per_minute"] == pytest.approx(3.0)
+    assert tool_usage["tool_a"]["avg_calls_per_minute"] == pytest.approx(3.0)
     assert tool_usage["tool_a"]["p50_response_time_ms"] == 200.0
     assert tool_usage["tool_a"]["p95_response_time_ms"] == 300.0
     assert tool_usage["tool_a"]["p99_response_time_ms"] == 300.0
     assert tool_usage["tool_b"]["calls"] == 1
-    assert tool_usage["tool_b"]["calls_per_minute"] == pytest.approx(1.0)
+    assert tool_usage["tool_b"]["avg_calls_per_minute"] == pytest.approx(1.0)
     assert metrics["total_errors"] == 1
     assert metrics["error_types"]["RuntimeError"] == 1
 
@@ -103,7 +103,7 @@ async def test_prometheus_output_contains_tool_metrics() -> None:
     output = await collector.format_prometheus_metrics()
 
     assert "open_stocks_mcp_tool_calls_total" in output
-    assert "open_stocks_mcp_tool_calls_per_minute" in output
+    assert "open_stocks_mcp_tool_avg_calls_per_minute" in output
     assert "open_stocks_mcp_tool_latency_ms" in output
     assert 'tool="tool\\"name\\\\x"' in output
     assert 'quantile="0.50"' in output


### PR DESCRIPTION
Closes #305

## Changes
- Renamed tool usage JSON metric key from `calls_per_minute` to `avg_calls_per_minute` in monitoring output.
- Renamed Prometheus gauge to `open_stocks_mcp_tool_avg_calls_per_minute`.
- Updated Prometheus HELP text to clarify this is an average over the rolling window.
- Updated README `/metrics` docs and affected unit/http transport tests.

## Test plan
- `uv run pytest tests/unit/test_monitoring.py tests/http_transport/test_http_server.py -q --tb=line`
- `uv run ruff check src/open_stocks_mcp/monitoring.py README.md tests/unit/test_monitoring.py tests/http_transport/test_http_server.py`
- `uv run mypy src/open_stocks_mcp/monitoring.py --no-error-summary`
- `uv run pytest -q --tb=line` (repository currently has unrelated pre-existing failures in cache/dependency/dev-tooling tests)
