### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ ignore_missing_imports = true
 pythonpath = ["src"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-pythonpath = ["src"]
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/src/open_stocks_mcp/brokers/base.py
+++ b/src/open_stocks_mcp/brokers/base.py
@@ -287,7 +287,9 @@ class BaseBroker(ABC):
         """
         pass
 
-    async def get_portfolio_snapshot(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    async def get_portfolio_snapshot(
+        self,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         """Get a normalized snapshot of the broker's portfolio and positions.
 
         This method provides a standard interface for cross-broker aggregation.
@@ -309,9 +311,13 @@ class BaseBroker(ABC):
 
         portfolio_data = portfolio_result.get("result", {})
         if "error" not in portfolio_data:
-            summary["market_value"] = self._safe_float(portfolio_data.get("market_value"))
+            summary["market_value"] = self._safe_float(
+                portfolio_data.get("market_value")
+            )
             summary["equity"] = self._safe_float(portfolio_data.get("equity"))
-            summary["buying_power"] = self._safe_float(portfolio_data.get("buying_power"))
+            summary["buying_power"] = self._safe_float(
+                portfolio_data.get("buying_power")
+            )
 
         positions_data = positions_result.get("result", {})
         if "error" not in positions_data:

--- a/src/open_stocks_mcp/brokers/robinhood.py
+++ b/src/open_stocks_mcp/brokers/robinhood.py
@@ -182,7 +182,9 @@ class RobinhoodBroker(BaseBroker):
 
         return await order_sell_market(symbol, int(quantity))
 
-    async def get_portfolio_snapshot(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    async def get_portfolio_snapshot(
+        self,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         """Get enriched portfolio snapshot from Robinhood."""
         summary, positions = await super().get_portfolio_snapshot()
 

--- a/src/open_stocks_mcp/brokers/schwab.py
+++ b/src/open_stocks_mcp/brokers/schwab.py
@@ -375,7 +375,9 @@ class SchwabBroker(BaseBroker):
             logger.error(f"Error getting Schwab transaction {transaction_id}: {e}")
             return {"result": {"error": str(e), "status": "error"}}
 
-    async def get_portfolio_snapshot(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    async def get_portfolio_snapshot(
+        self,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         """Get a normalized snapshot of Schwab accounts and positions."""
         summary: dict[str, Any] = {
             "market_value": 0.0,

--- a/src/open_stocks_mcp/server/tool_execution_limits.py
+++ b/src/open_stocks_mcp/server/tool_execution_limits.py
@@ -40,8 +40,7 @@ def install_tool_execution_limit(mcp_server: FastMCP, timeout_seconds: float) ->
                 "tool": tool_name,
                 "timeout_seconds": active_timeout,
                 "error": (
-                    f"Tool '{tool_name}' exceeded the "
-                    f"{active_timeout}s execution limit"
+                    f"Tool '{tool_name}' exceeded the {active_timeout}s execution limit"
                 ),
             }
             return mcp.types.CallToolResult(

--- a/src/open_stocks_mcp/tools/rate_limiter.py
+++ b/src/open_stocks_mcp/tools/rate_limiter.py
@@ -351,7 +351,9 @@ def get_broker_rate_limit_defaults(broker_name: str) -> tuple[int, int, int]:
             _int_env(
                 "OPEN_STOCKS_SCHWAB_CALLS_PER_MINUTE", DEFAULT_SCHWAB_CALLS_PER_MINUTE
             ),
-            _int_env("OPEN_STOCKS_SCHWAB_CALLS_PER_HOUR", DEFAULT_SCHWAB_CALLS_PER_HOUR),
+            _int_env(
+                "OPEN_STOCKS_SCHWAB_CALLS_PER_HOUR", DEFAULT_SCHWAB_CALLS_PER_HOUR
+            ),
             _int_env("OPEN_STOCKS_SCHWAB_BURST_SIZE", DEFAULT_SCHWAB_BURST_SIZE),
         )
     return (

--- a/src/open_stocks_mcp/tools/responses.py
+++ b/src/open_stocks_mcp/tools/responses.py
@@ -13,7 +13,9 @@ R = TypeVar("R")
 
 def create_error_response(error: Exception, context: str = "") -> dict[str, Any]:
     """Create a standardized error response."""
-    classified_error = error if isinstance(error, BrokerError) else classify_error(error)
+    classified_error = (
+        error if isinstance(error, BrokerError) else classify_error(error)
+    )
 
     response: dict[str, Any] = {
         "result": {

--- a/src/open_stocks_mcp/tools/retry.py
+++ b/src/open_stocks_mcp/tools/retry.py
@@ -72,6 +72,7 @@ async def execute_with_retry(
     from open_stocks_mcp.brokers.registry import get_broker_registry
     from open_stocks_mcp.brokers.session_state import get_session_manager
     from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
+
     last_exception = None
     retry_config = _get_retry_config()
     configured_max_retries = (
@@ -86,11 +87,7 @@ async def execute_with_retry(
     session_manager = get_session_manager()
     registry = await get_broker_registry()
     circuit_breaker = get_broker_circuit_breaker()
-    rate_limiter = (
-        registry.get_rate_limiter(broker_name)
-        if rate_limit
-        else None
-    )
+    rate_limiter = registry.get_rate_limiter(broker_name) if rate_limit else None
     auth_retry_count = 0
     max_auth_retries = retry_config.auth_max_retries
 

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -485,7 +485,9 @@ class TestMCPIntegration:
         """Test SSE endpoint wiring and first connected event payload."""
         app = create_http_server(mcp_server)
 
-        sse_route = next(route for route in app.routes if getattr(route, "path", None) == "/sse")
+        sse_route = next(
+            route for route in app.routes if getattr(route, "path", None) == "/sse"
+        )
         assert "GET" in getattr(sse_route, "methods", set())
         assert callable(getattr(sse_route, "endpoint", None))
         assert sse_route.endpoint.__name__ == "sse_endpoint"

--- a/tests/server/test_tool_execution_limits.py
+++ b/tests/server/test_tool_execution_limits.py
@@ -89,6 +89,4 @@ async def test_fast_tool_completes_normally() -> None:
     result = await server.call_tool("account_info", {})
 
     # Fast tool returns the normal call_tool result (not a timeout CallToolResult)
-    assert not (
-        isinstance(result, mcp.types.CallToolResult) and result.isError is True
-    )
+    assert not (isinstance(result, mcp.types.CallToolResult) and result.isError is True)

--- a/tests/unit/test_broker_registry.py
+++ b/tests/unit/test_broker_registry.py
@@ -425,13 +425,17 @@ class TestBrokerRegistry:
 
     @pytest.mark.asyncio
     async def test_broker_rate_limiters_are_independent(self, registry, monkeypatch):
-        monkeypatch.setattr("open_stocks_mcp.tools.rate_limiter.time.time", lambda: 1000.0)
+        monkeypatch.setattr(
+            "open_stocks_mcp.tools.rate_limiter.time.time", lambda: 1000.0
+        )
         sleep_calls: list[float] = []
 
         async def fake_sleep(seconds: float) -> None:
             sleep_calls.append(seconds)
 
-        monkeypatch.setattr("open_stocks_mcp.tools.rate_limiter.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr(
+            "open_stocks_mcp.tools.rate_limiter.asyncio.sleep", fake_sleep
+        )
 
         robinhood = registry.get_rate_limiter("robinhood")
         schwab = registry.get_rate_limiter("schwab")

--- a/tests/unit/test_cross_broker_tools.py
+++ b/tests/unit/test_cross_broker_tools.py
@@ -70,7 +70,9 @@ class TestGetAggregatedPortfolio:
             rh_broker if name == "robinhood" else schwab_broker
         )
 
-        async def _slow_snapshot(*_args: Any, **_kwargs: Any) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        async def _slow_snapshot(
+            *_args: Any, **_kwargs: Any
+        ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
             await asyncio.sleep(0.2)
             return (
                 {
@@ -475,7 +477,9 @@ class TestGetAggregatedPortfolio:
         )
 
         # Robinhood raises an exception during portfolio collection
-        rh_broker.get_portfolio_snapshot = AsyncMock(side_effect=RuntimeError("rh boom"))
+        rh_broker.get_portfolio_snapshot = AsyncMock(
+            side_effect=RuntimeError("rh boom")
+        )
 
         # Schwab returns valid data with one MSFT position
         schwab_broker.get_portfolio_snapshot = AsyncMock(
@@ -525,7 +529,9 @@ class TestGetAggregatedPortfolio:
     @pytest.mark.asyncio
     @pytest.mark.unit
     @pytest.mark.journey_portfolio
-    async def test_registered_third_broker_snapshot_is_aggregated_without_name_branch(self) -> None:
+    async def test_registered_third_broker_snapshot_is_aggregated_without_name_branch(
+        self,
+    ) -> None:
         """A third broker registered under a new name is aggregated if it implements snapshots."""
         mock_registry = MagicMock()
         mock_registry.list_brokers.return_value = ["paper"]

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -143,7 +143,10 @@ def test_robinhood_errors_subclass_broker_hierarchy_and_tag_broker() -> None:
     assert isinstance(auth_error, BrokerError)
     assert RobinStocksError("x").broker == "robinhood"
     assert classify_error(RuntimeError("unauthorized")).broker == "robinhood"
-    assert create_error_response(RuntimeError("unauthorized"))["result"]["broker"] == "robinhood"
+    assert (
+        create_error_response(RuntimeError("unauthorized"))["result"]["broker"]
+        == "robinhood"
+    )
 
 
 def test_create_error_response_without_context() -> None:
@@ -542,7 +545,9 @@ async def test_execute_with_retry_caches_retry_config(
 ) -> None:
     retry_module._get_retry_config.cache_clear()
     mock_load_config = Mock(
-        return_value=SimpleNamespace(retry=RetryConfig(max_retries=0, initial_delay=0.01, backoff_factor=2.0))
+        return_value=SimpleNamespace(
+            retry=RetryConfig(max_retries=0, initial_delay=0.01, backoff_factor=2.0)
+        )
     )
     monkeypatch.setattr("open_stocks_mcp.tools.retry.load_config", mock_load_config)
     _patch_retry_dependencies(monkeypatch)

--- a/tests/unit/test_rate_limited_marker.py
+++ b/tests/unit/test_rate_limited_marker.py
@@ -283,6 +283,7 @@ def test_pytester_explicit_m_not_rate_limited_selects_unmarked(
 
     result.assert_outcomes(passed=1, deselected=1)
 
+
 @pytest.mark.unit
 def test_subprocess_rate_limited_marker_tests_are_marked_slow() -> None:
     """Ensure subprocess tests are marked slow to avoid running in fast sessions."""

--- a/tests/unit/test_rate_limiter_isolation.py
+++ b/tests/unit/test_rate_limiter_isolation.py
@@ -76,9 +76,7 @@ def test_autouse_fixture_prevents_cross_test_bleed() -> None:
 @pytest.mark.asyncio
 async def test_option_position_tools_complete_fast() -> None:
     """Previously flaky option-position calls should return quickly."""
-    cases: list[
-        tuple[str, Callable[[], Awaitable[dict[str, Any]]], Any]
-    ] = [
+    cases: list[tuple[str, Callable[[], Awaitable[dict[str, Any]]], Any]] = [
         (
             "open_stocks_mcp.tools.options.positions.rh.options.get_aggregate_positions",
             get_aggregate_positions,

--- a/tests/unit/test_robinhood_broker.py
+++ b/tests/unit/test_robinhood_broker.py
@@ -481,10 +481,14 @@ class TestRobinhoodGetPortfolioSnapshotEnrichment:
 
         with (
             patch.object(
-                RobinhoodBroker, "get_portfolio", new=AsyncMock(return_value=rh_portfolio)
+                RobinhoodBroker,
+                "get_portfolio",
+                new=AsyncMock(return_value=rh_portfolio),
             ),
             patch.object(
-                RobinhoodBroker, "get_positions", new=AsyncMock(return_value=rh_positions)
+                RobinhoodBroker,
+                "get_positions",
+                new=AsyncMock(return_value=rh_positions),
             ),
             patch(
                 "open_stocks_mcp.brokers.robinhood.execute_with_retry",
@@ -515,10 +519,14 @@ class TestRobinhoodGetPortfolioSnapshotEnrichment:
 
         with (
             patch.object(
-                RobinhoodBroker, "get_portfolio", new=AsyncMock(return_value=rh_portfolio)
+                RobinhoodBroker,
+                "get_portfolio",
+                new=AsyncMock(return_value=rh_portfolio),
             ),
             patch.object(
-                RobinhoodBroker, "get_positions", new=AsyncMock(return_value=rh_positions)
+                RobinhoodBroker,
+                "get_positions",
+                new=AsyncMock(return_value=rh_positions),
             ),
             patch(
                 "open_stocks_mcp.brokers.robinhood.execute_with_retry",
@@ -547,10 +555,14 @@ class TestRobinhoodGetPortfolioSnapshotEnrichment:
 
         with (
             patch.object(
-                RobinhoodBroker, "get_portfolio", new=AsyncMock(return_value=rh_portfolio)
+                RobinhoodBroker,
+                "get_portfolio",
+                new=AsyncMock(return_value=rh_portfolio),
             ),
             patch.object(
-                RobinhoodBroker, "get_positions", new=AsyncMock(return_value=rh_positions)
+                RobinhoodBroker,
+                "get_positions",
+                new=AsyncMock(return_value=rh_positions),
             ),
             patch(
                 "open_stocks_mcp.brokers.robinhood.execute_with_retry",
@@ -584,10 +596,14 @@ class TestRobinhoodGetPortfolioSnapshotEnrichment:
 
         with (
             patch.object(
-                RobinhoodBroker, "get_portfolio", new=AsyncMock(return_value=rh_portfolio)
+                RobinhoodBroker,
+                "get_portfolio",
+                new=AsyncMock(return_value=rh_portfolio),
             ),
             patch.object(
-                RobinhoodBroker, "get_positions", new=AsyncMock(return_value=rh_positions)
+                RobinhoodBroker,
+                "get_positions",
+                new=AsyncMock(return_value=rh_positions),
             ),
             patch(
                 "open_stocks_mcp.brokers.robinhood.execute_with_retry",

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -467,30 +467,36 @@ async def test_ensure_authenticated_session_returns_error_tuple_on_exception() -
     assert success is False
     assert error == "invalid credentials"
 
+
 def test_pickle_clear_failure_threshold_can_be_configured(tmp_path: Path) -> None:
     manager = SessionManager(max_pickle_clear_failures=1)
     pickle_path = tmp_path / "robinhood.pickle"
     pickle_path.write_text("session")
-    
+
     with (
-        patch.object(manager._pickle, "_get_pickle_file_path", return_value=pickle_path),
-        patch.object(Path, "unlink", side_effect=PermissionError("denied"))
+        patch.object(
+            manager._pickle, "_get_pickle_file_path", return_value=pickle_path
+        ),
+        patch.object(Path, "unlink", side_effect=PermissionError("denied")),
     ):
         manager._clear_pickle_file()
         assert manager.should_block_auth_retries() is True
+
 
 def test_pickle_clear_failure_threshold_defaults_to_three(tmp_path: Path) -> None:
     manager = SessionManager()
     pickle_path = tmp_path / "robinhood.pickle"
     pickle_path.write_text("session")
-    
+
     with (
-        patch.object(manager._pickle, "_get_pickle_file_path", return_value=pickle_path),
-        patch.object(Path, "unlink", side_effect=PermissionError("denied"))
+        patch.object(
+            manager._pickle, "_get_pickle_file_path", return_value=pickle_path
+        ),
+        patch.object(Path, "unlink", side_effect=PermissionError("denied")),
     ):
         manager._clear_pickle_file()
         manager._clear_pickle_file()
         assert manager.should_block_auth_retries() is False
-        
+
         manager._clear_pickle_file()
         assert manager.should_block_auth_retries() is True


### PR DESCRIPTION
## Automated Code-Quality Cleanup

**Tools applied:** `ruff check --fix`, `ruff format`

### Changes
- **pyproject.toml** — removed duplicate `pythonpath` key in `[tool.pytest.ini_options]`
- **16 files reformatted** — consistent formatting across src/ and tests/

### Diff summary (17 files, +89 −44)
| Area | Files | Changes |
|------|-------|---------|
| `src/` | 6 | Format fixes (line length, trailing commas, imports) |
| `tests/` | 10 | Format fixes |
| `pyproject.toml` | 1 | Duplicate key removal |

### Validation
- **mypy**: ✅ 0 errors (86 source files)
- **ruff**: ✅ All checks passed
- **pytest**: 1007 passed, 8 failed (pre-existing), 69 skipped

🤖 Generated by AgentShore cleanup play