### PR TITLE
test: simplify rate-limited nodeid count logic

### DIFF
--- a/tests/unit/test_rate_limited_marker.py
+++ b/tests/unit/test_rate_limited_marker.py
@@ -201,13 +201,11 @@ def test_rate_limited_collection_nodeids() -> None:
     assert "test_api_error_handling" not in result.stdout
 
     # Also check count to be sure no extra tests are selected
-    # Tree format usually has <Function ...> or <Coroutine ...>
-    count = result.stdout.count("<Function") + result.stdout.count("<Coroutine")
-    # If it's nodeid format, it might not have those, so we fallback
-    if count == 0:
-        # Fallback for nodeid format (one per line)
-        lines = [line for line in result.stdout.splitlines() if "::" in line]
-        count = len(lines)
+    count = sum(
+        1
+        for line in result.stdout.splitlines()
+        if "::" in line and not line.startswith("no tests ran")
+    )
 
     assert count == 4, f"Expected 4 tests, found {count}. Output:\n{result.stdout}"
 


### PR DESCRIPTION
Closes #323

## Changes
- Removed unreachable tree-format collection count path in `test_rate_limited_collection_nodeids`
- Replaced it with direct nodeid-format line counting that ignores `no tests ran` summary lines
- Kept the exact assertion (`count == 4`) and all presence/absence checks unchanged

## Test plan
- `uv run pytest tests/unit/test_rate_limited_marker.py::test_rate_limited_collection_nodeids -q --tb=line` *(blocked: duplicate `pythonpath` key in `pyproject.toml`)*
- `python3 -m pytest -c /dev/null tests/unit/test_rate_limited_marker.py::test_rate_limited_collection_nodeids -q --tb=line` *(blocked: `open_stocks_mcp` import bootstrap requirement)*
- `ruff check --isolated tests/unit/test_rate_limited_marker.py`
- `mypy --config-file /dev/null --ignore-missing-imports --follow-imports=skip tests/unit/test_rate_limited_marker.py`