### PR TITLE
refactor: migrate robinhood_dividend_tools to execute_with_retry

### DIFF
--- a/src/open_stocks_mcp/tools/robinhood_dividend_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_dividend_tools.py
@@ -1,6 +1,5 @@
 """Robin Stocks dividend and income tracking tools."""
 
-import asyncio
 import contextlib
 from typing import Any
 
@@ -9,9 +8,9 @@ import robin_stocks.robinhood as rh
 from open_stocks_mcp.brokers.session_state import get_session_manager
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.tools.error_handling import (
+    execute_with_retry,
     handle_robin_stocks_errors,
 )
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 
 @handle_robin_stocks_errors
@@ -50,12 +49,8 @@ async def get_dividends() -> dict[str, Any]:
         if not await session_mgr.ensure_authenticated():
             return {"result": {"error": "Authentication required", "status": "error"}}
 
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter("robinhood")
-        await rate_limiter.acquire()
-
         # Get dividend data
-        dividends = await asyncio.to_thread(rh.account.get_dividends)
+        dividends = await execute_with_retry(rh.account.get_dividends)
 
         # Validate response
         if not dividends or not isinstance(dividends, list):
@@ -85,7 +80,7 @@ async def get_dividends() -> dict[str, Any]:
             instrument_url = dividend.get("instrument")
             if instrument_url:
                 try:
-                    instrument_data = await asyncio.to_thread(
+                    instrument_data = await execute_with_retry(
                         rh.stocks.get_instrument_by_url, instrument_url
                     )
                     if instrument_data and isinstance(instrument_data, dict):
@@ -145,15 +140,11 @@ async def get_total_dividends() -> dict[str, Any]:
         if not await session_mgr.ensure_authenticated():
             return {"result": {"error": "Authentication required", "status": "error"}}
 
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter("robinhood")
-        await rate_limiter.acquire()
-
         # Use robin_stocks built-in function
-        total = await asyncio.to_thread(rh.account.get_total_dividends)
+        total = await execute_with_retry(rh.account.get_total_dividends)
 
         # Also get detailed dividends for additional stats
-        dividends = await asyncio.to_thread(rh.account.get_dividends)
+        dividends = await execute_with_retry(rh.account.get_dividends)
 
         # Calculate additional statistics
         by_year: dict[str, float] = {}
@@ -239,12 +230,8 @@ async def get_dividends_by_instrument(symbol: str) -> dict[str, Any]:
         if not await session_mgr.ensure_authenticated():
             return {"result": {"error": "Authentication required", "status": "error"}}
 
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter("robinhood")
-        await rate_limiter.acquire()
-
         # Get dividends by instrument
-        dividends = await asyncio.to_thread(
+        dividends = await execute_with_retry(
             rh.account.get_dividends_by_instrument, symbol
         )
 
@@ -320,12 +307,8 @@ async def get_interest_payments() -> dict[str, Any]:
         if not await session_mgr.ensure_authenticated():
             return {"result": {"error": "Authentication required", "status": "error"}}
 
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter("robinhood")
-        await rate_limiter.acquire()
-
         # Get interest payments
-        interest_payments = await asyncio.to_thread(rh.account.get_interest_payments)
+        interest_payments = await execute_with_retry(rh.account.get_interest_payments)
 
         # Process interest payment data
         processed_payments = []
@@ -394,12 +377,8 @@ async def get_stock_loan_payments() -> dict[str, Any]:
         if not await session_mgr.ensure_authenticated():
             return {"result": {"error": "Authentication required", "status": "error"}}
 
-        # Apply rate limiting
-        rate_limiter = get_rate_limiter("robinhood")
-        await rate_limiter.acquire()
-
         # Get stock loan payments
-        loan_payments = await asyncio.to_thread(rh.account.get_stock_loan_payments)
+        loan_payments = await execute_with_retry(rh.account.get_stock_loan_payments)
 
         # Process loan payment data
         processed_payments = []
@@ -422,7 +401,7 @@ async def get_stock_loan_payments() -> dict[str, Any]:
                 instrument_url = payment.get("instrument")
                 if instrument_url:
                     try:
-                        instrument_data = await asyncio.to_thread(
+                        instrument_data = await execute_with_retry(
                             rh.stocks.get_instrument_by_url, instrument_url
                         )
                         if instrument_data and isinstance(instrument_data, dict):

--- a/tests/unit/test_analytics_tools.py
+++ b/tests/unit/test_analytics_tools.py
@@ -276,7 +276,6 @@ class TestDayTrades:
 class TestInterestPayments:
     """Test interest payments functionality."""
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
     @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
     @patch(
         "open_stocks_mcp.tools.robinhood_dividend_tools.rh.account.get_interest_payments"
@@ -288,7 +287,6 @@ class TestInterestPayments:
         self,
         mock_interest_payments: Any,
         mock_session_manager: Any,
-        mock_rate_limiter: Any,
     ) -> None:
         """Test successful interest payments retrieval."""
         mock_interest_payments.return_value = [
@@ -317,11 +315,6 @@ class TestInterestPayments:
         mock_session_instance.ensure_authenticated.return_value = True
         mock_session_manager.return_value = mock_session_instance
 
-        # Mock rate limiter
-        mock_rate_instance = AsyncMock()
-        mock_rate_instance.acquire.return_value = None
-        mock_rate_limiter.return_value = mock_rate_instance
-
         result = await get_interest_payments()
 
         assert "result" in result
@@ -332,7 +325,6 @@ class TestInterestPayments:
         assert result["result"]["interest_payments"][0]["type"] == "cash_management"
         assert result["result"]["status"] == "success"
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
     @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
@@ -346,7 +338,6 @@ class TestInterestPayments:
         self,
         mock_interest_payments: Any,
         mock_session_manager: Any,
-        mock_rate_limiter: Any,
     ) -> None:
         """Test interest payments when no data is available."""
         mock_interest_payments.return_value = None
@@ -355,11 +346,6 @@ class TestInterestPayments:
         mock_session_instance = AsyncMock()
         mock_session_instance.ensure_authenticated.return_value = True
         mock_session_manager.return_value = mock_session_instance
-
-        # Mock rate limiter
-        mock_rate_instance = AsyncMock()
-        mock_rate_instance.acquire.return_value = None
-        mock_rate_limiter.return_value = mock_rate_instance
 
         result = await get_interest_payments()
 
@@ -373,7 +359,6 @@ class TestInterestPayments:
 class TestStockLoanPayments:
     """Test stock loan payments functionality."""
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
     @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
     @patch(
         "open_stocks_mcp.tools.robinhood_dividend_tools.rh.stocks.get_instrument_by_url"
@@ -389,7 +374,6 @@ class TestStockLoanPayments:
         mock_loan_payments: Any,
         mock_instrument: Any,
         mock_session_manager: Any,
-        mock_rate_limiter: Any,
     ) -> None:
         """Test successful stock loan payments retrieval."""
         mock_loan_payments.return_value = [
@@ -425,11 +409,6 @@ class TestStockLoanPayments:
         mock_session_instance.ensure_authenticated.return_value = True
         mock_session_manager.return_value = mock_session_instance
 
-        # Mock rate limiter
-        mock_rate_instance = AsyncMock()
-        mock_rate_instance.acquire.return_value = None
-        mock_rate_limiter.return_value = mock_rate_instance
-
         result = await get_stock_loan_payments()
 
         assert "result" in result
@@ -442,7 +421,6 @@ class TestStockLoanPayments:
         assert result["result"]["loan_payments"][1]["symbol"] == "GME"
         assert result["result"]["status"] == "success"
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
     @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
@@ -453,7 +431,7 @@ class TestStockLoanPayments:
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_stock_loan_payments_no_data(
-        self, mock_loan_payments: Any, mock_session_manager: Any, mock_rate_limiter: Any
+        self, mock_loan_payments: Any, mock_session_manager: Any
     ) -> None:
         """Test stock loan payments when no data is available."""
         mock_loan_payments.return_value = None
@@ -462,11 +440,6 @@ class TestStockLoanPayments:
         mock_session_instance = AsyncMock()
         mock_session_instance.ensure_authenticated.return_value = True
         mock_session_manager.return_value = mock_session_instance
-
-        # Mock rate limiter
-        mock_rate_instance = AsyncMock()
-        mock_rate_instance.acquire.return_value = None
-        mock_rate_limiter.return_value = mock_rate_instance
 
         result = await get_stock_loan_payments()
 

--- a/tests/unit/test_dividend_tools.py
+++ b/tests/unit/test_dividend_tools.py
@@ -16,30 +16,23 @@ class TestDividendTools:
     """Test dividend tools with mocked responses."""
 
     @staticmethod
-    def _configure_authenticated_session(
-        mock_get_rate_limiter: Any, mock_get_session_manager: Any
-    ) -> None:
+    def _configure_authenticated_session(mock_get_session_manager: Any) -> None:
         session = mock_get_session_manager.return_value
         session.ensure_authenticated = AsyncMock(return_value=True)
-        mock_get_rate_limiter.return_value.acquire = AsyncMock(return_value=None)
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.execute_with_retry")
     @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.to_thread")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_dividends_success(
         self,
-        mock_to_thread: Any,
         mock_get_session_manager: Any,
-        mock_get_rate_limiter: Any,
+        mock_execute_with_retry: Any,
     ) -> None:
         """Test successful dividends retrieval."""
-        self._configure_authenticated_session(
-            mock_get_rate_limiter, mock_get_session_manager
-        )
-        mock_to_thread.side_effect = [
+        self._configure_authenticated_session(mock_get_session_manager)
+        mock_execute_with_retry.side_effect = [
             [
                 {
                     "amount": "10.00",
@@ -62,33 +55,24 @@ class TestDividendTools:
 
         assert "result" in result
         assert isinstance(result["result"], dict)
-        assert mock_to_thread.await_args_list[0].args[0].__name__ == "get_dividends"
-        assert (
-            mock_to_thread.await_args_list[1].args[0].__name__
-            == "get_instrument_by_url"
-        )
-        assert (
-            mock_to_thread.await_args_list[2].args[0].__name__
-            == "get_instrument_by_url"
-        )
+        calls = mock_execute_with_retry.call_args_list
+        assert calls[0].args[0].__name__ == "get_dividends"
+        assert calls[1].args[0].__name__ == "get_instrument_by_url"
+        assert calls[2].args[0].__name__ == "get_instrument_by_url"
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.execute_with_retry")
     @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.to_thread")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_total_dividends_success(
         self,
-        mock_to_thread: Any,
         mock_get_session_manager: Any,
-        mock_get_rate_limiter: Any,
+        mock_execute_with_retry: Any,
     ) -> None:
         """Test successful total dividends calculation."""
-        self._configure_authenticated_session(
-            mock_get_rate_limiter, mock_get_session_manager
-        )
-        mock_to_thread.side_effect = [
+        self._configure_authenticated_session(mock_get_session_manager)
+        mock_execute_with_retry.side_effect = [
             "100.50",
             [{"state": "paid", "paid_at": "2024-01-15T00:00:00Z", "amount": "10.00"}],
         ]
@@ -97,28 +81,23 @@ class TestDividendTools:
 
         assert "result" in result
         assert isinstance(result["result"], dict)
-        assert (
-            mock_to_thread.await_args_list[0].args[0].__name__ == "get_total_dividends"
-        )
-        assert mock_to_thread.await_args_list[1].args[0].__name__ == "get_dividends"
+        calls = mock_execute_with_retry.call_args_list
+        assert calls[0].args[0].__name__ == "get_total_dividends"
+        assert calls[1].args[0].__name__ == "get_dividends"
 
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_rate_limiter")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.execute_with_retry")
     @patch("open_stocks_mcp.tools.robinhood_dividend_tools.get_session_manager")
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.to_thread")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_dividends_by_instrument_success(
         self,
-        mock_to_thread: Any,
         mock_get_session_manager: Any,
-        mock_get_rate_limiter: Any,
+        mock_execute_with_retry: Any,
     ) -> None:
         """Test successful dividends by instrument retrieval."""
-        self._configure_authenticated_session(
-            mock_get_rate_limiter, mock_get_session_manager
-        )
-        mock_to_thread.return_value = [
+        self._configure_authenticated_session(mock_get_session_manager)
+        mock_execute_with_retry.return_value = [
             {"amount": "10.00", "symbol": "AAPL"},
         ]
 
@@ -126,20 +105,19 @@ class TestDividendTools:
 
         assert "result" in result
         assert isinstance(result["result"], dict)
-        assert (
-            mock_to_thread.await_args.args[0].__name__ == "get_dividends_by_instrument"
-        )
-        assert mock_to_thread.await_args.args[1] == "AAPL"
+        call = mock_execute_with_retry.call_args
+        assert call.args[0].__name__ == "get_dividends_by_instrument"
+        assert call.args[1] == "AAPL"
 
     @pytest.mark.exception_test
     @pytest.mark.skip(reason="Slow exception test - run with pytest -m exception_test")
-    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.asyncio.to_thread")
+    @patch("open_stocks_mcp.tools.robinhood_dividend_tools.execute_with_retry")
     @pytest.mark.journey_research
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_get_dividends_error(self, mock_to_thread: Any) -> None:
+    async def test_get_dividends_error(self, mock_execute_with_retry: Any) -> None:
         """Test error handling."""
-        mock_to_thread.side_effect = Exception("API Error")
+        mock_execute_with_retry.side_effect = Exception("API Error")
 
         result = await get_dividends()
 


### PR DESCRIPTION
Closes #938

## Changes
- Replaced manual `get_rate_limiter("robinhood")` + `await rate_limiter.acquire()` + `asyncio.to_thread(func, ...)` pattern in all 5 tool functions in `robinhood_dividend_tools.py` with `execute_with_retry(func, ...)`
- Removed `import asyncio` and `from open_stocks_mcp.tools.rate_limiter import get_rate_limiter` (no longer needed)
- Added `execute_with_retry` to the `error_handling` import
- Updated `tests/unit/test_dividend_tools.py` and `tests/unit/test_analytics_tools.py` to mock `execute_with_retry` / drop the now-absent `get_rate_limiter` mock

## Test plan
- `pytest tests/unit/test_dividend_tools.py` — 3 passed, 1 skipped
- `pytest -m journey_research` — 23 passed, 22 skipped
- `ruff check` — All checks passed
- `mypy src/open_stocks_mcp/tools/robinhood_dividend_tools.py` — Success: no issues found