### PR TITLE
fix: update test_rate_limited_collection_nodeids for pytest 9 tree output

### DIFF
--- a/tests/unit/test_rate_limited_marker.py
+++ b/tests/unit/test_rate_limited_marker.py
@@ -204,7 +204,7 @@ def test_rate_limited_collection_nodeids() -> None:
     count = sum(
         1
         for line in result.stdout.splitlines()
-        if "::" in line and not line.startswith("no tests ran")
+        if "<Function " in line or "<Coroutine " in line
     )
 
     assert count == 4, f"Expected 4 tests, found {count}. Output:\n{result.stdout}"


### PR DESCRIPTION
Closes #917

## Changes
- Updated `test_rate_limited_collection_nodeids` count logic to match pytest 9's `--collect-only` tree output format
- The test was counting lines containing `::` (flat node ID format), but pytest 9 outputs `<Function ...>` and `<Coroutine ...>` tree entries instead
- Changed the count filter to look for `<Function ` or `<Coroutine ` lines, which correctly counts 4 collected tests

## Test plan
- `uv run pytest tests/unit/test_rate_limited_marker.py -v` — all 13 tests pass
- Ruff check clean on changed file