### PR TITLE
feat: add local Schwab watchlist storage for unified tools

### DIFF
--- a/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
+++ b/docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md
@@ -452,6 +452,10 @@ The current implementation remains a 24-tool Schwab core. The broader parity roa
 ### Watchlists
 - **Status**: Deferred
 - **Rationale**: Schwab does not expose a watchlist endpoint; the current workaround is client-side JSON storage (local file or database).
+- **Current local store behavior**:
+  - Path: `OPEN_STOCKS_SCHWAB_WATCHLIST_STORE` if set, otherwise `~/.open-stocks-mcp/schwab_watchlists.json`.
+  - Format: JSON object `{"watchlists": {"<name>": ["SYMBOL", ...]}}` with uppercased, deduplicated symbols.
+  - Concurrency/permissions: reads and writes are best-effort local file operations; unreadable/corrupt or unwritable stores return tool warnings/errors and do not modify Robinhood results.
 
 ### Cryptocurrency
 - **Status**: Not Applicable

--- a/src/open_stocks_mcp/tools/unified_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/unified_watchlist_tools.py
@@ -91,8 +91,8 @@ async def get_unified_watchlists(brokers: list[str] | None = None) -> dict[str, 
     all_broker_names = registry.list_brokers()
     broker_names = brokers if brokers is not None else all_broker_names
 
-    brokers_out = {}
-    unified_watchlists = []
+    brokers_out: dict[str, dict[str, Any]] = {}
+    unified_watchlists: list[dict[str, Any]] = []
     warnings = []
     partial_failure = False
 
@@ -175,8 +175,8 @@ async def get_unified_watchlist_by_name(
     all_broker_names = registry.list_brokers()
     broker_names = brokers if brokers is not None else all_broker_names
 
-    per_broker = {}
-    combined_symbols = set()
+    per_broker: dict[str, dict[str, Any]] = {}
+    combined_symbols: set[str] = set()
     warnings = []
     found_any = False
 
@@ -241,8 +241,8 @@ async def add_symbols_to_unified_watchlist(
     broker_names = brokers if brokers is not None else all_broker_names
 
     normalized = _normalize_symbols(symbols)
-    per_broker = {}
-    warnings = []
+    per_broker: dict[str, dict[str, Any]] = {}
+    warnings: list[dict[str, str]] = []
 
     for name in broker_names:
         if name not in all_broker_names:
@@ -300,8 +300,8 @@ async def remove_symbols_from_unified_watchlist(
     broker_names = brokers if brokers is not None else all_broker_names
 
     normalized = _normalize_symbols(symbols)
-    per_broker = {}
-    warnings = []
+    per_broker: dict[str, dict[str, Any]] = {}
+    warnings: list[dict[str, str]] = []
 
     for name in broker_names:
         if name not in all_broker_names:

--- a/src/open_stocks_mcp/tools/unified_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/unified_watchlist_tools.py
@@ -10,6 +10,18 @@ from open_stocks_mcp.tools.watchlists.read import (
 from open_stocks_mcp.tools.watchlists.read import (
     get_watchlist_by_name as get_rh_watchlist_by_name,
 )
+from open_stocks_mcp.tools.watchlists.schwab_local_store import (
+    add_symbols as add_schwab_symbols,
+)
+from open_stocks_mcp.tools.watchlists.schwab_local_store import (
+    get_watchlist as get_schwab_watchlist,
+)
+from open_stocks_mcp.tools.watchlists.schwab_local_store import (
+    load_watchlists as load_schwab_watchlists,
+)
+from open_stocks_mcp.tools.watchlists.schwab_local_store import (
+    remove_symbols as remove_schwab_symbols,
+)
 from open_stocks_mcp.tools.watchlists.write import (
     add_symbols_to_watchlist as add_rh_symbols,
 )
@@ -46,6 +58,31 @@ def _compute_mutation_status(per_broker: dict[str, dict[str, Any]]) -> str:
     if any(status == "success" for status in actionable_statuses):
         return "partial_success"
     return "error"
+
+
+def _append_or_merge_watchlist(
+    unified_watchlists: list[dict[str, Any]], name: str, symbols: list[str], broker: str
+) -> None:
+    """Merge watchlist rows with the same name across brokers."""
+    for row in unified_watchlists:
+        if row.get("name") != name:
+            continue
+
+        merged_symbols = sorted(set(row.get("symbols", [])) | set(symbols))
+        row["symbols"] = merged_symbols
+        row["symbol_count"] = len(merged_symbols)
+        if broker not in row["brokers"]:
+            row["brokers"].append(broker)
+        return
+
+    unified_watchlists.append(
+        {
+            "name": name,
+            "symbols": symbols,
+            "symbol_count": len(symbols),
+            "brokers": [broker],
+        }
+    )
 
 
 async def get_unified_watchlists(brokers: list[str] | None = None) -> dict[str, Any]:
@@ -94,16 +131,24 @@ async def get_unified_watchlists(brokers: list[str] | None = None) -> dict[str, 
                 brokers_out[name] = {"status": "unavailable"}
                 partial_failure = True
         elif name == "schwab":
-            brokers_out[name] = {
-                "status": "unsupported",
-                "message": "Schwab does not currently expose a watchlist API.",
-            }
-            warnings.append(
-                {
-                    "broker": "schwab",
-                    "message": "Watchlists are not supported on Schwab.",
+            schwab_watchlists, load_error = load_schwab_watchlists()
+            if load_error:
+                brokers_out[name] = {"status": "error", "message": load_error}
+                warnings.append({"broker": "schwab", "message": load_error})
+                partial_failure = True
+            else:
+                brokers_out[name] = {
+                    "status": "success",
+                    "watchlist_count": len(schwab_watchlists),
+                    "storage_backend": "local_file",
                 }
-            )
+                for watchlist_name, watchlist_symbols in schwab_watchlists.items():
+                    _append_or_merge_watchlist(
+                        unified_watchlists,
+                        name=watchlist_name,
+                        symbols=watchlist_symbols,
+                        broker="schwab",
+                    )
         else:
             brokers_out[name] = {"status": "unsupported"}
 
@@ -162,13 +207,16 @@ async def get_unified_watchlist_by_name(
             else:
                 per_broker[name] = {"status": "unavailable"}
         elif name == "schwab":
-            per_broker[name] = {"status": "unsupported"}
-            warnings.append(
-                {
-                    "broker": "schwab",
-                    "message": "Watchlists are not supported on Schwab.",
-                }
-            )
+            schwab_symbols, load_error = get_schwab_watchlist(watchlist_name)
+            if load_error:
+                per_broker[name] = {"status": "error", "message": load_error}
+                warnings.append({"broker": "schwab", "message": load_error})
+            elif schwab_symbols is None:
+                per_broker[name] = {"status": "not_found"}
+            else:
+                per_broker[name] = {"status": "success", "symbols": schwab_symbols}
+                combined_symbols.update(schwab_symbols)
+                found_any = True
 
     symbols = sorted(combined_symbols)
     return create_success_response(
@@ -214,14 +262,21 @@ async def add_symbols_to_unified_watchlist(
             else:
                 per_broker[name] = {"status": "unavailable", "success": False}
         elif name == "schwab":
-            per_broker[name] = {
-                "status": "unsupported",
-                "success": False,
-                "message": "Schwab does not support watchlist mutations via API.",
-            }
-            warnings.append(
-                {"broker": "schwab", "message": "Add operation ignored for Schwab."}
-            )
+            combined_symbols, save_error = add_schwab_symbols(watchlist_name, normalized)
+            if save_error:
+                per_broker[name] = {
+                    "status": "error",
+                    "success": False,
+                    "message": save_error,
+                }
+                warnings.append({"broker": "schwab", "message": save_error})
+            else:
+                per_broker[name] = {
+                    "status": "success",
+                    "success": True,
+                    "symbols": combined_symbols,
+                    "storage_backend": "local_file",
+                }
 
     status = _compute_mutation_status(per_broker)
 
@@ -266,14 +321,21 @@ async def remove_symbols_from_unified_watchlist(
             else:
                 per_broker[name] = {"status": "unavailable", "success": False}
         elif name == "schwab":
-            per_broker[name] = {
-                "status": "unsupported",
-                "success": False,
-                "message": "Schwab does not support watchlist mutations via API.",
-            }
-            warnings.append(
-                {"broker": "schwab", "message": "Remove operation ignored for Schwab."}
-            )
+            remaining_symbols, save_error = remove_schwab_symbols(watchlist_name, normalized)
+            if save_error:
+                per_broker[name] = {
+                    "status": "error",
+                    "success": False,
+                    "message": save_error,
+                }
+                warnings.append({"broker": "schwab", "message": save_error})
+            else:
+                per_broker[name] = {
+                    "status": "success",
+                    "success": True,
+                    "symbols": remaining_symbols,
+                    "storage_backend": "local_file",
+                }
 
     status = _compute_mutation_status(per_broker)
 

--- a/src/open_stocks_mcp/tools/watchlists/schwab_local_store.py
+++ b/src/open_stocks_mcp/tools/watchlists/schwab_local_store.py
@@ -1,0 +1,119 @@
+"""Local file-backed watchlist storage for Schwab parity."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+STORE_PATH_ENV = "OPEN_STOCKS_SCHWAB_WATCHLIST_STORE"
+DEFAULT_STORE_PATH = Path("~/.open-stocks-mcp/schwab_watchlists.json").expanduser()
+
+
+def get_store_path() -> Path:
+    """Resolve the Schwab local watchlist store path."""
+    configured = os.getenv(STORE_PATH_ENV, "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return DEFAULT_STORE_PATH
+
+
+def _normalize_payload(raw: Any) -> dict[str, list[str]]:
+    if not isinstance(raw, dict):
+        return {}
+
+    watchlists = raw.get("watchlists", raw)
+    if not isinstance(watchlists, dict):
+        return {}
+
+    normalized: dict[str, list[str]] = {}
+    for name, symbols in watchlists.items():
+        if not isinstance(name, str):
+            continue
+        if not isinstance(symbols, list):
+            continue
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for symbol in symbols:
+            if not isinstance(symbol, str):
+                continue
+            value = symbol.strip().upper()
+            if value and value not in seen:
+                seen.add(value)
+                cleaned.append(value)
+        normalized[name] = cleaned
+    return normalized
+
+
+def load_watchlists() -> tuple[dict[str, list[str]], str | None]:
+    """Load all Schwab watchlists from local storage."""
+    path = get_store_path()
+    if not path.exists():
+        return {}, None
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, f"Unable to read Schwab watchlist store at {path}: {exc}"
+
+    return _normalize_payload(raw), None
+
+
+def save_watchlists(watchlists: dict[str, list[str]]) -> str | None:
+    """Persist all Schwab watchlists to local storage."""
+    path = get_store_path()
+    payload = {"watchlists": watchlists}
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError as exc:
+        return f"Unable to write Schwab watchlist store at {path}: {exc}"
+
+    return None
+
+
+def get_watchlist(name: str) -> tuple[list[str] | None, str | None]:
+    """Load a single watchlist by name."""
+    watchlists, error = load_watchlists()
+    if error:
+        return None, error
+    return watchlists.get(name), None
+
+
+def add_symbols(name: str, symbols: list[str]) -> tuple[list[str], str | None]:
+    """Add symbols to a named watchlist and persist."""
+    watchlists, error = load_watchlists()
+    if error:
+        return [], error
+
+    existing = watchlists.get(name, [])
+    merged = list(existing)
+    seen = set(existing)
+    for symbol in symbols:
+        if symbol not in seen:
+            seen.add(symbol)
+            merged.append(symbol)
+
+    watchlists[name] = merged
+    error = save_watchlists(watchlists)
+    return merged, error
+
+
+def remove_symbols(name: str, symbols: list[str]) -> tuple[list[str], str | None]:
+    """Remove symbols from a named watchlist and persist."""
+    watchlists, error = load_watchlists()
+    if error:
+        return [], error
+
+    existing = watchlists.get(name, [])
+    remaining = [symbol for symbol in existing if symbol not in set(symbols)]
+
+    if remaining:
+        watchlists[name] = remaining
+    elif name in watchlists:
+        del watchlists[name]
+
+    error = save_watchlists(watchlists)
+    return remaining, error

--- a/tests/unit/test_unified_watchlist_tools.py
+++ b/tests/unit/test_unified_watchlist_tools.py
@@ -60,19 +60,49 @@ async def test_get_unified_watchlists_success(
     with patch(
         "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
         return_value=rh_watchlists,
+    ), patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
+        return_value=({"Income": ["SCHD", "VYM"]}, None),
     ):
         result = await get_unified_watchlists()
 
     assert result["result"]["status"] in ["success", "partial_success"]
-    assert "robinhood" in result["result"]["brokers"]
-    assert "schwab" in result["result"]["brokers"]
-    assert result["result"]["brokers"]["schwab"]["status"] == "unsupported"
+    assert result["result"]["brokers"]["schwab"]["status"] == "success"
 
-    # Check aggregation
     watchlists = result["result"]["watchlists"]
-    assert len(watchlists) >= 1
+    assert len(watchlists) == 2
     tech = next(w for w in watchlists if w["name"] == "Tech")
     assert "robinhood" in tech["brokers"]
+    assert tech["symbols"] == ["AAPL", "MSFT"]
+
+
+@pytest.mark.asyncio
+async def test_get_unified_watchlists_merges_same_name_across_brokers(
+    mock_registry, mock_robinhood, mock_schwab
+):
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
+
+    rh_watchlists = {
+        "result": {
+            "watchlists": [{"name": "Tech", "symbols": ["AAPL"], "symbol_count": 1}],
+            "status": "success",
+        }
+    }
+
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
+        return_value=rh_watchlists,
+    ), patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
+        return_value=({"Tech": ["MSFT", "AAPL"]}, None),
+    ):
+        result = await get_unified_watchlists()
+
+    tech = next(w for w in result["result"]["watchlists"] if w["name"] == "Tech")
+    assert sorted(tech["brokers"]) == ["robinhood", "schwab"]
     assert tech["symbols"] == ["AAPL", "MSFT"]
 
 
@@ -98,22 +128,23 @@ async def test_get_unified_watchlist_by_name_success(
     with patch(
         "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name",
         return_value=rh_watchlist,
+    ), patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_schwab_watchlist",
+        return_value=(["SCHD"], None),
     ):
         result = await get_unified_watchlist_by_name("Tech")
 
     assert result["result"]["status"] in ["success", "partial_success"]
     assert result["result"]["watchlist_name"] == "Tech"
-    assert result["result"]["symbols"] == ["AAPL", "MSFT"]
-    assert "robinhood" in result["result"]["brokers"]
-    assert "schwab" in result["result"]["brokers"]
-    assert result["result"]["per_broker"]["schwab"]["status"] == "unsupported"
+    assert result["result"]["symbols"] == ["AAPL", "MSFT", "SCHD"]
+    assert result["result"]["per_broker"]["schwab"]["status"] == "success"
 
 
 @pytest.mark.asyncio
-async def test_add_symbols_to_unified_watchlist_success_with_unsupported_broker(
+async def test_add_symbols_to_unified_watchlist_success(
     mock_registry, mock_robinhood, mock_schwab
 ):
-    """Test success when RH succeeds and unsupported brokers are neutral."""
+    """Test success when RH and Schwab local store both succeed."""
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
     mock_registry.get_broker.side_effect = lambda name: (
         mock_robinhood if name == "robinhood" else mock_schwab
@@ -126,21 +157,24 @@ async def test_add_symbols_to_unified_watchlist_success_with_unsupported_broker(
     with patch(
         "open_stocks_mcp.tools.unified_watchlist_tools.add_rh_symbols",
         return_value=rh_result,
+    ), patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.add_schwab_symbols",
+        return_value=(["AAPL"], None),
     ):
         result = await add_symbols_to_unified_watchlist("Tech", ["aapl", "AAPL "])
 
     assert result["result"]["status"] == "success"
     assert "AAPL" in result["result"]["symbols_added"]
-    assert len(result["result"]["symbols_added"]) == 1  # De-duplicated and uppercased
+    assert len(result["result"]["symbols_added"]) == 1
     assert result["result"]["per_broker"]["robinhood"]["status"] == "success"
-    assert result["result"]["per_broker"]["schwab"]["status"] == "unsupported"
+    assert result["result"]["per_broker"]["schwab"]["status"] == "success"
 
 
 @pytest.mark.asyncio
-async def test_remove_symbols_from_unified_watchlist_success_with_unsupported_broker(
+async def test_remove_symbols_from_unified_watchlist_success(
     mock_registry, mock_robinhood, mock_schwab
 ):
-    """Test success when RH succeeds and unsupported brokers are neutral."""
+    """Test success when RH and Schwab local store both succeed."""
     mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
     mock_registry.get_broker.side_effect = lambda name: (
         mock_robinhood if name == "robinhood" else mock_schwab
@@ -153,9 +187,38 @@ async def test_remove_symbols_from_unified_watchlist_success_with_unsupported_br
     with patch(
         "open_stocks_mcp.tools.unified_watchlist_tools.remove_rh_symbols",
         return_value=rh_result,
+    ), patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.remove_schwab_symbols",
+        return_value=([], None),
     ):
         result = await remove_symbols_from_unified_watchlist("Tech", ["AAPL"])
 
     assert result["result"]["status"] == "success"
     assert result["result"]["symbols_removed"] == ["AAPL"]
     assert result["result"]["per_broker"]["robinhood"]["status"] == "success"
+    assert result["result"]["per_broker"]["schwab"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_get_unified_watchlists_handles_corrupt_schwab_store(
+    mock_registry, mock_robinhood, mock_schwab
+):
+    mock_registry.list_brokers.return_value = ["robinhood", "schwab"]
+    mock_registry.get_broker.side_effect = lambda name: (
+        mock_robinhood if name == "robinhood" else mock_schwab
+    )
+
+    rh_watchlists = {"result": {"watchlists": [], "status": "success"}}
+
+    with patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
+        return_value=rh_watchlists,
+    ), patch(
+        "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
+        return_value=({}, "Unable to read Schwab watchlist store"),
+    ):
+        result = await get_unified_watchlists()
+
+    assert result["result"]["status"] == "partial_success"
+    assert result["result"]["brokers"]["schwab"]["status"] == "error"
+    assert result["result"]["warnings"][0]["broker"] == "schwab"


### PR DESCRIPTION
Closes #891

## Changes
- add a local JSON-backed Schwab watchlist storage module with configurable path via `OPEN_STOCKS_SCHWAB_WATCHLIST_STORE`
- wire unified watchlist read/add/remove tools to use local Schwab storage instead of returning unsupported
- merge same-named watchlists across Robinhood and Schwab in unified read responses
- update watchlist unit tests for local-store success, mixed aggregation, and corrupt-store handling
- document storage path, data format, and file error behavior in the tool comparison doc

## Test plan
- uv run pytest tests/unit/test_unified_watchlist_tools.py -q --tb=line
- uv run ruff check src/open_stocks_mcp/tools/unified_watchlist_tools.py tests/unit/test_unified_watchlist_tools.py src/open_stocks_mcp/tools/watchlists/schwab_local_store.py docs/TOOL_COMPARISON_ROBINHOOD_VS_SCHWAB.md