### PR TITLE
test: tighten list_tools() assertion in test_example_notebooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ ignore_missing_imports = true
 pythonpath = ["src"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-pythonpath = ["src"]
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/tests/unit/test_example_notebooks.py
+++ b/tests/unit/test_example_notebooks.py
@@ -68,6 +68,17 @@ async def test_notebook_structure(notebook_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_dry_run_notebook_uses_session_list_tools() -> None:
+    """dry-run notebook must call session.list_tools(), not a bare list_tools()."""
+    assert DRY_RUN_NOTEBOOK.exists(), f"Notebook {DRY_RUN_NOTEBOOK} does not exist"
+    nb = nbformat.read(DRY_RUN_NOTEBOOK, as_version=4)  # type: ignore[no-untyped-call]
+    code_sources = [cell.source for cell in nb.cells if cell.cell_type == "code"]
+    assert any("session.list_tools()" in source for source in code_sources), (
+        f"Notebook {DRY_RUN_NOTEBOOK} must contain a code cell with 'session.list_tools()'"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "notebook_path",
     [PORTFOLIO_NOTEBOOK, OPTIONS_NOTEBOOK, QUICKSTART_NOTEBOOK, DRY_RUN_NOTEBOOK],


### PR DESCRIPTION
Closes #314

## Changes
- Added `test_dry_run_notebook_uses_session_list_tools` test that asserts `examples/notebooks/02_trading_safe_dry_run.ipynb` contains a code cell with the exact string `session.list_tools()` rather than relying on the loose `list_tools()` substring coincidence.
- Fixed a pre-existing duplicate `pythonpath = ["src"]` key in `[tool.pytest.ini_options]` that was causing pytest to fail to parse `pyproject.toml`.

## Test plan
- `uv run pytest tests/unit/test_example_notebooks.py -q --tb=line` — 7 passed
- `uv run ruff check tests/unit/test_example_notebooks.py` — no issues
- `rg 'assert any\("list_tools\(\)" in source' tests/unit/test_example_notebooks.py` — no matches (loose form absent)