### PR TITLE
docs: consolidate duplicate Contributing links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,8 @@ MCP_HTTP_URL="http://localhost:3001/mcp" adk eval examples/google_adk_agent test
 
 ## Contributing
 
-See [CONTRIBUTING.md](contributing/README.md) for development guidelines.
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and debugging recipes.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — development setup, workflow, and code guidelines
+- [contributing/README.md](contributing/README.md) — local debugging and editor configuration
 
 ## License
 


### PR DESCRIPTION
Closes #931

## Changes
- Replace two ambiguous `See [CONTRIBUTING.md](...)` lines (same display text, different target files) with a clear bullet list giving distinct descriptions for each file
- `CONTRIBUTING.md` — development setup, workflow, and code guidelines
- `contributing/README.md` — local debugging and editor configuration

## Test plan
- Visual review: Contributing section now has one clear section with two distinctly-named links instead of two identically-named links pointing to different files