### PR TITLE
refactor: eliminate duplicate CircuitBreakerConfig dataclass

### DIFF
--- a/src/open_stocks_mcp/tools/circuit_breaker.py
+++ b/src/open_stocks_mcp/tools/circuit_breaker.py
@@ -4,25 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass
 from typing import Any
 
-from open_stocks_mcp.config import get_config
+from open_stocks_mcp.config import CircuitBreakerConfig, get_config
 from open_stocks_mcp.tools.exceptions import CircuitBreakerError
-
-
-@dataclass
-class CircuitBreakerConfig:
-    """Circuit breaker runtime configuration."""
-
-    enabled: bool = True
-    failure_threshold: int = 5
-    recovery_timeout_seconds: float = 60.0
-
-    @property
-    def cooldown_seconds(self) -> float:
-        """Backward-compatible alias for recovery timeout."""
-        return self.recovery_timeout_seconds
 
 
 class BrokerCircuitBreaker:

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from open_stocks_mcp.config import load_config, reset_cache_config
+from open_stocks_mcp.config import (
+    CircuitBreakerConfig as CanonicalCircuitBreakerConfig,
+    load_config,
+    reset_cache_config,
+)
 from open_stocks_mcp.tools.circuit_breaker import (
     BrokerCircuitBreaker,
     CircuitBreakerConfig,
@@ -163,3 +167,7 @@ def test_load_config_reads_recovery_timeout_env(
     assert cfg.circuit_breaker.failure_threshold == 2
     assert cfg.circuit_breaker.recovery_timeout_seconds == 0.25
     assert cfg.circuit_breaker.cooldown_seconds == 0.25
+
+
+def test_circuit_breaker_uses_canonical_config_dataclass() -> None:
+    assert CircuitBreakerConfig is CanonicalCircuitBreakerConfig


### PR DESCRIPTION
Closes #926

## Changes
- removed duplicate `CircuitBreakerConfig` dataclass from `tools/circuit_breaker.py`
- imported canonical `CircuitBreakerConfig` from `config.py` in circuit breaker runtime
- added a unit test asserting `tools.circuit_breaker.CircuitBreakerConfig` is the canonical config type

## Test plan
- uv run pytest tests/unit/test_circuit_breaker.py tests/unit/test_config.py -q