### PR TITLE
test: add metrics bearer bypass regression coverage

### DIFF
--- a/tests/http_transport/test_http_auth.py
+++ b/tests/http_transport/test_http_auth.py
@@ -372,6 +372,20 @@ class TestBearerTokenAuth:
         response = await authed_client.get("/")
         assert response.status_code == 200
 
+    async def test_metrics_bypasses_bearer_auth(
+        self, authed_client: httpx.AsyncClient
+    ) -> None:
+        mcp_response = await authed_client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+        )
+        assert mcp_response.status_code == 401
+
+        metrics_response = await authed_client.get("/metrics")
+        assert metrics_response.status_code == 200
+        assert metrics_response.headers["content-type"].startswith("text/plain")
+        assert "open_stocks_mcp_total_calls" in metrics_response.text
+
 
 @pytest.mark.integration
 @pytest.mark.journey_system


### PR DESCRIPTION
Closes #308

## Changes
- add `test_metrics_bypasses_bearer_auth` in `TestBearerTokenAuth`
- verify `/mcp` returns 401 without bearer token when `api_key` is configured
- verify `/metrics` remains unauthenticated and returns Prometheus text body

## Test plan
- `uv run pytest tests/http_transport/test_http_auth.py::TestBearerTokenAuth::test_metrics_bypasses_bearer_auth -q --tb=line` (blocked by existing pyproject.toml duplicate key)
- `uv run pytest tests/http_transport/test_http_auth.py -q --tb=line` (blocked by existing pyproject.toml duplicate key)
- `uv run ruff check tests/http_transport/test_http_auth.py` (blocked by existing pyproject.toml duplicate key)
