### PR TITLE
test: isolate cache test globals

### DIFF
--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -10,7 +10,21 @@ from unittest.mock import patch
 
 import pytest
 
-...
+
+@pytest.fixture(autouse=True)
+def reset_cache_test_state() -> None:
+    """Keep global cache/config/metrics state isolated between tests."""
+    from open_stocks_mcp import monitoring
+    from open_stocks_mcp.config import reset_cache_config
+    from open_stocks_mcp.tools.cache import clear_caches
+
+    clear_caches()
+    reset_cache_config()
+    monitoring._metrics_collector = None
+    yield
+    clear_caches()
+    reset_cache_config()
+    monitoring._metrics_collector = None
 
 
 class TestCachedAsyncDecorator:


### PR DESCRIPTION
Closes #886

## Changes
- Replaces the placeholder expression in `tests/unit/test_cache.py` with an autouse fixture that resets cache entries, global cache config, and the global metrics collector around each test.
- Prevents `CACHE_ENABLED` mutations and cache metric counters from leaking into later cache/tool integration tests.

## Test plan
- `uv run pytest tests/unit/test_cache.py -q --tb=short`
- `uv run ruff check tests/unit/test_cache.py`
