### PR TITLE
chore: cleanup (ruff format)

### DIFF
--- a/src/open_stocks_mcp/tools/unified_watchlist_tools.py
+++ b/src/open_stocks_mcp/tools/unified_watchlist_tools.py
@@ -274,7 +274,9 @@ async def add_symbols_to_unified_watchlist(
             else:
                 per_broker[name] = {"status": "unavailable", "success": False}
         elif name == "schwab":
-            combined_symbols, save_error = add_schwab_symbols(watchlist_name, normalized)
+            combined_symbols, save_error = add_schwab_symbols(
+                watchlist_name, normalized
+            )
             if save_error:
                 per_broker[name] = {
                     "status": "error",
@@ -333,7 +335,9 @@ async def remove_symbols_from_unified_watchlist(
             else:
                 per_broker[name] = {"status": "unavailable", "success": False}
         elif name == "schwab":
-            remaining_symbols, save_error = remove_schwab_symbols(watchlist_name, normalized)
+            remaining_symbols, save_error = remove_schwab_symbols(
+                watchlist_name, normalized
+            )
             if save_error:
                 per_broker[name] = {
                     "status": "error",

--- a/tests/server/test_tool_helpers.py
+++ b/tests/server/test_tool_helpers.py
@@ -152,7 +152,9 @@ class TestRateLimitStatusHelper:
         assert response["result"]["limit"] == 100
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_global_limiter_when_registry_uninitialized(self) -> None:
+    async def test_falls_back_to_global_limiter_when_registry_uninitialized(
+        self,
+    ) -> None:
         global_limiter = MagicMock()
         global_limiter.get_stats.return_value = {"requests_made": 7, "limit": 99}
 

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -8,6 +8,8 @@ import pytest
 
 from open_stocks_mcp.config import (
     CircuitBreakerConfig as CanonicalCircuitBreakerConfig,
+)
+from open_stocks_mcp.config import (
     load_config,
     reset_cache_config,
 )

--- a/tests/unit/test_schwab_local_store.py
+++ b/tests/unit/test_schwab_local_store.py
@@ -36,7 +36,9 @@ def test_normalize_payload_handles_malformed_root() -> None:
 
 
 @pytest.mark.unit
-def test_load_watchlists_missing_file_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_watchlists_missing_file_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     missing = Path("/tmp/does-not-exist-schwab-watchlists.json")
     monkeypatch.setattr(store, "get_store_path", lambda: missing)
 
@@ -47,7 +49,9 @@ def test_load_watchlists_missing_file_returns_empty(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.unit
-def test_load_watchlists_reads_and_normalizes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_watchlists_reads_and_normalizes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     path = tmp_path / "schwab_watchlists.json"
     path.write_text(
         json.dumps({"watchlists": {"Tech": ["aapl", " AAPL ", "msft", 1]}}),
@@ -77,7 +81,9 @@ def test_load_watchlists_returns_error_for_invalid_json(
 
 
 @pytest.mark.unit
-def test_save_watchlists_writes_expected_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_save_watchlists_writes_expected_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     path = tmp_path / "nested" / "schwab_watchlists.json"
     monkeypatch.setattr(store, "get_store_path", lambda: path)
 

--- a/tests/unit/test_unified_watchlist_tools.py
+++ b/tests/unit/test_unified_watchlist_tools.py
@@ -57,12 +57,15 @@ async def test_get_unified_watchlists_success(
         }
     }
 
-    with patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
-        return_value=rh_watchlists,
-    ), patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
-        return_value=({"Income": ["SCHD", "VYM"]}, None),
+    with (
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
+            return_value=rh_watchlists,
+        ),
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
+            return_value=({"Income": ["SCHD", "VYM"]}, None),
+        ),
     ):
         result = await get_unified_watchlists()
 
@@ -92,12 +95,15 @@ async def test_get_unified_watchlists_merges_same_name_across_brokers(
         }
     }
 
-    with patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
-        return_value=rh_watchlists,
-    ), patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
-        return_value=({"Tech": ["MSFT", "AAPL"]}, None),
+    with (
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
+            return_value=rh_watchlists,
+        ),
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
+            return_value=({"Tech": ["MSFT", "AAPL"]}, None),
+        ),
     ):
         result = await get_unified_watchlists()
 
@@ -125,12 +131,15 @@ async def test_get_unified_watchlist_by_name_success(
         }
     }
 
-    with patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name",
-        return_value=rh_watchlist,
-    ), patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.get_schwab_watchlist",
-        return_value=(["SCHD"], None),
+    with (
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name",
+            return_value=rh_watchlist,
+        ),
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.get_schwab_watchlist",
+            return_value=(["SCHD"], None),
+        ),
     ):
         result = await get_unified_watchlist_by_name("Tech")
 
@@ -229,7 +238,9 @@ async def test_get_unified_watchlist_by_name_unregistered_broker_partial_failure
         "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlist_by_name",
         return_value=rh_not_found,
     ):
-        result = await get_unified_watchlist_by_name("Tech", brokers=["robinhood", "fakeBroker"])
+        result = await get_unified_watchlist_by_name(
+            "Tech", brokers=["robinhood", "fakeBroker"]
+        )
 
     assert result["result"]["status"] == "partial_failure"
     assert result["result"]["per_broker"]["fakeBroker"]["status"] == "error"
@@ -249,12 +260,15 @@ async def test_add_symbols_to_unified_watchlist_partial_success(
         "result": {"success": True, "symbols_added": ["AAPL"], "status": "success"}
     }
 
-    with patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.add_rh_symbols",
-        return_value=rh_result,
-    ), patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.add_schwab_symbols",
-        return_value=(["AAPL"], None),
+    with (
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.add_rh_symbols",
+            return_value=rh_result,
+        ),
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.add_schwab_symbols",
+            return_value=(["AAPL"], None),
+        ),
     ):
         result = await add_symbols_to_unified_watchlist("Tech", ["aapl", "AAPL "])
 
@@ -279,12 +293,15 @@ async def test_remove_symbols_from_unified_watchlist_success(
         "result": {"success": True, "symbols_removed": ["AAPL"], "status": "success"}
     }
 
-    with patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.remove_rh_symbols",
-        return_value=rh_result,
-    ), patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.remove_schwab_symbols",
-        return_value=([], None),
+    with (
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.remove_rh_symbols",
+            return_value=rh_result,
+        ),
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.remove_schwab_symbols",
+            return_value=([], None),
+        ),
     ):
         result = await remove_symbols_from_unified_watchlist("Tech", ["AAPL"])
 
@@ -305,12 +322,15 @@ async def test_get_unified_watchlists_handles_corrupt_schwab_store(
 
     rh_watchlists = {"result": {"watchlists": [], "status": "success"}}
 
-    with patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
-        return_value=rh_watchlists,
-    ), patch(
-        "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
-        return_value=({}, "Unable to read Schwab watchlist store"),
+    with (
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.get_rh_watchlists",
+            return_value=rh_watchlists,
+        ),
+        patch(
+            "open_stocks_mcp.tools.unified_watchlist_tools.load_schwab_watchlists",
+            return_value=({}, "Unable to read Schwab watchlist store"),
+        ),
     ):
         result = await get_unified_watchlists()
 


### PR DESCRIPTION
Automated code quality cleanup using ruff.

**Files changed:** 5
**Changes made:**
- 1 lint fix via ruff check --fix
- 4 files reformatted via ruff format

**Testing:** Existing test suite validated (1 pre-existing flaky test in test_rate_limiter_isolation.py unrelated to formatting)