### PR TITLE
fix: preserve registry order in get_aggregated_portfolio brokers dict

### DIFF
--- a/src/open_stocks_mcp/tools/cross_broker_tools.py
+++ b/src/open_stocks_mcp/tools/cross_broker_tools.py
@@ -59,50 +59,55 @@ async def get_aggregated_portfolio() -> dict[str, Any]:
         available_names.append(name)
         coros.append(broker.get_portfolio_snapshot())
 
+    results_map: dict[str, Any] = {}
     if coros:
         results = await asyncio.gather(*coros, return_exceptions=True)
-        for name, result in zip(available_names, results, strict=True):
-            if isinstance(result, BaseException):
-                logger.error(
-                    f"Error collecting data from broker {name}: {result}",
-                    exc_info=result,
-                )
-                brokers_out[name] = {
-                    "status": "error",
-                    "error": str(result),
-                    "market_value": 0.0,
-                    "equity": 0.0,
-                    "buying_power": 0.0,
-                    "positions": [],
-                    "position_count": 0,
-                }
-                unavailable.append(name)
-                continue
-
-            summary, positions = result
-            market_value = summary.get("market_value", 0.0)
-            equity = summary.get("equity", 0.0)
-            buying_power = summary.get("buying_power", 0.0)
-
-            brokers_out[name] = {
-                "status": "available",
-                "error": None,
-                "market_value": market_value,
-                "equity": equity,
-                "buying_power": buying_power,
-                "positions": positions,
-                "position_count": len(positions),
-            }
-            all_positions.extend(positions)
-            total_market_value += market_value
-            total_equity += equity
-            total_buying_power += buying_power
+        results_map = dict(zip(available_names, results, strict=True))
 
     for name in broker_names:
-        if name in brokers_out:
-            continue
         if name in unavailable_records:
             brokers_out[name] = unavailable_records[name]
+            continue
+
+        if name not in results_map:
+            continue
+
+        result = results_map[name]
+        if isinstance(result, BaseException):
+            logger.error(
+                f"Error collecting data from broker {name}: {result}",
+                exc_info=result,
+            )
+            brokers_out[name] = {
+                "status": "error",
+                "error": str(result),
+                "market_value": 0.0,
+                "equity": 0.0,
+                "buying_power": 0.0,
+                "positions": [],
+                "position_count": 0,
+            }
+            unavailable.append(name)
+            continue
+
+        summary, positions = result
+        market_value = summary.get("market_value", 0.0)
+        equity = summary.get("equity", 0.0)
+        buying_power = summary.get("buying_power", 0.0)
+
+        brokers_out[name] = {
+            "status": "available",
+            "error": None,
+            "market_value": market_value,
+            "equity": equity,
+            "buying_power": buying_power,
+            "positions": positions,
+            "position_count": len(positions),
+        }
+        all_positions.extend(positions)
+        total_market_value += market_value
+        total_equity += equity
+        total_buying_power += buying_power
 
     return create_success_response(
         {

--- a/tests/unit/test_cross_broker_tools.py
+++ b/tests/unit/test_cross_broker_tools.py
@@ -569,3 +569,38 @@ class TestGetAggregatedPortfolio:
         assert data["aggregated"]["total_market_value"] == 1000.0
         assert len(data["aggregated"]["positions"]) == 1
         assert data["aggregated"]["positions"][0]["symbol"] == "BTC"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.journey_portfolio
+    async def test_brokers_dict_preserves_registry_order_with_unavailable_middle(
+        self,
+    ) -> None:
+        """brokers dict keys follow registry.list_brokers() order even when a middle broker is unavailable."""
+        mock_registry = MagicMock()
+        mock_registry.list_brokers.return_value = ["robinhood", "schwab", "paper"]
+
+        rh_broker = MockBroker("robinhood", authenticated=True)
+        schwab_broker = MockBroker("schwab", authenticated=False)
+        paper_broker = MockBroker("paper", authenticated=True)
+
+        def _get_broker(name: str) -> MockBroker:
+            return {"robinhood": rh_broker, "schwab": schwab_broker, "paper": paper_broker}[name]
+
+        mock_registry.get_broker.side_effect = _get_broker
+
+        rh_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=({"market_value": 1000.0, "equity": 1000.0, "buying_power": 500.0}, [])
+        )
+        paper_broker.get_portfolio_snapshot = AsyncMock(
+            return_value=({"market_value": 2000.0, "equity": 2000.0, "buying_power": 1000.0}, [])
+        )
+
+        with patch(
+            "open_stocks_mcp.tools.cross_broker_tools.get_broker_registry",
+            return_value=mock_registry,
+        ):
+            result = await get_aggregated_portfolio()
+
+        broker_keys = list(result["result"]["brokers"].keys())
+        assert broker_keys == ["robinhood", "schwab", "paper"]


### PR DESCRIPTION
Closes #542

## Changes
- Refactored `get_aggregated_portfolio` to build `results_map` after `asyncio.gather`, then iterate `broker_names` in a single pass to construct `brokers_out` in registry order
- Removed the two-phase approach (available-first, then unavailable) that caused insertion-order drift
- Added a regression test with three brokers where the middle one is unavailable, asserting dict key order matches `registry.list_brokers()`

## Test plan
- `pytest tests/unit/test_cross_broker_tools.py` — all 12 tests pass including new ordering test
- `pytest -m journey_portfolio` — 24 passed, 3 skipped
- `mypy src/open_stocks_mcp/tools/cross_broker_tools.py` — no issues
- `ruff check src/open_stocks_mcp/tools/cross_broker_tools.py` — no issues