### PR TITLE
fix: restore uv run prefix in notebook startup snippet

### DIFF
--- a/examples/notebooks/01_market_data_quickstart.ipynb
+++ b/examples/notebooks/01_market_data_quickstart.ipynb
@@ -1,82 +1,82 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Prerequisites & Safety\n",
-        "\n",
-        "Required environment variables:\n",
-        "- ROBINHOOD_USERNAME\n",
-        "- ROBINHOOD_PASSWORD\n",
-        "\n",
-        "This notebook uses read-only market and portfolio tools. No order placement calls are included."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Connect to the MCP server\n",
-        "\n",
-        "Start the server first:\n",
-        "```bash\n",
-        "open-stocks-mcp-server --transport http --port 3001\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "from mcp import ClientSession\n",
-        "from mcp.client.streamable_http import streamablehttp_client\n",
-        "\n",
-        "mcp_http_url = os.environ.get(\"MCP_HTTP_URL\", \"http://localhost:3001/mcp\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "async with streamablehttp_client(mcp_http_url) as (read, write, _):\n",
-        "    async with ClientSession(read, write) as session:\n",
-        "        await session.initialize()\n",
-        "        aapl_quote = await session.call_tool(\"stock_price\", {\"symbol\": \"AAPL\"})\n",
-        "        market_status = await session.call_tool(\"market_hours\", {})\n",
-        "        portfolio_snapshot = await session.call_tool(\"portfolio\", {})\n",
-        "\n",
-        "aapl_quote, market_status, portfolio_snapshot"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Next steps\n",
-        "\n",
-        "- Review [tools.md](../../docs/api/tools.md) for full tool coverage.\n",
-        "- Continue with `02_trading_safe_dry_run.ipynb` for safe trading payload patterns."
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Prerequisites & Safety\n",
+    "\n",
+    "Required environment variables:\n",
+    "- ROBINHOOD_USERNAME\n",
+    "- ROBINHOOD_PASSWORD\n",
+    "\n",
+    "This notebook uses read-only market and portfolio tools. No order placement calls are included."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to the MCP server\n",
+    "\n",
+    "Start the server first:\n",
+    "```bash\n",
+    "uv run open-stocks-mcp-server --transport http --port 3001\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from mcp import ClientSession\n",
+    "from mcp.client.streamable_http import streamablehttp_client\n",
+    "\n",
+    "mcp_http_url = os.environ.get(\"MCP_HTTP_URL\", \"http://localhost:3001/mcp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async with streamablehttp_client(mcp_http_url) as (read, write, _):\n",
+    "    async with ClientSession(read, write) as session:\n",
+    "        await session.initialize()\n",
+    "        aapl_quote = await session.call_tool(\"stock_price\", {\"symbol\": \"AAPL\"})\n",
+    "        market_status = await session.call_tool(\"market_hours\", {})\n",
+    "        portfolio_snapshot = await session.call_tool(\"portfolio\", {})\n",
+    "\n",
+    "aapl_quote, market_status, portfolio_snapshot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- Review [tools.md](../../docs/api/tools.md) for full tool coverage.\n",
+    "- Continue with `02_trading_safe_dry_run.ipynb` for safe trading payload patterns."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Closes #310

## Changes
- Restored the  prefix in the notebook startup command snippet in  cell 1
- Kept scope to the single targeted notebook cell

## Test plan
- python3 -c "import json; nb=json.load(open('examples/notebooks/01_market_data_quickstart.ipynb')); assert 'uv run open-stocks-mcp-server --transport http --port 3001' in ''.join(nb['cells'][1]['source'])"
- python3 -c "import json; json.load(open('examples/notebooks/01_market_data_quickstart.ipynb'))"
- grep -n 'uv run open-stocks-mcp-server' CLAUDE.md examples/notebooks/01_market_data_quickstart.ipynb