### PR TITLE
fix: preserve HTTPException from _require_metrics_collector in /mcp tools/call

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -790,6 +790,8 @@ def create_http_server(
                     outcome="success",
                 )
 
+            except HTTPException:
+                raise
             except Exception as e:
                 logger.error(f"MCP method '{method}' failed: {e}")
                 error_response = {
@@ -807,6 +809,8 @@ def create_http_server(
                     error_type=type(e).__name__,
                 )
 
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"MCP endpoint error: {e}")
             error_response = {

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -183,6 +183,24 @@ class TestHttpTransportUnit:
         assert response.status_code in {200, 204}
         assert "POST" in response.headers["access-control-allow-methods"]
 
+    @patch(
+        "open_stocks_mcp.server.http_transport.get_metrics_collector", return_value=None
+    )
+    def test_mcp_tools_call_propagates_metrics_collector_http_exception(
+        self, _mock_get_metrics_collector: Mock, client: TestClient
+    ) -> None:
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "account_info", "arguments": {}},
+                "id": 9,
+            },
+        )
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Metrics collector unavailable"
+
 
 @pytest.fixture(scope="module")
 def slow_timeout_mcp_server() -> FastMCP:


### PR DESCRIPTION
Closes #307

## Changes
- Added `except HTTPException: raise` before the inner `except Exception` block in `mcp_endpoint` (the method-dispatch try/except) so `HTTPException` raised by `_require_metrics_collector()` is not translated into a JSON-RPC `-32603` response.
- Added `except HTTPException: raise` before the outer `except Exception` block in `mcp_endpoint` as a second guard so no outer handler can mask it either.
- Added `test_mcp_tools_call_propagates_metrics_collector_http_exception` to `tests/unit/test_http_transport.py` as a regression test that patches `get_metrics_collector` to return `None` and asserts HTTP 503 with the correct detail.

## Test plan
- `uv run pytest tests/unit/test_http_transport.py::TestHttpTransportUnit::test_mcp_tools_call_propagates_metrics_collector_http_exception -q --tb=short` → 1 passed
- `uv run pytest tests/unit/test_http_transport.py -q --tb=short` → 15 passed
- `uv run pytest tests/http_transport/test_http_server.py::TestMCPIntegration -q --tb=short` → 10 passed
- `uv run ruff check src/open_stocks_mcp/server/http_transport.py tests/unit/test_http_transport.py` → All checks passed
- `uv run mypy src/open_stocks_mcp/server/http_transport.py` → Success: no issues found