### PR TITLE
test: tighten redirected stderr MFA assertion

### DIFF
--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -406,7 +406,7 @@ def test_interactive_mfa_prompt_uses_original_stderr_when_stderr_is_redirected()
     assert code == "654321"
     assert "ROBINHOOD MFA REQUIRED" in original_stderr.getvalue()
     assert "Enter verification code:" in original_stderr.getvalue()
-    assert "ROBINHOOD MFA REQUIRED" not in redirected_stderr.getvalue()
+    assert redirected_stderr.getvalue() == ""
 
 
 @pytest.mark.journey_account


### PR DESCRIPTION
Closes #349

## Changes
- tightened `test_interactive_mfa_prompt_uses_original_stderr_when_stderr_is_redirected` to assert redirected stderr is exactly empty (`== ""`)
- kept existing assertions that prompt text is emitted to `sys.__stderr__` and MFA code is read from interactive stdin

## Test plan
- `uv run pytest tests/unit/test_session_manager.py::test_interactive_mfa_prompt_uses_original_stderr_when_stderr_is_redirected -q --tb=line` *(blocked: `pyproject.toml` duplicate key `pythonpath`)*
- `pytest tests/unit/test_session_manager.py::test_interactive_mfa_prompt_uses_original_stderr_when_stderr_is_redirected -q --tb=line` *(blocked: same parse error)*
- `uv run ruff check tests/unit/test_session_manager.py` *(blocked: same parse error)*
- `ruff check tests/unit/test_session_manager.py` *(blocked: same parse error)*