### PR TITLE
test: restore RUN_RATE_LIMITED=1 assertion in doc-presence test

### DIFF
--- a/tests/unit/test_rate_limited_marker.py
+++ b/tests/unit/test_rate_limited_marker.py
@@ -216,6 +216,7 @@ def test_rate_limited_docs_are_present() -> None:
     for relative_path in ("README.md", "CLAUDE.md"):
         content = (ROOT / relative_path).read_text(encoding="utf-8")
         assert "rate_limited" in content
+        assert "RUN_RATE_LIMITED=1" in content
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #350

## Changes
- Restored the `RUN_RATE_LIMITED=1` assertion in `test_rate_limited_docs_are_present` that was simplified away during PR #320 review
- Guards against silent removal of the env-var documentation form from `README.md` and `CLAUDE.md`

## Test plan
- `uv run pytest tests/unit/test_rate_limited_marker.py::test_rate_limited_docs_are_present -q` passes with the restored assertion
- Full `tests/unit/test_rate_limited_marker.py` suite has no regressions from this change (pre-existing `test_rate_limited_collection_nodeids` failure confirmed on `main`)
- `ruff check` passes on the modified file