### PR TITLE
docs: update Docker README tool count, Schwab docs, and pin policy

### DIFF
--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -147,10 +147,12 @@ Update your `.env` file with both Robinhood and Schwab credentials:
 ROBINHOOD_USERNAME=your_username
 ROBINHOOD_PASSWORD=your_password
 
-# Schwab
+# Schwab (optional — omit if only using Robinhood)
 SCHWAB_API_KEY=your_api_key
 SCHWAB_APP_SECRET=your_app_secret
+SCHWAB_CALLBACK_URL=https://127.0.0.1:8182/
 SCHWAB_TOKEN_PATH=/home/mcp/.tokens/schwab_token.json
+ENABLED_BROKERS=robinhood,schwab
 
 # Security (Required for Docker)
 MCP_API_KEY=your_long_random_secret
@@ -253,7 +255,7 @@ curl http://localhost:3001/status
 
 # Available tools list
 curl http://localhost:3001/tools
-# Returns: Complete list of 83 available MCP tools
+# Returns: Complete list of 152 available MCP tools
 ```
 
 ✅ **Security features validated:**
@@ -269,8 +271,9 @@ curl http://localhost:3001/tools
 
 ### Available Tools
 
-The server provides **83 MCP tools** across **11 categories**:
+The server provides **152 MCP tools** across **12 categories**:
 
+**Robinhood tools:**
 - **Account Management**: `account_info`, `portfolio`, `account_details`, `positions`
 - **Market Data**: `stock_price`, `stock_info`, `search_stocks_tool`, `market_hours`, `price_history`
 - **Options Trading**: `options_chains`, `find_options`, `option_market_data`, `option_historicals`
@@ -282,6 +285,13 @@ The server provides **83 MCP tools** across **11 categories**:
 - **Trading Operations**: `buy_stock_market`, `buy_stock_limit`, `sell_stock_market`, `cancel_stock_order_by_id`
 - **System Management**: `session_status`, `rate_limit_status`, `metrics_summary`, `health_check`
 - **Utility**: `list_tools`
+
+**Schwab tools** (enabled when `ENABLED_BROKERS=robinhood,schwab`):
+- **Account**: `schwab_account_numbers`, `schwab_account_details`, `schwab_all_accounts`
+- **Market Data**: `schwab_quote`, `schwab_quotes`, `schwab_price_history`, `schwab_market_hours`
+- **Trading**: `schwab_buy_stock_market`, `schwab_sell_stock_market`, `schwab_buy_stock_limit`
+- **Options**: `schwab_option_chain`, `schwab_option_expiration_dates`
+- **Research**: `schwab_get_dividends`, `schwab_instruments`, `schwab_movers`
 
 ## Management
 
@@ -369,15 +379,17 @@ Adjust these in `docker-compose.yml` based on your needs.
 - ✅ FastAPI-based server with comprehensive middleware
 - ✅ Security headers and CORS support
 - ✅ Health check and monitoring endpoints
-- ✅ Complete trading functionality (83 MCP tools)
+- ✅ Complete trading functionality (152 MCP tools)
 - ✅ Live trading validation (market/limit orders tested)
 - ✅ Trading API bugs fixed (`rh.get_quotes()` corrections)
 - ✅ Full backward compatibility with STDIO transport
 
 **Container Image:**
-- **Production**: Uses PyPI package `open-stocks-mcp==0.6.5`
+- **Production**: Uses PyPI package `open-stocks-mcp==0.6.5` pinned via the `OPEN_STOCKS_MCP_VERSION` Dockerfile build arg
 - **Development**: Built from source with latest features
 - **Base**: Python 3.11-slim for security and performance
+
+**Updating the pinned version:** The production image installs a specific PyPI release rather than pulling `latest`. To upgrade to a new release, update `ARG OPEN_STOCKS_MCP_VERSION=<new-version>` in `Dockerfile` (or override with `--build-arg OPEN_STOCKS_MCP_VERSION=<new-version>`) and rebuild with `docker-compose build --no-cache`.
 
 ### Trading Features Validated
 - ✅ **Market Orders**: `buy_stock_market` tested with XOM

--- a/tests/unit/test_docker_example.py
+++ b/tests/unit/test_docker_example.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 import tomllib
 
 import pytest
@@ -7,6 +8,26 @@ import pytest
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
 PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
 DOCKERFILE_PATH = PROJECT_ROOT / "examples" / "open-stocks-mcp-docker" / "Dockerfile"
+DOCKER_README_PATH = PROJECT_ROOT / "examples" / "open-stocks-mcp-docker" / "README.md"
+APP_PY_PATH = PROJECT_ROOT / "src" / "open_stocks_mcp" / "server" / "app.py"
+
+_STALE_VERSION_PATTERN = re.compile(r"0\.5\.5")
+
+_REQUIRED_SCHWAB_ENV_VARS = [
+    "SCHWAB_API_KEY",
+    "SCHWAB_APP_SECRET",
+    "SCHWAB_CALLBACK_URL",
+    "SCHWAB_TOKEN_PATH",
+    "ENABLED_BROKERS=robinhood,schwab",
+]
+
+_REQUIRED_SCHWAB_TOOLS = [
+    "schwab_account_numbers",
+    "schwab_quote",
+    "schwab_buy_stock_market",
+    "schwab_option_chain",
+    "schwab_get_dividends",
+]
 
 
 @pytest.mark.unit
@@ -56,4 +77,76 @@ def test_dockerfile_uses_versioned_install():
     unversioned_command = "RUN pip install --no-cache-dir --upgrade open-stocks-mcp"
     assert unversioned_command + "\n" not in dockerfile_content, (
         "Dockerfile contains an unversioned install command; it must be replaced with the versioned one."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_no_stale_version():
+    """Docker README must not reference the stale 0.5.5 release."""
+    readme_content = DOCKER_README_PATH.read_text()
+    matches = _STALE_VERSION_PATTERN.findall(readme_content)
+    assert not matches, (
+        f"Docker README still contains stale version string '0.5.5' ({len(matches)} occurrences). "
+        "Update every reference to match pyproject.toml."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_tool_count_matches_app():
+    """Docker README tool count must match the @mcp.tool() registrations in server/app.py."""
+    readme_content = DOCKER_README_PATH.read_text()
+    app_content = APP_PY_PATH.read_text()
+
+    actual_count = sum(
+        1
+        for line in app_content.splitlines()
+        if line.strip() == "@mcp.tool()"
+    )
+
+    # Find all numeric tool-count claims in the README (e.g. "152 MCP tools", "**152 MCP tools**")
+    claimed = re.findall(r"\b(\d+)\s+MCP tools\b", readme_content)
+    assert claimed, "Docker README contains no '\\d+ MCP tools' claim — add the tool count."
+
+    wrong = [c for c in claimed if int(c) != actual_count]
+    assert not wrong, (
+        f"Docker README claims {wrong} MCP tools but src/open_stocks_mcp/server/app.py "
+        f"has {actual_count} @mcp.tool() registrations. Update every count in the README."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_includes_schwab_env_vars():
+    """Docker README Quick Start must document optional Schwab environment variables."""
+    readme_content = DOCKER_README_PATH.read_text()
+    missing = [var for var in _REQUIRED_SCHWAB_ENV_VARS if var not in readme_content]
+    assert not missing, (
+        f"Docker README Quick Start is missing Schwab env vars: {missing}. "
+        "Add an optional Schwab credentials block to the Quick Start section."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_lists_schwab_tools():
+    """Docker README Available Tools section must include representative schwab_* tools."""
+    readme_content = DOCKER_README_PATH.read_text()
+    missing = [tool for tool in _REQUIRED_SCHWAB_TOOLS if tool not in readme_content]
+    assert not missing, (
+        f"Docker README Available Tools section is missing schwab_* tools: {missing}. "
+        "Add representative Schwab tools to the Available Tools listing."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_docker_readme_documents_pypi_pin_policy():
+    """Docker README must explain the pinned PyPI version policy via OPEN_STOCKS_MCP_VERSION."""
+    readme_content = DOCKER_README_PATH.read_text()
+    assert "OPEN_STOCKS_MCP_VERSION" in readme_content, (
+        "Docker README must document the OPEN_STOCKS_MCP_VERSION build arg used to pin the "
+        "PyPI package version. Add a note explaining that changing the release requires "
+        "updating this build arg before rebuilding."
     )


### PR DESCRIPTION
Closes #327

## Changes

- Correct MCP tool count from 83 to 152 (matches `@mcp.tool()` registrations in `src/open_stocks_mcp/server/app.py`)
- Add `SCHWAB_CALLBACK_URL` and `ENABLED_BROKERS=robinhood,schwab` to multi-broker credentials block in the Docker README
- Add representative `schwab_*` tools to the Available Tools section (`schwab_account_numbers`, `schwab_quote`, `schwab_buy_stock_market`, `schwab_option_chain`, `schwab_get_dividends`, and more)
- Document `OPEN_STOCKS_MCP_VERSION` build arg and explain the pinned PyPI version policy with update instructions
- Add 5 README drift tests to `tests/unit/test_docker_example.py` that enforce: no stale 0.5.5 references, tool count matches app.py, Schwab env vars present, Schwab tools listed, and pin policy documented

## Test plan

- `uv run pytest tests/unit/test_docker_example.py -q --tb=line` — all 7 tests pass (2 existing + 5 new)
- `uv run ruff check tests/unit/test_docker_example.py` — linting passes
- `rg -n "0\.5\.5|v0\.5\.5|83 MCP tools" examples/open-stocks-mcp-docker/README.md` — exits with no matches