### PR TITLE
perf: serve /tools/docs from lifespan cache

### DIFF
--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -520,10 +520,12 @@ def create_http_server(
             raise HTTPException(status_code=500, detail="Failed to list tools") from e
 
     @app.get("/tools/docs")
-    async def tools_docs() -> dict[str, Any]:
-        """Return MCP tool docs metadata from the live registry."""
+    async def tools_docs(request: Request) -> dict[str, Any]:
+        """Return MCP tool docs metadata from the lifespan cache."""
         try:
-            payload = await build_tool_docs_payload(mcp_server)
+            payload = getattr(request.app.state, "tool_docs_payload", None)
+            if payload is None:
+                payload = await build_tool_docs_payload(mcp_server)
             tools = [
                 {"name": t["name"], "description": t["description"]}
                 for t in payload["result"]["tools"]

--- a/tests/http_transport/test_http_server.py
+++ b/tests/http_transport/test_http_server.py
@@ -382,6 +382,35 @@ class TestHTTPEndpoints:
             assert "name" in item
             assert "description" in item
 
+    async def test_tools_docs_serves_from_lifespan_cache(
+        self, mcp_server: FastMCP
+    ) -> None:
+        """Verify /tools/docs reads app.state cache, not rebuilding on each request."""
+        from httpx import ASGITransport
+
+        cached_payload = {
+            "result": {
+                "tools": [{"name": "cached_tool", "description": "from cache"}],
+                "count": 1,
+            }
+        }
+        app = create_http_server(mcp_server)
+        app.state.tool_docs_payload = cached_payload
+
+        with patch(
+            "open_stocks_mcp.server.http_transport.build_tool_docs_payload"
+        ) as mock_build:
+            transport = ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.get("/tools/docs")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["result"]["tools"][0]["name"] == "cached_tool"
+        mock_build.assert_not_called()
+
     async def test_openapi_contains_all_mcp_tools(
         self, http_client: httpx.AsyncClient, mcp_server: FastMCP
     ) -> None:


### PR DESCRIPTION
Closes #932

## Changes
- `/tools/docs` endpoint now reads `app.state.tool_docs_payload` set during server lifespan startup instead of calling `build_tool_docs_payload` on every request
- Falls back to building the payload only if the cache is absent (e.g., in test clients that skip lifespan events)
- Adds `test_tools_docs_serves_from_lifespan_cache` to assert the cache path is taken when state is populated

## Test plan
- `pytest tests/http_transport/test_http_server.py::TestHTTPEndpoints::test_tools_docs_serves_from_lifespan_cache` — new regression test
- `pytest tests/http_transport/test_http_server.py::TestHTTPEndpoints::test_tools_docs_endpoint_lists_tools` — existing smoke test still passes
- `pytest -m journey_system -q` — 440 passed, 0 failures