### PR TITLE
fix: normalize unified watchlist mutation status

### DIFF
--- a/src/open_stocks_mcp/tools/unified_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/unified_watchlist_tools.py
@@ -31,6 +31,23 @@ def _normalize_symbols(symbols: list[str]) -> list[str]:
     return normalized
 
 
+def _compute_mutation_status(per_broker: dict[str, dict[str, Any]]) -> str:
+    """Compute mutation status while treating unsupported brokers as neutral."""
+    actionable_statuses = [
+        broker_result.get("status")
+        for broker_result in per_broker.values()
+        if broker_result.get("status") != "unsupported"
+    ]
+
+    if not actionable_statuses:
+        return "error"
+    if all(status == "success" for status in actionable_statuses):
+        return "success"
+    if any(status == "success" for status in actionable_statuses):
+        return "partial_success"
+    return "error"
+
+
 async def get_unified_watchlists(brokers: list[str] | None = None) -> dict[str, Any]:
     """Get all watchlists across supported brokers."""
     registry = await get_broker_registry()
@@ -206,14 +223,7 @@ async def add_symbols_to_unified_watchlist(
                 {"broker": "schwab", "message": "Add operation ignored for Schwab."}
             )
 
-    # Determine overall status
-    success_count = sum(1 for b in per_broker.values() if b.get("status") == "success")
-    if success_count == len(per_broker) and len(per_broker) > 0:
-        status = "success"
-    elif success_count > 0:
-        status = "partial_success"
-    else:
-        status = "error"
+    status = _compute_mutation_status(per_broker)
 
     return create_success_response(
         {
@@ -265,13 +275,7 @@ async def remove_symbols_from_unified_watchlist(
                 {"broker": "schwab", "message": "Remove operation ignored for Schwab."}
             )
 
-    success_count = sum(1 for b in per_broker.values() if b.get("status") == "success")
-    if success_count == len(per_broker) and len(per_broker) > 0:
-        status = "success"
-    elif success_count > 0:
-        status = "partial_success"
-    else:
-        status = "error"
+    status = _compute_mutation_status(per_broker)
 
     return create_success_response(
         {

--- a/tests/unit/test_unified_watchlist_tools.py
+++ b/tests/unit/test_unified_watchlist_tools.py
@@ -110,10 +110,10 @@ async def test_get_unified_watchlist_by_name_success(
 
 
 @pytest.mark.asyncio
-async def test_add_symbols_to_unified_watchlist_partial_success(
+async def test_add_symbols_to_unified_watchlist_success_with_unsupported_broker(
     mock_registry, mock_robinhood, mock_schwab
 ):
-    """Test partial success when adding symbols (RH success, Schwab unsupported)."""
+    """Test success when RH succeeds and unsupported brokers are neutral."""
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
     mock_registry.get_broker.side_effect = lambda name: (
         mock_robinhood if name == "robinhood" else mock_schwab
@@ -129,7 +129,7 @@ async def test_add_symbols_to_unified_watchlist_partial_success(
     ):
         result = await add_symbols_to_unified_watchlist("Tech", ["aapl", "AAPL "])
 
-    assert result["result"]["status"] == "partial_success"
+    assert result["result"]["status"] == "success"
     assert "AAPL" in result["result"]["symbols_added"]
     assert len(result["result"]["symbols_added"]) == 1  # De-duplicated and uppercased
     assert result["result"]["per_broker"]["robinhood"]["status"] == "success"
@@ -137,10 +137,10 @@ async def test_add_symbols_to_unified_watchlist_partial_success(
 
 
 @pytest.mark.asyncio
-async def test_remove_symbols_from_unified_watchlist_success(
+async def test_remove_symbols_from_unified_watchlist_success_with_unsupported_broker(
     mock_registry, mock_robinhood, mock_schwab
 ):
-    """Test success when removing symbols from Robinhood."""
+    """Test success when RH succeeds and unsupported brokers are neutral."""
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
     mock_registry.get_broker.side_effect = lambda name: (
         mock_robinhood if name == "robinhood" else mock_schwab
@@ -156,8 +156,6 @@ async def test_remove_symbols_from_unified_watchlist_success(
     ):
         result = await remove_symbols_from_unified_watchlist("Tech", ["AAPL"])
 
-    assert (
-        result["result"]["status"] == "partial_success"
-    )  # Because Schwab is unsupported
+    assert result["result"]["status"] == "success"
     assert result["result"]["symbols_removed"] == ["AAPL"]
     assert result["result"]["per_broker"]["robinhood"]["status"] == "success"


### PR DESCRIPTION
Closes #377

## Changes
- add `_compute_mutation_status` helper to aggregate broker mutation outcomes
- treat `unsupported` broker results as neutral when computing overall add/remove status
- update unit tests to assert `success` when Robinhood succeeds and Schwab is unsupported

## Test plan
- uv run pytest tests/unit/test_unified_watchlist_tools.py -q