### PR TITLE
fix: redesign Schwab orders eval as multi-step flow

### DIFF
--- a/examples/google_adk_agent/README.md
+++ b/examples/google_adk_agent/README.md
@@ -146,13 +146,13 @@ The agent has access to 60+ MCP tools organized into these categories:
 You can evaluate the agent's performance using ADK's evaluation tools. 
 
 ### **Schwab Orders Evaluation**
-To test the agent's ability to retrieve Schwab order history (read-only), run:
+Multi-step eval: the agent first calls `schwab_account_numbers` to resolve the account hash, then calls `schwab_orders` to retrieve order history — no raw account hash in the user prompt.
 
 ```bash
 MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
 ```
 
-> **Note**: This evaluation requires live Schwab OAuth credentials and a valid account hash returned by `schwab_account_numbers`.
+> **Note**: This evaluation requires live Schwab OAuth credentials.
 
 ## Agent Capabilities
 

--- a/tests/evals/5_ord_schwab_orders_test.json
+++ b/tests/evals/5_ord_schwab_orders_test.json
@@ -1,7 +1,7 @@
 {
   "eval_set_id": "schwab_orders_test_set",
   "name": "Schwab Orders Test",
-  "description": "Test case for retrieving Schwab orders through agent interaction",
+  "description": "Multi-step test: agent resolves Schwab account hash via schwab_account_numbers, then retrieves orders via schwab_orders",
   "eval_cases": [
     {
       "eval_id": "schwab_orders_test",
@@ -11,7 +11,7 @@
           "user_content": {
             "parts": [
               {
-                "text": "Show me my recent orders on Schwab for account REPLACE_WITH_SCHWAB_ACCOUNT_HASH. (Note: The placeholder account hash must be replaced with a real hash from schwab_account_numbers before live execution.)"
+                "text": "Show me my recent Schwab orders."
               }
             ],
             "role": "user"
@@ -19,7 +19,7 @@
           "final_response": {
             "parts": [
               {
-                "text": "I have retrieved your recent orders for Schwab account REPLACE_WITH_SCHWAB_ACCOUNT_HASH. You have 0 open orders. (Note: For live execution, ensure REPLACE_WITH_SCHWAB_ACCOUNT_HASH is replaced with a real account hash returned by the schwab_account_numbers tool.)"
+                "text": "I looked up your Schwab account and retrieved your recent orders. Here is a summary of your order history."
               }
             ],
             "role": "model"
@@ -28,9 +28,13 @@
             "tool_uses": [
               {
                 "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
                 "args": {
-                  "account_hash": "REPLACE_WITH_SCHWAB_ACCOUNT_HASH",
-                  "max_results": 10
+                  "account_hash": "resolved-account-hash"
                 },
                 "name": "schwab_orders"
               }

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -258,9 +258,9 @@ Evaluations for Schwab-specific tools. These typically require live Schwab OAuth
 - `tests/evals/2_mkt_schwab_search_instruments_test.json` — exercises `schwab_search_instruments`.
 - `tests/evals/8_opt_schwab_option_chain_test.json` — exercises `schwab_option_chain`.
 - `tests/evals/8_opt_schwab_option_expirations_test.json` — exercises `schwab_option_expirations`.
-- `tests/evals/5_ord_schwab_orders_test.json` — exercises `schwab_orders` (requires `account_hash`).
+- `tests/evals/5_ord_schwab_orders_test.json` — multi-step: `schwab_account_numbers` then `schwab_orders` to retrieve recent orders without requiring a raw account hash in the user message.
 
-> **Note on Schwab Evaluations**: Most Schwab evaluations require live OAuth credentials. The `schwab_orders` evaluation specifically requires a valid `account_hash`, which can be retrieved using the `schwab_account_numbers` tool. For testing, replace the `REPLACE_WITH_SCHWAB_ACCOUNT_HASH` placeholder in the JSON with a real hash from your account.
+> **Note on Schwab Evaluations**: Most Schwab evaluations require live OAuth credentials.
 >
 > The `final_response` examples in Schwab eval JSON files are illustrative placeholders only. Before running against a live Schwab account, update those expected values (account numbers, account hashes, quotes, and other account-specific fields) to match real output from your account, or ADK eval assertions will fail.
 


### PR DESCRIPTION
Closes #365

## Changes
- Redesigned `5_ord_schwab_orders_test.json` as a multi-step eval: agent calls `schwab_account_numbers` first to resolve the account hash, then calls `schwab_orders` with the resolved hash
- Removed `REPLACE_WITH_SCHWAB_ACCOUNT_HASH` placeholder from the user message — the prompt now reads naturally: "Show me my recent Schwab orders."
- Removed hardcoded `max_results: 10` that conflicted with the tool's default of 50
- Updated `ADK-testing-evals.md` and `examples/google_adk_agent/README.md` to describe the multi-step flow

## Test plan
- Verified JSON is valid and structurally matches existing multi-step evals (e.g., `8_opt_option_market_data_test.json`)
- Confirmed no `REPLACE_WITH` placeholders remain in any eval file
- Unit tests pass (pre-existing failures in cache/dependency/rate-limit tests are unrelated)
- Ruff lint passes on all changed files