### PR TITLE
test: fix comment indentation in HTTP error handling test

### DIFF
--- a/tests/http_transport/test_http_error_handling.py
+++ b/tests/http_transport/test_http_error_handling.py
@@ -82,8 +82,7 @@ class TestHTTPErrorHandling:
             headers={"content-type": "application/json"},
         )
         assert response.status_code in [400, 401, 422]
-
-    # Bad Request or Unprocessable Entity
+        # Bad Request or Unprocessable Entity
 
     async def test_invalid_content_type(self, http_client: httpx.AsyncClient) -> None:
         """Test handling of invalid content types"""


### PR DESCRIPTION
Closes #360

## Changes
- move  comment back into 
- align indentation/scoping with the surrounding test body

## Test plan
- uv run pytest tests/http_transport/test_http_error_handling.py -q