### PR TITLE
fix: handle uninitialized registry in rate-limit status

### DIFF
--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -9,7 +9,10 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
-from open_stocks_mcp.brokers.registry import get_broker_registry
+from open_stocks_mcp.brokers.registry import (
+    RegistryNotInitializedError,
+    get_broker_registry,
+)
 from open_stocks_mcp.brokers.session_state import get_session_manager
 from open_stocks_mcp.health import get_health_service
 from open_stocks_mcp.logging_config import logger
@@ -117,17 +120,27 @@ async def get_list_brokers_data() -> dict[str, Any]:
 
 async def get_rate_limit_status_data() -> dict[str, Any]:
     """Return current rate limit usage and statistics."""
-    rate_limiter = get_rate_limiter("robinhood")
+    fallback_note: str | None = None
+    try:
+        rate_limiter = get_rate_limiter("robinhood")
+    except RegistryNotInitializedError:
+        # Early startup can hit this before broker registry lifespan init.
+        rate_limiter = get_rate_limiter()
+        fallback_note = (
+            "broker registry not initialized; using global rate limiter fallback"
+        )
     stats = rate_limiter.get_stats()
 
-    return {
-        "result": {
-            **stats,
-            "endpoint_usage": stats.get("endpoint_usage", {}),
-            "circuit_breaker": get_broker_circuit_breaker().snapshot(),
-            "status": "success",
-        }
+    result: dict[str, Any] = {
+        **stats,
+        "endpoint_usage": stats.get("endpoint_usage", {}),
+        "circuit_breaker": get_broker_circuit_breaker().snapshot(),
+        "status": "success",
     }
+    if fallback_note:
+        result["note"] = fallback_note
+
+    return {"result": result}
 
 
 async def get_metrics_summary_data() -> dict[str, Any]:

--- a/tests/server/test_tool_helpers.py
+++ b/tests/server/test_tool_helpers.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from mcp.server.fastmcp import FastMCP
 
+from open_stocks_mcp.brokers.registry import RegistryNotInitializedError
 from open_stocks_mcp.server.tool_helpers import (
     get_broker_status_data,
     get_health_check_data,
@@ -149,6 +150,28 @@ class TestRateLimitStatusHelper:
         assert response["result"]["status"] == "success"
         assert response["result"]["requests_made"] == 5
         assert response["result"]["limit"] == 100
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_global_limiter_when_registry_uninitialized(self) -> None:
+        global_limiter = MagicMock()
+        global_limiter.get_stats.return_value = {"requests_made": 7, "limit": 99}
+
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_rate_limiter"
+        ) as mock_get_rl:
+            mock_get_rl.side_effect = [
+                RegistryNotInitializedError("not initialized"),
+                global_limiter,
+            ]
+
+            response = await get_rate_limit_status_data()
+
+        assert mock_get_rl.call_args_list[0].args == ("robinhood",)
+        assert mock_get_rl.call_args_list[1].args == ()
+        assert response["result"]["status"] == "success"
+        assert response["result"]["requests_made"] == 7
+        assert response["result"]["limit"] == 99
+        assert "global rate limiter fallback" in response["result"]["note"]
 
 
 @pytest.mark.journey_system


### PR DESCRIPTION
Closes #937

## Changes
- catch `RegistryNotInitializedError` in `get_rate_limit_status_data` when requesting the Robinhood-scoped limiter
- fall back to the global lazy rate limiter during early startup before broker registry initialization
- include a `note` field in the response when fallback is used
- add server helper test coverage for the fallback path

## Test plan
- uv run pytest tests/server/test_tool_helpers.py -q
- uv run ruff check src/open_stocks_mcp/server/tool_helpers.py tests/server/test_tool_helpers.py
- uv run mypy src/open_stocks_mcp/server/tool_helpers.py