### PR TITLE
docs: remove internal CI scope wording

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -51,5 +51,4 @@ uv run jupyter lab examples/notebooks/
 
 ## CI Scope
 
-Notebook execution is intentionally not run in CI by design for this issue. CI
-workflow changes are out of scope for Foreman skills.
+Notebook execution is intentionally not run in CI by design.

--- a/tests/unit/test_phase8_parent_acceptance.py
+++ b/tests/unit/test_phase8_parent_acceptance.py
@@ -41,6 +41,12 @@ class TestReadmeDiscoverability:
     def test_links_contributing(self) -> None:
         assert "CONTRIBUTING.md" in self.readme
 
+    def test_api_docs_use_public_ci_scope_language(self) -> None:
+        api_readme = (ROOT / "docs" / "api" / "README.md").read_text()
+        assert "Foreman skills" not in api_readme
+        assert "foreman skills" not in api_readme.lower()
+        assert "Notebook execution is intentionally not run in CI by design." in api_readme
+
 
 class TestGeneratedToolDocs:
     """Generated tool documentation must exist with registry counts."""


### PR DESCRIPTION
Closes #315

## Changes
- Updated  CI Scope wording to remove the internal term .
- Added focused docs acceptance test  in .

## Test plan
-  *(blocked: repo-level  duplicate key parse error)*
-  *(blocked by same parse error)*
- tests/unit/test_phase8_parent_acceptance.py:46:        assert "Foreman skills" not in api_readme
tests/unit/test_phase8_parent_acceptance.py:47:        assert "foreman skills" not in api_readme.lower() *(passes; only test assertions contain the phrase)*
- docs/api/README.md:54:Notebook execution is intentionally not run in CI by design.
tests/unit/test_phase8_parent_acceptance.py:48:        assert "Notebook execution is intentionally not run in CI by design." in api_readme *(passes)*