### PR TITLE
fix: prune empty deques from tool_usage and tool_response_times on cleanup

### DIFF
--- a/src/open_stocks_mcp/monitoring.py
+++ b/src/open_stocks_mcp/monitoring.py
@@ -197,11 +197,17 @@ class MetricsCollector:
         for tool_calls in self.tool_usage.values():
             while tool_calls and tool_calls[0][0] < cutoff:
                 tool_calls.popleft()
+        empty_tools = [t for t, d in self.tool_usage.items() if not d]
+        for t in empty_tools:
+            del self.tool_usage[t]
 
         # Clean per-tool response times
         for tool_durations in self.tool_response_times.values():
             while tool_durations and tool_durations[0][0] < cutoff:
                 tool_durations.popleft()
+        empty_tools = [t for t, d in self.tool_response_times.items() if not d]
+        for t in empty_tools:
+            del self.tool_response_times[t]
 
         while (
             self.broker_operations and self.broker_operations[0]["timestamp"] < cutoff

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -127,7 +127,8 @@ async def test_get_metrics_cleans_stale_tool_samples() -> None:
 
     assert metrics["calls_in_window"] == 1
     assert metrics["tool_usage"]["new_tool"]["calls"] == 1
-    assert metrics["tool_usage"]["old_tool"]["calls"] == 0
+    # Pruning removes the key entirely once its deque empties
+    assert "old_tool" not in metrics["tool_usage"]
 
 
 @pytest.mark.asyncio
@@ -242,6 +243,35 @@ async def test_alert_dedup_cleanup_avoids_memory_growth() -> None:
 
     # Map should be empty since 1s > 0.1s
     assert "test_signal" not in collector._last_alert_at
+
+
+@pytest.mark.asyncio
+async def test_clean_old_entries_prunes_empty_deques() -> None:
+    collector = MetricsCollector(window_size_minutes=1)
+    now = datetime.now()
+    stale = now - timedelta(minutes=2)
+
+    # Insert stale entries for old_tool
+    collector.tool_usage["old_tool"].append((stale, True))
+    collector.tool_response_times["old_tool"].append((stale, 0.5))
+    # Insert current entries for recent_tool
+    collector.tool_usage["recent_tool"].append((now, True))
+    collector.tool_response_times["recent_tool"].append((now, 0.1))
+
+    collector._clean_old_entries(now)
+
+    # old_tool's deques are now empty — keys should be pruned
+    assert "old_tool" not in collector.tool_usage
+    assert "old_tool" not in collector.tool_response_times
+    # recent_tool should still be present with data intact
+    assert "recent_tool" in collector.tool_usage
+    assert len(collector.tool_usage["recent_tool"]) == 1
+    assert "recent_tool" in collector.tool_response_times
+    assert len(collector.tool_response_times["recent_tool"]) == 1
+
+    # record_api_call must be able to re-create a pruned key via defaultdict
+    await collector.record_api_call("old_tool", 0.05, True)
+    assert "old_tool" in collector.tool_usage
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #306

## Changes
- After each `popleft` loop in `_clean_old_entries`, collect and delete keys whose deques are now empty from both `tool_usage` and `tool_response_times`
- Updated existing `test_get_metrics_cleans_stale_tool_samples` to assert the key is absent (not present with zero calls) since pruning now removes it entirely
- Added `test_clean_old_entries_prunes_empty_deques` verifying: stale keys are pruned, recent keys are preserved with data intact, and `record_api_call` can re-create a pruned key via `defaultdict`

## Test plan
- `uv run pytest tests/unit/test_monitoring.py tests/unit/test_monitoring_alerts.py -q --tb=line` — 23 passed
- `uv run ruff check src/open_stocks_mcp/monitoring.py tests/unit/test_monitoring.py` — no issues
- `uv run mypy src/open_stocks_mcp/monitoring.py --no-error-summary` — no errors