### PR TITLE
fix: remove duplicate market rate-limit acquires

### DIFF
--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -117,7 +117,7 @@ async def get_list_brokers_data() -> dict[str, Any]:
 
 async def get_rate_limit_status_data() -> dict[str, Any]:
     """Return current rate limit usage and statistics."""
-    rate_limiter = get_rate_limiter()
+    rate_limiter = get_rate_limiter("robinhood")
     stats = rate_limiter.get_stats()
 
     return {

--- a/src/open_stocks_mcp/tools/market/earnings.py
+++ b/src/open_stocks_mcp/tools/market/earnings.py
@@ -15,7 +15,6 @@ from open_stocks_mcp.tools.error_handling import (
     log_api_call,
     validate_symbol,
 )
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 
 @handle_robin_stocks_errors
@@ -67,10 +66,6 @@ async def get_stock_earnings(symbol: str) -> dict[str, Any]:
             return create_error_response(
                 ValueError("Authentication required"), "authentication"
             )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
 
         log_api_call("get_stock_earnings", symbol=symbol)
 
@@ -131,10 +126,6 @@ async def get_stock_splits(symbol: str) -> dict[str, Any]:
             return create_error_response(
                 ValueError("Authentication required"), "authentication"
             )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
 
         log_api_call("get_stock_splits", symbol=symbol)
 
@@ -198,10 +189,6 @@ async def get_stock_events(symbol: str) -> dict[str, Any]:
             return create_error_response(
                 ValueError("Authentication required"), "authentication"
             )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
 
         log_api_call("get_stock_events", symbol=symbol)
 

--- a/src/open_stocks_mcp/tools/market/level2.py
+++ b/src/open_stocks_mcp/tools/market/level2.py
@@ -15,7 +15,6 @@ from open_stocks_mcp.tools.error_handling import (
     log_api_call,
     validate_symbol,
 )
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 
 @handle_robin_stocks_errors
@@ -61,10 +60,6 @@ async def get_stock_level2_data(symbol: str) -> dict[str, Any]:
             return create_error_response(
                 ValueError("Authentication required"), "authentication"
             )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
 
         log_api_call("get_stock_level2_data", symbol=symbol)
 

--- a/src/open_stocks_mcp/tools/market/movers.py
+++ b/src/open_stocks_mcp/tools/market/movers.py
@@ -13,7 +13,6 @@ from open_stocks_mcp.tools.error_handling import (
     handle_robin_stocks_errors,
     log_api_call,
 )
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 
 @handle_robin_stocks_errors
@@ -57,10 +56,6 @@ async def get_top_movers_sp500(direction: str = "up") -> dict[str, Any]:
         return create_error_response(
             ValueError("Authentication required"), "authentication"
         )
-
-    # Apply rate limiting
-    rate_limiter = get_rate_limiter()
-    await rate_limiter.acquire()
 
     log_api_call("get_top_movers_sp500", direction=direction)
 
@@ -130,10 +125,6 @@ async def get_top_100() -> dict[str, Any]:
             ValueError("Authentication required"), "authentication"
         )
 
-    # Apply rate limiting
-    rate_limiter = get_rate_limiter()
-    await rate_limiter.acquire()
-
     log_api_call("get_top_100")
 
     # Get top 100 stocks with retry logic
@@ -198,10 +189,6 @@ async def get_top_movers() -> dict[str, Any]:
             ValueError("Authentication required"), "authentication"
         )
 
-    # Apply rate limiting
-    rate_limiter = get_rate_limiter()
-    await rate_limiter.acquire()
-
     log_api_call("get_top_movers")
 
     # Get top movers with retry logic
@@ -257,10 +244,6 @@ async def get_stocks_by_tag(tag: str) -> dict[str, Any]:
         return create_error_response(
             ValueError("Authentication required"), "authentication"
         )
-
-    # Apply rate limiting
-    rate_limiter = get_rate_limiter()
-    await rate_limiter.acquire()
 
     log_api_call("get_stocks_by_tag", tag=tag)
 

--- a/src/open_stocks_mcp/tools/market/news.py
+++ b/src/open_stocks_mcp/tools/market/news.py
@@ -15,7 +15,6 @@ from open_stocks_mcp.tools.error_handling import (
     log_api_call,
     validate_symbol,
 )
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 
 @handle_robin_stocks_errors
@@ -61,10 +60,6 @@ async def get_stock_news(symbol: str) -> dict[str, Any]:
             return create_error_response(
                 ValueError("Authentication required"), "authentication"
             )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
 
         log_api_call("get_stock_news", symbol=symbol)
 

--- a/src/open_stocks_mcp/tools/market/ratings.py
+++ b/src/open_stocks_mcp/tools/market/ratings.py
@@ -15,7 +15,6 @@ from open_stocks_mcp.tools.error_handling import (
     log_api_call,
     validate_symbol,
 )
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 
 @handle_robin_stocks_errors
@@ -62,10 +61,6 @@ async def get_stock_ratings(symbol: str) -> dict[str, Any]:
             return create_error_response(
                 ValueError("Authentication required"), "authentication"
             )
-
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter()
-        await rate_limiter.acquire()
 
         log_api_call("get_stock_ratings", symbol=symbol)
 

--- a/tests/server/test_tool_helpers.py
+++ b/tests/server/test_tool_helpers.py
@@ -144,6 +144,8 @@ class TestRateLimitStatusHelper:
 
             response = await get_rate_limit_status_data()
 
+        mock_get_rl.assert_called_once_with("robinhood")
+
         assert response["result"]["status"] == "success"
         assert response["result"]["requests_made"] == 5
         assert response["result"]["limit"] == 100

--- a/tests/unit/test_market_research_tools.py
+++ b/tests/unit/test_market_research_tools.py
@@ -23,13 +23,11 @@ class TestTopMoversSP500:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.movers.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.movers.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.movers.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_top_movers_sp500_up_success(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
@@ -37,10 +35,6 @@ class TestTopMoversSP500:
         # Mock authentication - make it async
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-
-        # Mock rate limiter - make it async
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         # Mock API response
         mock_execute_with_retry.return_value = [
@@ -80,22 +74,18 @@ class TestTopMoversSP500:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.movers.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.movers.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.movers.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_top_movers_sp500_down_success(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test successful retrieval of S&P 500 down movers."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         # Mock API response
         mock_execute_with_retry.return_value = [
@@ -140,22 +130,18 @@ class TestTopMoversSP500:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.movers.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.movers.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.movers.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_top_movers_sp500_no_data(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test when no movers data is available."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         mock_execute_with_retry.return_value = None
 
@@ -195,22 +181,18 @@ class TestStockRatings:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.ratings.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.ratings.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.ratings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_ratings_success(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test successful stock ratings retrieval."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         # Mock API response
         mock_execute_with_retry.return_value = {
@@ -262,22 +244,18 @@ class TestStockRatings:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.ratings.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.ratings.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.ratings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_ratings_no_data(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test when no ratings data is available."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         mock_execute_with_retry.return_value = None
 
@@ -296,22 +274,18 @@ class TestStockEarnings:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.earnings.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.earnings.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.earnings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_earnings_success(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test successful stock earnings retrieval."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         # Mock API response
         mock_execute_with_retry.return_value = [
@@ -369,22 +343,18 @@ class TestStockEarnings:
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.earnings.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.earnings.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.earnings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_earnings_no_data(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test when no earnings data is available."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         mock_execute_with_retry.return_value = None
 
@@ -401,22 +371,18 @@ class TestStockNews:
 
     @patch("open_stocks_mcp.tools.market.news.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.news.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.news.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_news_success(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test successful stock news retrieval."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         # Mock API response
         mock_execute_with_retry.return_value = [
@@ -472,22 +438,18 @@ class TestStockNews:
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
     @patch("open_stocks_mcp.tools.market.news.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.news.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.news.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_news_no_data(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test when no news data is available."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         mock_execute_with_retry.return_value = None
 
@@ -504,22 +466,18 @@ class TestStockSplits:
 
     @patch("open_stocks_mcp.tools.market.earnings.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.earnings.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.earnings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_splits_success(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test successful stock splits retrieval."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         # Mock API response
         mock_execute_with_retry.return_value = [
@@ -567,22 +525,18 @@ class TestStockSplits:
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
     @patch("open_stocks_mcp.tools.market.earnings.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.earnings.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.earnings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_splits_no_data(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test when no splits data is available."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         mock_execute_with_retry.return_value = None
 
@@ -599,22 +553,18 @@ class TestStockEvents:
 
     @patch("open_stocks_mcp.tools.market.earnings.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.earnings.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.earnings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_events_success(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test successful stock events retrieval."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         # Mock API response
         mock_execute_with_retry.return_value = [
@@ -658,22 +608,18 @@ class TestStockEvents:
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
     @patch("open_stocks_mcp.tools.market.earnings.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.earnings.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.earnings.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_events_no_data(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test when no events data is available."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         mock_execute_with_retry.return_value = None
 
@@ -690,22 +636,18 @@ class TestStockLevel2Data:
 
     @patch("open_stocks_mcp.tools.market.level2.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.level2.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.level2.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_level2_data_success(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test successful Level II data retrieval."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         # Mock API response
         mock_execute_with_retry.return_value = {
@@ -750,22 +692,18 @@ class TestStockLevel2Data:
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
     @patch("open_stocks_mcp.tools.market.level2.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.level2.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.level2.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_level2_data_no_data(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test when no Level II data is available (Gold subscription required)."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         mock_execute_with_retry.return_value = None
 
@@ -781,22 +719,18 @@ class TestStockLevel2Data:
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
     @patch("open_stocks_mcp.tools.market.level2.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.level2.get_session_manager")
-    @patch("open_stocks_mcp.tools.market.level2.get_rate_limiter")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_level2_data_api_error(
         self,
-        mock_rate_limiter: Any,
         mock_session_manager: Any,
         mock_execute_with_retry: Any,
     ) -> None:
         """Test API error handling for Level II data."""
-        # Mock authentication and rate limiting
+        # Mock authentication
         mock_session = mock_session_manager.return_value
         mock_session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_limiter = mock_rate_limiter.return_value
-        mock_limiter.acquire = AsyncMock(return_value=None)
 
         mock_execute_with_retry.side_effect = Exception("Gold subscription required")
 


### PR DESCRIPTION
Closes #872

## Changes
- removed direct `get_rate_limiter().acquire()` calls from Robinhood market tools that already use `execute_with_retry`
- switched `get_rate_limit_status_data` to read Robinhood broker-specific limiter via `get_rate_limiter("robinhood")`
- updated unit tests to stop mocking removed manual limiter calls and to assert broker-specific limiter selection in server helper tests

## Test plan
- `pytest -q -o addopts='' tests/unit/test_market_research_tools.py`
- `pytest -q -o addopts='' tests/unit/test_market_research_tools.py tests/server/test_tool_helpers.py` (fails in this environment during collection due to missing optional dependency: `ModuleNotFoundError: No module named "schwab"`)
