### PR TITLE
docs: remove internal 'Foreman skills' term from API docs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -51,5 +51,4 @@ uv run jupyter lab examples/notebooks/
 
 ## CI Scope
 
-Notebook execution is intentionally not run in CI by design for this issue. CI
-workflow changes are out of scope for Foreman skills.
+Notebook execution is intentionally not run in CI by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ ignore_missing_imports = true
 pythonpath = ["src"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-pythonpath = ["src"]
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/tests/unit/test_phase8_parent_acceptance.py
+++ b/tests/unit/test_phase8_parent_acceptance.py
@@ -27,6 +27,12 @@ class TestReadmeDiscoverability:
     def test_links_api_tools_reference(self) -> None:
         assert "docs/api/tools.md" in self.readme
 
+    def test_api_docs_use_public_ci_scope_language(self) -> None:
+        api_readme = (ROOT / "docs" / "api" / "README.md").read_text()
+        api_lower = api_readme.lower()
+        assert "foreman skills" not in api_lower
+        assert "Notebook execution is intentionally not run in CI by design." in api_readme
+
     def test_links_notebooks_via_api_docs(self) -> None:
         assert "notebook" in self.readme.lower()
         api_readme = (ROOT / "docs" / "api" / "README.md").read_text()


### PR DESCRIPTION
Closes #315

## Changes
- Replaced internal "Foreman skills" orchestration terminology in `docs/api/README.md` CI Scope section with public-facing language: "Notebook execution is intentionally not run in CI by design."
- Added `test_api_docs_use_public_ci_scope_language` regression test in `tests/unit/test_phase8_parent_acceptance.py` to prevent reintroduction of the internal term.
- Fixed duplicate `pythonpath` key in `pyproject.toml` that was causing TOML parse errors.

## Test plan
- `uv run pytest tests/unit/test_phase8_parent_acceptance.py -q --tb=line` — all 23 tests pass including the new regression test.
- `uv run ruff check tests/unit/test_phase8_parent_acceptance.py` — lint clean.