### PR TITLE
refactor: add _require_health_service() guard consistent with existing helpers

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -209,6 +209,14 @@ def _require_metrics_collector() -> Any:
     return metrics_collector
 
 
+def _require_health_service() -> Any:
+    """Return health service or raise 503 when unavailable."""
+    svc = get_health_service()
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Service unhealthy")
+    return svc
+
+
 class BearerAuthMiddleware(BaseHTTPMiddleware):
     """Require ``Authorization: Bearer <api_key>`` on protected endpoints.
 
@@ -394,7 +402,7 @@ def create_http_server(
         try:
             _require_session_manager()
             metrics_collector = _require_metrics_collector()
-            health_service = get_health_service()
+            health_service = _require_health_service()
             health_status = await health_service.get_status()
             metrics = await metrics_collector.get_metrics()
 

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -184,6 +184,23 @@ class TestHttpTransportUnit:
         assert "POST" in response.headers["access-control-allow-methods"]
 
     @patch(
+        "open_stocks_mcp.server.http_transport.get_health_service", return_value=None
+    )
+    @patch(
+        "open_stocks_mcp.server.http_transport.get_metrics_collector",
+        return_value=AsyncMock(),
+    )
+    def test_health_returns_503_when_health_service_unavailable(
+        self,
+        _mock_get_metrics_collector: Mock,
+        _mock_get_health_service: Mock,
+        client: TestClient,
+    ) -> None:
+        response = client.get("/health")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Service unhealthy"
+
+    @patch(
         "open_stocks_mcp.server.http_transport.get_metrics_collector", return_value=None
     )
     def test_mcp_tools_call_propagates_metrics_collector_http_exception(


### PR DESCRIPTION
Closes #361

## Changes
- Added `_require_health_service()` helper in `http_transport.py`, consistent with the existing `_require_session_manager()` and `_require_metrics_collector()` guard pattern
- Updated `health_check()` endpoint to use `_require_health_service()` instead of calling `get_health_service()` directly, making the failure mode an explicit 503 HTTPException rather than an implicit AttributeError
- Added unit test `test_health_returns_503_when_health_service_unavailable` covering the new guard

## Test plan
- `pytest tests/unit/test_http_transport.py -q` — all 16 tests pass including the new one
- `ruff check src/open_stocks_mcp/server/http_transport.py tests/unit/test_http_transport.py` — clean
- `mypy src/open_stocks_mcp/server/http_transport.py` — clean