### PR TITLE
refactor: remove unused avg_response_time_degraded_ms config

### DIFF
--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -240,7 +240,6 @@ class AlertConfig:
     latency_p95_threshold_ms: float = 5000.0
     error_rate_degraded_threshold_percent: float = 10.0
     error_rate_unhealthy_threshold_percent: float = 25.0
-    avg_response_time_degraded_ms: float = 5000.0
     avg_response_time_unhealthy_ms: float = 10000.0
     dedup_window_seconds: float = 300.0
 
@@ -759,13 +758,6 @@ def load_config(config_path: Path | str | None = None) -> ServerConfig:
                     os.getenv("ALERT_ERROR_RATE_UNHEALTHY_THRESHOLD", "25.0"),
                 ),
                 "ALERT_ERROR_RATE_UNHEALTHY_THRESHOLD_PERCENT",
-            ),
-            avg_response_time_degraded_ms=_parse_float(
-                os.getenv(
-                    "ALERT_AVG_RESPONSE_TIME_DEGRADED_MS",
-                    os.getenv("ALERT_LATENCY_P95_THRESHOLD_MS", "5000.0"),
-                ),
-                "ALERT_AVG_RESPONSE_TIME_DEGRADED_MS",
             ),
             avg_response_time_unhealthy_ms=_parse_float(
                 os.getenv("ALERT_AVG_RESPONSE_TIME_UNHEALTHY_MS", "10000.0"),


### PR DESCRIPTION
Closes #949

## Changes
- Removed `avg_response_time_degraded_ms` field from `AlertConfig` dataclass
- Removed corresponding env var parsing (`ALERT_AVG_RESPONSE_TIME_DEGRADED_MS`) from `_build_config()`

## Test plan
- [x] `pytest tests/unit/test_config.py` — 40 passed
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues found
- [x] Grep confirms no remaining references to the removed field