### PR TITLE
docs: update Docker README with current version, tool count, and Schwab coverage

### DIFF
--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -60,6 +60,19 @@ ROBINHOOD_USERNAME=your_robinhood_username
 ROBINHOOD_PASSWORD=your_robinhood_password
 ```
 
+**Optional: Schwab broker** (requires a [Schwab developer account](https://developer.schwab.com/)):
+
+```env
+# Schwab credentials (add to .env for multi-broker support)
+SCHWAB_API_KEY=your_schwab_api_key
+SCHWAB_APP_SECRET=your_schwab_app_secret
+SCHWAB_CALLBACK_URL=https://127.0.0.1:8182/
+SCHWAB_TOKEN_PATH=/home/mcp/.tokens/schwab_token.json
+ENABLED_BROKERS=robinhood,schwab
+```
+
+See [Multi-Broker Setup](#multi-broker-setup-robinhood--schwab) for the full OAuth first-run flow.
+
 ⚠️ **Security Note**: Never commit the `.env` file to version control. It's already included in `.gitignore`.
 
 ### 4. Device Verification Setup
@@ -253,7 +266,7 @@ curl http://localhost:3001/status
 
 # Available tools list
 curl http://localhost:3001/tools
-# Returns: Complete list of 83 available MCP tools
+# Returns: Complete list of 152 available MCP tools
 ```
 
 ✅ **Security features validated:**
@@ -269,7 +282,7 @@ curl http://localhost:3001/tools
 
 ### Available Tools
 
-The server provides **83 MCP tools** across **11 categories**:
+The server provides **152 MCP tools** across **12 categories**:
 
 - **Account Management**: `account_info`, `portfolio`, `account_details`, `positions`
 - **Market Data**: `stock_price`, `stock_info`, `search_stocks_tool`, `market_hours`, `price_history`
@@ -282,6 +295,7 @@ The server provides **83 MCP tools** across **11 categories**:
 - **Trading Operations**: `buy_stock_market`, `buy_stock_limit`, `sell_stock_market`, `cancel_stock_order_by_id`
 - **System Management**: `session_status`, `rate_limit_status`, `metrics_summary`, `health_check`
 - **Utility**: `list_tools`
+- **Schwab Broker**: `schwab_account_numbers`, `schwab_quote`, `schwab_buy_stock_market`, `schwab_option_chain`, `schwab_get_dividends`
 
 ## Management
 
@@ -369,7 +383,7 @@ Adjust these in `docker-compose.yml` based on your needs.
 - ✅ FastAPI-based server with comprehensive middleware
 - ✅ Security headers and CORS support
 - ✅ Health check and monitoring endpoints
-- ✅ Complete trading functionality (83 MCP tools)
+- ✅ Complete trading functionality (152 MCP tools)
 - ✅ Live trading validation (market/limit orders tested)
 - ✅ Trading API bugs fixed (`rh.get_quotes()` corrections)
 - ✅ Full backward compatibility with STDIO transport

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ ignore_missing_imports = true
 pythonpath = ["src"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-pythonpath = ["src"]
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/tests/unit/test_docker_example.py
+++ b/tests/unit/test_docker_example.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 import tomllib
 
 import pytest
@@ -7,6 +8,8 @@ import pytest
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
 PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
 DOCKERFILE_PATH = PROJECT_ROOT / "examples" / "open-stocks-mcp-docker" / "Dockerfile"
+README_PATH = PROJECT_ROOT / "examples" / "open-stocks-mcp-docker" / "README.md"
+APP_PY_PATH = PROJECT_ROOT / "src" / "open_stocks_mcp" / "server" / "app.py"
 
 
 @pytest.mark.unit
@@ -57,3 +60,76 @@ def test_dockerfile_uses_versioned_install():
     assert unversioned_command + "\n" not in dockerfile_content, (
         "Dockerfile contains an unversioned install command; it must be replaced with the versioned one."
     )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_no_stale_version():
+    """Docker README must not contain stale package version strings."""
+    readme_content = README_PATH.read_text()
+    for stale in ["0.5.5", "v0.5.5"]:
+        assert stale not in readme_content, (
+            f"Docker README still references stale version '{stale}'"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_version_matches_pyproject():
+    """Docker README must reference the pinned PyPI version matching pyproject.toml."""
+    with open(PYPROJECT_PATH, "rb") as f:
+        pyproject_data = tomllib.load(f)
+    expected_version = pyproject_data["project"]["version"]
+    readme_content = README_PATH.read_text()
+    assert f"open-stocks-mcp=={expected_version}" in readme_content, (
+        f"Docker README must reference pinned version 'open-stocks-mcp=={expected_version}'"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_tool_count_matches_app():
+    """Docker README tool count must match active @mcp.tool() registrations in server/app.py."""
+    app_content = APP_PY_PATH.read_text()
+    actual_count = len(re.findall(r"^\s*@mcp\.tool\(\)", app_content, re.MULTILINE))
+    readme_content = README_PATH.read_text()
+    assert f"{actual_count} MCP tools" in readme_content, (
+        f"Docker README must document active tool count ({actual_count} MCP tools); "
+        "update all tool-count references in the file"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_schwab_quick_start():
+    """Docker README Quick Start must include optional Schwab credentials section."""
+    readme_content = README_PATH.read_text()
+    required_vars = [
+        "SCHWAB_API_KEY",
+        "SCHWAB_APP_SECRET",
+        "SCHWAB_CALLBACK_URL",
+        "SCHWAB_TOKEN_PATH",
+        "ENABLED_BROKERS=robinhood,schwab",
+    ]
+    for var in required_vars:
+        assert var in readme_content, (
+            f"Docker README missing Schwab env var example: {var}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_schwab_tools():
+    """Docker README Available Tools must list representative schwab_* tools."""
+    readme_content = README_PATH.read_text()
+    required_tools = [
+        "schwab_account_numbers",
+        "schwab_quote",
+        "schwab_buy_stock_market",
+        "schwab_option_chain",
+        "schwab_get_dividends",
+    ]
+    for tool in required_tools:
+        assert tool in readme_content, (
+            f"Docker README Available Tools missing representative Schwab tool: {tool}"
+        )


### PR DESCRIPTION
Closes #327

## Changes
- Update all `83 MCP tools` references to `152` (actual `@mcp.tool()` count in `server/app.py`)
- Update tool category count from 11 to 12 (new Schwab Broker category added)
- Add optional Schwab credentials block to Quick Start Step 3 (`SCHWAB_API_KEY`, `SCHWAB_APP_SECRET`, `SCHWAB_CALLBACK_URL`, `SCHWAB_TOKEN_PATH`, `ENABLED_BROKERS=robinhood,schwab`)
- Add **Schwab Broker** category to Available Tools listing with representative tools (`schwab_account_numbers`, `schwab_quote`, `schwab_buy_stock_market`, `schwab_option_chain`, `schwab_get_dividends`)
- Fix duplicate `pythonpath` key in `pyproject.toml` `[tool.pytest.ini_options]` (blocked pytest from running)
- Add 5 README drift tests to `tests/unit/test_docker_example.py` that fail when README drifts from pyproject version, active tool count, or Schwab documentation requirements

## Test plan
- `uv run pytest tests/unit/test_docker_example.py -q --tb=line` — all 7 tests pass
- `uv run ruff check tests/unit/test_docker_example.py` — lint clean
- `rg -n "0\.5\.5|v0\.5\.5|83 MCP tools" examples/open-stocks-mcp-docker/README.md` — no matches