### PR TITLE
fix: distinguish broker errors from not_found in get_unified_watchlist_by_name

### DIFF
--- a/src/open_stocks_mcp/tools/unified_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/unified_watchlist_tools.py
@@ -179,10 +179,12 @@ async def get_unified_watchlist_by_name(
     combined_symbols: set[str] = set()
     warnings = []
     found_any = False
+    partial_failure = False
 
     for name in broker_names:
         if name not in all_broker_names:
             per_broker[name] = {"status": "error", "message": "Broker not registered"}
+            partial_failure = True
             continue
 
         broker = registry.get_broker(name)
@@ -204,8 +206,10 @@ async def get_unified_watchlist_by_name(
                         "status": "error",
                         "message": rh_data.get("message", "Error"),
                     }
+                    partial_failure = True
             else:
                 per_broker[name] = {"status": "unavailable"}
+                partial_failure = True
         elif name == "schwab":
             schwab_symbols, load_error = get_schwab_watchlist(watchlist_name)
             if load_error:
@@ -219,6 +223,14 @@ async def get_unified_watchlist_by_name(
                 found_any = True
 
     symbols = sorted(combined_symbols)
+
+    if found_any:
+        status = "success"
+    elif partial_failure:
+        status = "partial_failure"
+    else:
+        status = "not_found"
+
     return create_success_response(
         {
             "watchlist_name": watchlist_name,
@@ -227,7 +239,7 @@ async def get_unified_watchlist_by_name(
             "brokers": list(per_broker.keys()),
             "per_broker": per_broker,
             "warnings": warnings,
-            "status": "success" if found_any else "not_found",
+            "status": status,
         }
     )
 

--- a/tests/unit/test_unified_watchlist_tools.py
+++ b/tests/unit/test_unified_watchlist_tools.py
@@ -141,7 +141,102 @@ async def test_get_unified_watchlist_by_name_success(
 
 
 @pytest.mark.asyncio
-async def test_add_symbols_to_unified_watchlist_success(
+async def test_get_unified_watchlist_by_name_broker_error_not_masked_as_not_found(
+    mock_registry, mock_robinhood, mock_schwab
+):
+    """When a broker returns an error, status should be partial_failure, not not_found."""
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
+
+    rh_error = {
+        "result": {
+            "status": "error",
+            "message": "Authentication failed",
+        }
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name",
+        return_value=rh_error,
+    ):
+        result = await get_unified_watchlist_by_name("Tech")
+
+    assert result["result"]["status"] == "partial_failure"
+    assert result["result"]["per_broker"]["robinhood"]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_get_unified_watchlist_by_name_broker_unavailable_not_masked(
+    mock_registry, mock_robinhood, mock_schwab
+):
+    """When a broker is unavailable, status should be partial_failure, not not_found."""
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_robinhood.is_available.return_value = False
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
+
+    result = await get_unified_watchlist_by_name("Tech")
+
+    assert result["result"]["status"] == "partial_failure"
+    assert result["result"]["per_broker"]["robinhood"]["status"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_get_unified_watchlist_by_name_genuine_not_found(
+    mock_registry, mock_robinhood, mock_schwab
+):
+    """When the watchlist genuinely doesn't exist (no broker errors), status is not_found."""
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
+
+    rh_not_found = {
+        "result": {
+            "status": "not_found",
+        }
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name",
+        return_value=rh_not_found,
+    ):
+        result = await get_unified_watchlist_by_name("NonExistent")
+
+    assert result["result"]["status"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_get_unified_watchlist_by_name_unregistered_broker_partial_failure(
+    mock_registry, mock_robinhood
+):
+    """When an unregistered broker is requested, status should be partial_failure."""
+    mock_registry.list_brokers.return_value = ["robinhood"]
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else None
+    )
+
+    rh_not_found = {
+        "result": {
+            "status": "not_found",
+        }
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name",
+        return_value=rh_not_found,
+    ):
+        result = await get_unified_watchlist_by_name("Tech", brokers=["robinhood", "fakeBroker"])
+
+    assert result["result"]["status"] == "partial_failure"
+    assert result["result"]["per_broker"]["fakeBroker"]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_add_symbols_to_unified_watchlist_partial_success(
     mock_registry, mock_robinhood, mock_schwab
 ):
     """Test success when RH and Schwab local store both succeed."""


### PR DESCRIPTION
Closes #378

## Changes
- Track `partial_failure` in `get_unified_watchlist_by_name` when a broker returns an error, is unavailable, or is unregistered
- Return `"partial_failure"` status instead of masking these cases as `"not_found"`
- Keep `"not_found"` only for when all brokers genuinely report the watchlist doesn't exist (no errors)

## Test plan
- Added `test_get_unified_watchlist_by_name_broker_error_not_masked_as_not_found` — broker error → `partial_failure`
- Added `test_get_unified_watchlist_by_name_broker_unavailable_not_masked` — broker unavailable → `partial_failure`
- Added `test_get_unified_watchlist_by_name_genuine_not_found` — genuine not found → `not_found`
- Added `test_get_unified_watchlist_by_name_unregistered_broker_partial_failure` — unregistered broker → `partial_failure`
- All 28 watchlist journey tests pass (24 passed, 4 skipped for rate-limited)
- Lint, type check all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)