### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -402,16 +402,16 @@ def _parse_broker_settings(brokers_yaml: dict[str, Any]) -> BrokerSettings:
         rh_timeout = 23
 
     sc_api_key = os.getenv("SCHWAB_API_KEY") or _optional_string(sc_yaml.get("api_key"))
-    sc_app_secret = (
-        os.getenv("SCHWAB_APP_SECRET") or _optional_string(sc_yaml.get("app_secret"))
+    sc_app_secret = os.getenv("SCHWAB_APP_SECRET") or _optional_string(
+        sc_yaml.get("app_secret")
     )
     sc_callback_url = (
         os.getenv("SCHWAB_CALLBACK_URL")
         or _optional_string(sc_yaml.get("callback_url"))
         or "https://127.0.0.1:8182/"
     )
-    sc_token_path = (
-        os.getenv("SCHWAB_TOKEN_PATH") or _optional_string(sc_yaml.get("token_path"))
+    sc_token_path = os.getenv("SCHWAB_TOKEN_PATH") or _optional_string(
+        sc_yaml.get("token_path")
     )
 
     raw_enabled = os.getenv("ENABLED_BROKERS")

--- a/tests/unit/test_docker_example.py
+++ b/tests/unit/test_docker_example.py
@@ -100,14 +100,14 @@ def test_docker_readme_tool_count_matches_app():
     app_content = APP_PY_PATH.read_text()
 
     actual_count = sum(
-        1
-        for line in app_content.splitlines()
-        if line.strip() == "@mcp.tool()"
+        1 for line in app_content.splitlines() if line.strip() == "@mcp.tool()"
     )
 
     # Find all numeric tool-count claims in the README (e.g. "152 MCP tools", "**152 MCP tools**")
     claimed = re.findall(r"\b(\d+)\s+MCP tools\b", readme_content)
-    assert claimed, "Docker README contains no '\\d+ MCP tools' claim — add the tool count."
+    assert claimed, (
+        "Docker README contains no '\\d+ MCP tools' claim — add the tool count."
+    )
 
     wrong = [c for c in claimed if int(c) != actual_count]
     assert not wrong, (

--- a/tests/unit/test_phase8_parent_acceptance.py
+++ b/tests/unit/test_phase8_parent_acceptance.py
@@ -27,12 +27,6 @@ class TestReadmeDiscoverability:
     def test_links_api_tools_reference(self) -> None:
         assert "docs/api/tools.md" in self.readme
 
-    def test_api_docs_use_public_ci_scope_language(self) -> None:
-        api_readme = (ROOT / "docs" / "api" / "README.md").read_text()
-        api_lower = api_readme.lower()
-        assert "foreman skills" not in api_lower
-        assert "Notebook execution is intentionally not run in CI by design." in api_readme
-
     def test_links_notebooks_via_api_docs(self) -> None:
         assert "notebook" in self.readme.lower()
         api_readme = (ROOT / "docs" / "api" / "README.md").read_text()
@@ -51,7 +45,9 @@ class TestReadmeDiscoverability:
         api_readme = (ROOT / "docs" / "api" / "README.md").read_text()
         assert "Foreman skills" not in api_readme
         assert "foreman skills" not in api_readme.lower()
-        assert "Notebook execution is intentionally not run in CI by design." in api_readme
+        assert (
+            "Notebook execution is intentionally not run in CI by design." in api_readme
+        )
 
 
 class TestGeneratedToolDocs:


### PR DESCRIPTION
## Summary

Automated code-quality cleanup via ruff check/format and manual fix.

### Changes
- **src/open_stocks_mcp/config.py** — ruff format (whitespace/style)
- **tests/unit/test_docker_example.py** — ruff format (whitespace/style)
- **tests/unit/test_phase8_parent_acceptance.py** — removed duplicate method `test_api_docs_use_public_ci_scope_language` (F811 redefinition), kept the more thorough version

### Validation
- ruff check: **pass** (0 errors)
- mypy: **pass** (0 errors, 86 source files)
- pytest unit: **1023 passed**, 9 failed (pre-existing), 69 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)