### PR TITLE
fix: return -32600 for missing/non-string MCP method

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -596,6 +596,26 @@ def create_http_server(
             params = json_request.get("params", {})
             _log_mcp_request(method, request_id)
 
+            if not isinstance(method, str):
+                return _mcp_json_response(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32600,
+                            "message": (
+                                "Invalid Request: method missing or not a string"
+                            ),
+                        },
+                        "id": request_id,
+                    },
+                    status_code=200,
+                    method=method,
+                    request_id=request_id,
+                    outcome="error",
+                    error_code=-32600,
+                    error_type="invalid_request",
+                )
+
             try:
                 result: dict[str, Any]
                 if method == "initialize":

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -89,6 +89,29 @@ class TestHttpTransportUnit:
         assert "method not found" in body["error"]["message"].lower()
         assert body["id"] == 7
 
+    def test_mcp_missing_method_returns_invalid_request_minus_32600(
+        self, client: TestClient
+    ) -> None:
+        response = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["error"]["code"] == -32600
+        assert "invalid request" in body["error"]["message"].lower()
+        assert body["id"] == 1
+
+    def test_mcp_non_string_method_returns_invalid_request_minus_32600(
+        self, client: TestClient
+    ) -> None:
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": None, "id": 2},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["error"]["code"] == -32600
+        assert "invalid request" in body["error"]["message"].lower()
+        assert body["id"] == 2
+
     def test_mcp_tools_call_missing_name_returns_invalid_params_minus_32602(
         self, client: TestClient
     ) -> None:


### PR DESCRIPTION
Closes #363

## Changes
- add MCP JSON-RPC guard in `/mcp` handler to treat missing/non-string `method` as Invalid Request (`-32600`)
- preserve unknown string method behavior as Method Not Found (`-32601`)
- add unit tests for missing and non-string `method` payloads and id preservation

## Test plan
- uv run pytest tests/unit/test_http_transport.py::TestHttpTransportUnit -q --tb=line
- uv run ruff check src/open_stocks_mcp/server/http_transport.py tests/unit/test_http_transport.py