### PR TITLE
feat: add ADK eval fixtures for all uncovered schwab_* MCP tools

### DIFF
--- a/tests/evals/1_acc_schwab_account_balances_test.json
+++ b/tests/evals/1_acc_schwab_account_balances_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_account_balances_test_set",
+  "name": "Schwab Account Balances Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves balances via schwab_account_balances",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_account_balances_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-account-balances-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What are my current Schwab account balances?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab account balances:\n\n* **Cash Balance**: $500.00\n* **Total Equity**: $10,500.00\n* **Buying Power**: $500.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_account_balances"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_account_test.json
+++ b/tests/evals/1_acc_schwab_account_test.json
@@ -1,0 +1,54 @@
+{
+  "eval_set_id": "schwab_account_test_set",
+  "name": "Schwab Account Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves account details via schwab_account",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_account_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-account-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab account details including balances and positions."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab account details:\n\n* **Account Hash**: abc123hash\n* **Equity**: $10,000.00\n* **Cash**: $500.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash",
+                  "include_positions": true
+                },
+                "name": "schwab_account"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_accounts_test.json
+++ b/tests/evals/1_acc_schwab_accounts_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "schwab_accounts_test_set",
+  "name": "Schwab Accounts Test",
+  "description": "Test case for retrieving all Schwab accounts with balances and positions via schwab_accounts",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_accounts_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-accounts-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "List all my Schwab accounts with their current balances."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are all your Schwab accounts:\n\n* **Account 1**:\n  * Account Hash: abc123hash\n  * Equity: $10,000.00\n  * Cash: $500.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "include_positions": true
+                },
+                "name": "schwab_accounts"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_check_margin_status_test.json
+++ b/tests/evals/1_acc_schwab_check_margin_status_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_check_margin_status_test_set",
+  "name": "Schwab Check Margin Status Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then checks margin status via schwab_check_margin_status",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_check_margin_status_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-check-margin-status-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Check my Schwab margin account status."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Schwab margin status:\n\n* **Margin Enabled**: Yes\n* **Margin Balance**: $0.00\n* **Maintenance Margin**: $5,000.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_check_margin_status"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_get_aggregate_positions_test.json
+++ b/tests/evals/1_acc_schwab_get_aggregate_positions_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_get_aggregate_positions_test_set",
+  "name": "Schwab Get Aggregate Positions Test",
+  "description": "Test case for retrieving aggregated Schwab positions across all accounts via schwab_get_aggregate_positions",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_aggregate_positions_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-aggregate-positions-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my aggregated Schwab positions across all accounts."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your aggregated Schwab positions across all accounts:\n\n* **AAPL**: 10 shares total, Avg Cost: $150.00\n* **MSFT**: 5 shares total, Avg Cost: $280.00\n* **Total Invested**: $2,900.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_get_aggregate_positions"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_get_all_account_data_test.json
+++ b/tests/evals/1_acc_schwab_get_all_account_data_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_get_all_account_data_test_set",
+  "name": "Schwab Get All Account Data Test",
+  "description": "Test case for retrieving all Schwab account data in a single call via schwab_get_all_account_data",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_all_account_data_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-all-account-data-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Give me a complete overview of all my Schwab account data."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is a complete overview of your Schwab account data:\n\n* **Accounts**: 1 account found\n* **Total Equity**: $10,500.00\n* **Cash**: $500.00\n* **Positions**: AAPL, MSFT\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_get_all_account_data"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_get_build_holdings_test.json
+++ b/tests/evals/1_acc_schwab_get_build_holdings_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_get_build_holdings_test_set",
+  "name": "Schwab Get Build Holdings Test",
+  "description": "Test case for building a consolidated Schwab holdings view via schwab_get_build_holdings",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_build_holdings_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-build-holdings-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Build a consolidated view of all my Schwab holdings."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is a consolidated view of your Schwab holdings:\n\n* **AAPL**: 10 shares, Current Value: $2,230.90\n* **MSFT**: 5 shares, Current Value: $2,077.50\n* **Total Value**: $4,308.40\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_get_build_holdings"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_get_day_trades_test.json
+++ b/tests/evals/1_acc_schwab_get_day_trades_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_get_day_trades_test_set",
+  "name": "Schwab Get Day Trades Test",
+  "description": "Test case for retrieving Schwab day trade count and PDT status via schwab_get_day_trades",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_day_trades_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-day-trades-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "How many day trades have I made on Schwab this week?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Schwab day trade summary:\n\n* **Day Trades Used**: 2\n* **Day Trades Remaining**: 1 (before PDT rule)\n* **PDT Status**: Not flagged\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_get_day_trades"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_get_margin_interest_test.json
+++ b/tests/evals/1_acc_schwab_get_margin_interest_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_get_margin_interest_test_set",
+  "name": "Schwab Get Margin Interest Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves margin interest charges via schwab_get_margin_interest",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_margin_interest_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-margin-interest-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab margin interest charges for this month."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab margin interest charges:\n\n* **Total Interest Charged**: $0.00\n* **Period**: current month\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_get_margin_interest"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_get_user_preferences_test.json
+++ b/tests/evals/1_acc_schwab_get_user_preferences_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_get_user_preferences_test_set",
+  "name": "Schwab Get User Preferences Test",
+  "description": "Test case for retrieving Schwab user preferences and settings via schwab_get_user_preferences",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_user_preferences_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-user-preferences-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab account preferences and settings."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab user preferences:\n\n* **Default Account**: abc123hash\n* **Streaming Preferences**: enabled\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_get_user_preferences"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/1_acc_schwab_portfolio_test.json
+++ b/tests/evals/1_acc_schwab_portfolio_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_portfolio_test_set",
+  "name": "Schwab Portfolio Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves portfolio via schwab_portfolio",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_portfolio_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-portfolio-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab portfolio holdings."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab portfolio holdings:\n\n* **AAPL**: 10 shares @ $150.00\n* **MSFT**: 5 shares @ $280.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_portfolio"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_schwab_get_instrument_by_cusip_test.json
+++ b/tests/evals/2_mkt_schwab_get_instrument_by_cusip_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "schwab_get_instrument_by_cusip_test_set",
+  "name": "Schwab Get Instrument By CUSIP Test",
+  "description": "Test case for retrieving Schwab instrument details by CUSIP identifier via schwab_get_instrument_by_cusip",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_instrument_by_cusip_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-instrument-by-cusip-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Look up the Schwab instrument for CUSIP 037833100 (Apple)."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the Schwab instrument details for CUSIP 037833100:\n\n* **Symbol**: AAPL\n* **Description**: Apple Inc.\n* **CUSIP**: 037833100\n* **Exchange**: NASDAQ\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "cusip": "037833100"
+                },
+                "name": "schwab_get_instrument_by_cusip"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_schwab_get_market_hours_test.json
+++ b/tests/evals/2_mkt_schwab_get_market_hours_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "schwab_get_market_hours_test_set",
+  "name": "Schwab Get Market Hours Test",
+  "description": "Test case for retrieving market hours for a given exchange via schwab_get_market_hours",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_market_hours_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-market-hours-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What are the Schwab market hours for the equity market today?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the Schwab equity market hours for today:\n\n* **Market**: equity\n* **Session Open**: 09:30 AM ET\n* **Session Close**: 04:00 PM ET\n* **Is Open**: Yes\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "market": "equity"
+                },
+                "name": "schwab_get_market_hours"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_schwab_get_movers_sp500_test.json
+++ b/tests/evals/2_mkt_schwab_get_movers_sp500_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_get_movers_sp500_test_set",
+  "name": "Schwab Get Movers SP500 Test",
+  "description": "Test case for retrieving top S&P 500 market movers via schwab_get_movers_sp500",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_movers_sp500_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-movers-sp500-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What are the top S&P 500 movers today on Schwab?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the top S&P 500 movers today via Schwab:\n\n* **NVDA**: +5.2% (Top Gainer)\n* **TSLA**: -3.1% (Top Loser)\n* **AAPL**: +1.5%\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_get_movers_sp500"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_schwab_get_movers_test.json
+++ b/tests/evals/2_mkt_schwab_get_movers_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "schwab_get_movers_test_set",
+  "name": "Schwab Get Movers Test",
+  "description": "Test case for retrieving top market movers via schwab_get_movers",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_movers_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-movers-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me the top market movers on Schwab for the NASDAQ today."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the top NASDAQ movers today via Schwab:\n\n* **NVDA**: +5.2%\n* **TSLA**: -3.1%\n* **META**: +2.8%\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "index": "$COMPX"
+                },
+                "name": "schwab_get_movers"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_schwab_instrument_test.json
+++ b/tests/evals/2_mkt_schwab_instrument_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "schwab_instrument_test_set",
+  "name": "Schwab Instrument Test",
+  "description": "Test case for retrieving Schwab instrument details for a symbol via schwab_instrument",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_instrument_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-instrument-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Get me the Schwab instrument details for AAPL."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the Schwab instrument details for AAPL:\n\n* **Symbol**: AAPL\n* **Description**: Apple Inc.\n* **Exchange**: NASDAQ\n* **Asset Type**: EQUITY\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL"
+                },
+                "name": "schwab_instrument"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/2_mkt_schwab_quotes_test.json
+++ b/tests/evals/2_mkt_schwab_quotes_test.json
@@ -1,0 +1,48 @@
+{
+  "eval_set_id": "schwab_quotes_test_set",
+  "name": "Schwab Quotes Test",
+  "description": "Test case for retrieving multiple Schwab stock quotes in a single call via schwab_quotes",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_quotes_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-quotes-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Get me Schwab quotes for AAPL, MSFT, and GOOGL."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the Schwab quotes for your requested symbols:\n\n* **AAPL**: $223.09\n* **MSFT**: $415.50\n* **GOOGL**: $178.25\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbols": ["AAPL", "MSFT", "GOOGL"]
+                },
+                "name": "schwab_quotes"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_get_open_stock_orders_test.json
+++ b/tests/evals/5_ord_schwab_get_open_stock_orders_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_get_open_stock_orders_test_set",
+  "name": "Schwab Get Open Stock Orders Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves open stock orders via schwab_get_open_stock_orders",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_open_stock_orders_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-open-stock-orders-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my open Schwab stock orders."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your open Schwab stock orders:\n\n* **Order 1**: Buy 10 AAPL @ $220.00 Limit - WORKING\n* **Order 2**: Sell 5 MSFT @ $430.00 Limit - WORKING\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_get_open_stock_orders"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_get_order_test.json
+++ b/tests/evals/5_ord_schwab_get_order_test.json
@@ -1,0 +1,54 @@
+{
+  "eval_set_id": "schwab_get_order_test_set",
+  "name": "Schwab Get Order Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves a specific order via schwab_get_order",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_order_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-order-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Look up the details of my Schwab order with ID 123456789."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the details for Schwab order 123456789:\n\n* **Order ID**: 123456789\n* **Symbol**: AAPL\n* **Type**: Limit Buy\n* **Quantity**: 10\n* **Price**: $220.00\n* **Status**: WORKING"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash",
+                  "order_id": "123456789"
+                },
+                "name": "schwab_get_order"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_get_transaction_test.json
+++ b/tests/evals/5_ord_schwab_get_transaction_test.json
@@ -1,0 +1,54 @@
+{
+  "eval_set_id": "schwab_get_transaction_test_set",
+  "name": "Schwab Get Transaction Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves a specific transaction via schwab_get_transaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_transaction_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-transaction-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Look up the details of Schwab transaction ID 987654321."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are the details for Schwab transaction 987654321:\n\n* **Transaction ID**: 987654321\n* **Type**: TRADE\n* **Symbol**: AAPL\n* **Quantity**: 10\n* **Price**: $220.00\n* **Date**: 2025-01-15\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash",
+                  "transaction_id": "987654321"
+                },
+                "name": "schwab_get_transaction"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_transactions_by_date_test.json
+++ b/tests/evals/5_ord_schwab_transactions_by_date_test.json
@@ -1,0 +1,55 @@
+{
+  "eval_set_id": "schwab_transactions_by_date_test_set",
+  "name": "Schwab Transactions By Date Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves transactions for a date range via schwab_transactions_by_date",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_transactions_by_date_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-transactions-by-date-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab transactions from January 1 to January 15, 2025."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab transactions from January 1 to January 15, 2025:\n\n* **Trade**: Bought 10 AAPL @ $220.00 on 2025-01-15\n* **Trade**: Sold 5 MSFT @ $410.00 on 2025-01-10\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash",
+                  "start_date": "2025-01-01",
+                  "end_date": "2025-01-15"
+                },
+                "name": "schwab_transactions_by_date"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_transactions_test.json
+++ b/tests/evals/5_ord_schwab_transactions_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_transactions_test_set",
+  "name": "Schwab Transactions Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves transaction history via schwab_transactions",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_transactions_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-transactions-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my recent Schwab transaction history."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your recent Schwab transactions:\n\n* **Trade**: Bought 10 AAPL @ $220.00 on 2025-01-15\n* **Trade**: Sold 5 MSFT @ $410.00 on 2025-01-10\n* **Dividend**: AAPL $0.25/share on 2025-01-08\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_transactions"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/7_pmt_schwab_get_dividends_by_symbol_test.json
+++ b/tests/evals/7_pmt_schwab_get_dividends_by_symbol_test.json
@@ -1,0 +1,54 @@
+{
+  "eval_set_id": "schwab_get_dividends_by_symbol_test_set",
+  "name": "Schwab Get Dividends By Symbol Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves dividends for a specific symbol via schwab_get_dividends_by_symbol",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_dividends_by_symbol_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-dividends-by-symbol-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "How much has Schwab paid me in AAPL dividends?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab AAPL dividend payments:\n\n* **2025-01-08**: $25.00 (10 shares @ $0.25/share)\n* **2024-10-07**: $24.00 (10 shares @ $0.24/share)\n* **Total**: $49.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash",
+                  "symbol": "AAPL"
+                },
+                "name": "schwab_get_dividends_by_symbol"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/7_pmt_schwab_get_dividends_test.json
+++ b/tests/evals/7_pmt_schwab_get_dividends_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_get_dividends_test_set",
+  "name": "Schwab Get Dividends Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves dividend payments via schwab_get_dividends",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_dividends_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-dividends-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab dividend payments for this year."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab dividend payments:\n\n* **AAPL**: $25.00 on 2025-01-08\n* **MSFT**: $35.00 on 2025-01-12\n* **Total**: $60.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_get_dividends"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/7_pmt_schwab_get_interest_payments_test.json
+++ b/tests/evals/7_pmt_schwab_get_interest_payments_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_get_interest_payments_test_set",
+  "name": "Schwab Get Interest Payments Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves interest payments via schwab_get_interest_payments",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_interest_payments_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-interest-payments-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab interest payment history."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab interest payments:\n\n* **2025-01-15**: $1.25 (Cash sweep interest)\n* **2024-12-16**: $1.10 (Cash sweep interest)\n* **Total**: $2.35\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_get_interest_payments"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/7_pmt_schwab_get_stock_loan_payments_test.json
+++ b/tests/evals/7_pmt_schwab_get_stock_loan_payments_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_get_stock_loan_payments_test_set",
+  "name": "Schwab Get Stock Loan Payments Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves stock loan payments via schwab_get_stock_loan_payments",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_stock_loan_payments_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-stock-loan-payments-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab stock loan payment history."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab stock loan payments:\n\n* No stock loan payments found for this period.\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_get_stock_loan_payments"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/7_pmt_schwab_get_total_dividends_test.json
+++ b/tests/evals/7_pmt_schwab_get_total_dividends_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_get_total_dividends_test_set",
+  "name": "Schwab Get Total Dividends Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves total dividend income via schwab_get_total_dividends",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_total_dividends_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-total-dividends-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "What is my total Schwab dividend income for this year?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your total Schwab dividend income summary:\n\n* **Total Dividends Received**: $60.00\n* **Year-to-Date**: 2025\n* **Sources**: AAPL ($25.00), MSFT ($35.00)\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_get_total_dividends"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_find_tradable_options_test.json
+++ b/tests/evals/8_opt_schwab_find_tradable_options_test.json
@@ -1,0 +1,51 @@
+{
+  "eval_set_id": "schwab_find_tradable_options_test_set",
+  "name": "Schwab Find Tradable Options Test",
+  "description": "Test case for finding tradable Schwab options for a symbol via schwab_find_tradable_options",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_find_tradable_options_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-find-tradable-options-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Find tradable AAPL call options on Schwab expiring in January 2025 with strikes near $200."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are tradable AAPL call options on Schwab near your criteria:\n\n* **AAPL 200C 2025-01-17**: Ask $5.50, Delta: 0.45, Volume: 12,340\n* **AAPL 205C 2025-01-17**: Ask $3.20, Delta: 0.35, Volume: 8,510\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "option_type": "CALL",
+                  "expiration_date": "2025-01-17",
+                  "strike_price": 200.0
+                },
+                "name": "schwab_find_tradable_options"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_get_all_option_positions_test.json
+++ b/tests/evals/8_opt_schwab_get_all_option_positions_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_get_all_option_positions_test_set",
+  "name": "Schwab Get All Option Positions Test",
+  "description": "Test case for retrieving all Schwab option positions across accounts via schwab_get_all_option_positions",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_all_option_positions_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-all-option-positions-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me all my Schwab option positions."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are all your Schwab option positions:\n\n* **AAPL 200C 2025-01-17**: 2 contracts, Current Value: $450.00\n* **MSFT 300P 2025-03-21**: 1 contract, Current Value: $120.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_get_all_option_positions"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_get_open_option_positions_test.json
+++ b/tests/evals/8_opt_schwab_get_open_option_positions_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_get_open_option_positions_test_set",
+  "name": "Schwab Get Open Option Positions Test",
+  "description": "Test case for retrieving open Schwab option positions via schwab_get_open_option_positions",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_get_open_option_positions_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-get-open-option-positions-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my open Schwab option positions."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your open Schwab option positions:\n\n* **AAPL 200C 2025-01-17**: 2 contracts, Delta: 0.45, Current Value: $450.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_get_open_option_positions"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_open_option_orders_test.json
+++ b/tests/evals/8_opt_schwab_open_option_orders_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_open_option_orders_test_set",
+  "name": "Schwab Open Option Orders Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves open option orders via schwab_open_option_orders",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_open_option_orders_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-open-option-orders-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my open Schwab option orders."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your open Schwab option orders:\n\n* **Order 1**: Sell 1 MSFT 300P 2025-03-21 @ $4.50 - WORKING\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_open_option_orders"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_option_chain_by_expiration_test.json
+++ b/tests/evals/8_opt_schwab_option_chain_by_expiration_test.json
@@ -1,0 +1,49 @@
+{
+  "eval_set_id": "schwab_option_chain_by_expiration_test_set",
+  "name": "Schwab Option Chain By Expiration Test",
+  "description": "Test case for retrieving Schwab option chain filtered by expiration date via schwab_option_chain_by_expiration",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_option_chain_by_expiration_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-option-chain-by-expiration-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Get me the Schwab AAPL option chain for the January 2025 expiration."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the Schwab AAPL option chain for the January 2025 expiration:\n\n* **Calls**:\n  * Strike $200: Ask $5.50, Bid $5.20, Delta: 0.45\n  * Strike $210: Ask $2.10, Bid $1.90, Delta: 0.30\n* **Puts**:\n  * Strike $200: Ask $4.80, Bid $4.50, Delta: -0.55\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "expiration_date": "2025-01-17"
+                },
+                "name": "schwab_option_chain_by_expiration"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_option_orders_test.json
+++ b/tests/evals/8_opt_schwab_option_orders_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_option_orders_test_set",
+  "name": "Schwab Option Orders Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves option orders via schwab_option_orders",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_option_orders_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-option-orders-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my recent Schwab option orders."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your recent Schwab option orders:\n\n* **Order 1**: Buy 2 AAPL 200C 2025-01-17 @ $5.00 - FILLED\n* **Order 2**: Sell 1 MSFT 300P 2025-03-21 @ $4.50 - WORKING\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_option_orders"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_option_quote_test.json
+++ b/tests/evals/8_opt_schwab_option_quote_test.json
@@ -1,0 +1,51 @@
+{
+  "eval_set_id": "schwab_option_quote_test_set",
+  "name": "Schwab Option Quote Test",
+  "description": "Test case for retrieving a Schwab option quote for a specific contract via schwab_option_quote",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_option_quote_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-option-quote-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Get me the Schwab option quote for the AAPL January 2025 $200 call."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is the Schwab option quote for AAPL Jan 2025 $200 Call:\n\n* **Symbol**: AAPL  250117C00200000\n* **Bid**: $5.20\n* **Ask**: $5.50\n* **Last**: $5.35\n* **Delta**: 0.45\n* **Implied Volatility**: 28.5%\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "symbol": "AAPL",
+                  "expiration_date": "2025-01-17",
+                  "strike_price": 200.0,
+                  "option_type": "CALL"
+                },
+                "name": "schwab_option_quote"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_options_positions_test.json
+++ b/tests/evals/8_opt_schwab_options_positions_test.json
@@ -1,0 +1,53 @@
+{
+  "eval_set_id": "schwab_options_positions_test_set",
+  "name": "Schwab Options Positions Test",
+  "description": "Multi-step test: agent resolves account hash via schwab_account_numbers, then retrieves option positions via schwab_options_positions",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_options_positions_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-options-positions-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Show me my Schwab options positions for my account."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here are your Schwab options positions:\n\n* **AAPL 200C 2025-01-17**: 2 contracts, P&L: +$50.00\n* **MSFT 300P 2025-03-21**: 1 contract, P&L: -$20.00\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_account_numbers"
+              },
+              {
+                "id": "adk-tool-use-id",
+                "args": {
+                  "account_hash": "resolved-account-hash"
+                },
+                "name": "schwab_options_positions"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/9_adv_schwab_build_user_profile_test.json
+++ b/tests/evals/9_adv_schwab_build_user_profile_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_build_user_profile_test_set",
+  "name": "Schwab Build User Profile Test",
+  "description": "Test case for building a comprehensive Schwab user profile aggregating account and portfolio data via schwab_build_user_profile",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_build_user_profile_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-build-user-profile-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Build my complete Schwab user profile with account summary."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Here is your Schwab user profile summary:\n\n* **Total Equity**: $10,500.00\n* **Cash Balance**: $500.00\n* **Number of Accounts**: 1\n* **Holdings**: AAPL (10 shares), MSFT (5 shares)\n* **Status**: success"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {},
+                "name": "schwab_build_user_profile"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -252,27 +252,85 @@ adk eval examples/google_adk_agent tests/evals/9_adv_broker_status_test.json --c
 
 Evaluations for Schwab-specific tools. These typically require live Schwab OAuth credentials and a running MCP server.
 
+> **Coverage gate**: `tests/unit/test_schwab_eval_coverage.py` enforces that every registered `schwab_*` MCP tool has an eval fixture here or an entry in `EVAL_OMISSION_ALLOWLIST`. Run `pytest tests/unit/test_schwab_eval_coverage.py` to verify coverage.
+
+> **Note on Schwab Evaluations**: All Schwab evaluations require live OAuth credentials. The `final_response` examples are illustrative placeholders only — update them to match real account output before running against a live Schwab account.
+
+#### Account Evals (`1_acc_schwab_*`)
+
 - `tests/evals/1_acc_schwab_account_numbers_test.json` — exercises `schwab_account_numbers`.
+- `tests/evals/1_acc_schwab_account_test.json` — multi-step: `schwab_account_numbers` then `schwab_account` to retrieve account details.
+- `tests/evals/1_acc_schwab_accounts_test.json` — exercises `schwab_accounts` to list all accounts with balances.
+- `tests/evals/1_acc_schwab_portfolio_test.json` — multi-step: `schwab_account_numbers` then `schwab_portfolio` to retrieve portfolio holdings.
+- `tests/evals/1_acc_schwab_account_balances_test.json` — multi-step: `schwab_account_numbers` then `schwab_account_balances`.
+- `tests/evals/1_acc_schwab_check_margin_status_test.json` — multi-step: `schwab_account_numbers` then `schwab_check_margin_status`.
+- `tests/evals/1_acc_schwab_get_margin_interest_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_margin_interest`.
+- `tests/evals/1_acc_schwab_get_user_preferences_test.json` — exercises `schwab_get_user_preferences`.
+- `tests/evals/1_acc_schwab_get_all_account_data_test.json` — exercises `schwab_get_all_account_data`.
+- `tests/evals/1_acc_schwab_get_build_holdings_test.json` — exercises `schwab_get_build_holdings`.
+- `tests/evals/1_acc_schwab_get_day_trades_test.json` — exercises `schwab_get_day_trades`.
+- `tests/evals/1_acc_schwab_get_aggregate_positions_test.json` — exercises `schwab_get_aggregate_positions`.
+
+#### Market Evals (`2_mkt_schwab_*`)
+
 - `tests/evals/2_mkt_schwab_quote_test.json` — exercises `schwab_quote`.
+- `tests/evals/2_mkt_schwab_quotes_test.json` — exercises `schwab_quotes` for multiple symbols.
 - `tests/evals/2_mkt_schwab_price_history_test.json` — exercises `schwab_price_history`.
 - `tests/evals/2_mkt_schwab_search_instruments_test.json` — exercises `schwab_search_instruments`.
+- `tests/evals/2_mkt_schwab_instrument_test.json` — exercises `schwab_instrument`.
+- `tests/evals/2_mkt_schwab_get_market_hours_test.json` — exercises `schwab_get_market_hours`.
+- `tests/evals/2_mkt_schwab_get_movers_test.json` — exercises `schwab_get_movers`.
+- `tests/evals/2_mkt_schwab_get_movers_sp500_test.json` — exercises `schwab_get_movers_sp500`.
+- `tests/evals/2_mkt_schwab_get_instrument_by_cusip_test.json` — exercises `schwab_get_instrument_by_cusip`.
+
+#### Order/Transaction Evals (`5_ord_schwab_*`)
+
+- `tests/evals/5_ord_schwab_orders_test.json` — multi-step: `schwab_account_numbers` then `schwab_orders`.
+- `tests/evals/5_ord_schwab_get_open_stock_orders_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_open_stock_orders`.
+- `tests/evals/5_ord_schwab_get_order_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_order`.
+- `tests/evals/5_ord_schwab_transactions_test.json` — multi-step: `schwab_account_numbers` then `schwab_transactions`.
+- `tests/evals/5_ord_schwab_transactions_by_date_test.json` — multi-step: `schwab_account_numbers` then `schwab_transactions_by_date`.
+- `tests/evals/5_ord_schwab_get_transaction_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_transaction`.
+
+#### Payment Evals (`7_pmt_schwab_*`)
+
+- `tests/evals/7_pmt_schwab_get_dividends_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_dividends`.
+- `tests/evals/7_pmt_schwab_get_dividends_by_symbol_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_dividends_by_symbol`.
+- `tests/evals/7_pmt_schwab_get_stock_loan_payments_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_stock_loan_payments`.
+- `tests/evals/7_pmt_schwab_get_interest_payments_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_interest_payments`.
+- `tests/evals/7_pmt_schwab_get_total_dividends_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_total_dividends`.
+
+#### Options Evals (`8_opt_schwab_*`)
+
 - `tests/evals/8_opt_schwab_option_chain_test.json` — exercises `schwab_option_chain`.
+- `tests/evals/8_opt_schwab_option_chain_by_expiration_test.json` — exercises `schwab_option_chain_by_expiration`.
 - `tests/evals/8_opt_schwab_option_expirations_test.json` — exercises `schwab_option_expirations`.
-- `tests/evals/5_ord_schwab_orders_test.json` — multi-step: `schwab_account_numbers` then `schwab_orders` to retrieve recent orders without requiring a raw account hash in the user message.
+- `tests/evals/8_opt_schwab_options_positions_test.json` — multi-step: `schwab_account_numbers` then `schwab_options_positions`.
+- `tests/evals/8_opt_schwab_option_orders_test.json` — multi-step: `schwab_account_numbers` then `schwab_option_orders`.
+- `tests/evals/8_opt_schwab_open_option_orders_test.json` — multi-step: `schwab_account_numbers` then `schwab_open_option_orders`.
+- `tests/evals/8_opt_schwab_get_all_option_positions_test.json` — exercises `schwab_get_all_option_positions`.
+- `tests/evals/8_opt_schwab_get_open_option_positions_test.json` — exercises `schwab_get_open_option_positions`.
+- `tests/evals/8_opt_schwab_find_tradable_options_test.json` — exercises `schwab_find_tradable_options`.
+- `tests/evals/8_opt_schwab_option_quote_test.json` — exercises `schwab_option_quote`.
 
-> **Note on Schwab Evaluations**: Most Schwab evaluations require live OAuth credentials.
->
-> The `final_response` examples in Schwab eval JSON files are illustrative placeholders only. Before running against a live Schwab account, update those expected values (account numbers, account hashes, quotes, and other account-specific fields) to match real output from your account, or ADK eval assertions will fail.
+#### Advanced/Profile Evals (`9_adv_schwab_*`)
 
-Run with:
+- `tests/evals/9_adv_schwab_build_user_profile_test.json` — exercises `schwab_build_user_profile`.
+
+#### Omitted Tools (no eval — see coverage gate for justification)
+
+The following `schwab_*` tools are intentionally excluded from ADK eval coverage. See `EVAL_OMISSION_ALLOWLIST` in `tests/unit/test_schwab_eval_coverage.py` for the documented rationale.
+
+- **Streaming** (`schwab_stream_*`): real-time WebSocket subscriptions; no stable request/response pattern for eval assertions.
+- **Trading mutations** (`schwab_buy_*`, `schwab_sell_*`, `schwab_cancel_*`, `schwab_order_*`, `schwab_option_buy_*`, `schwab_option_sell_*`, `schwab_place_order`, `schwab_replace_order`): require live credentials and execute real market orders or destructive cancellations; covered by integration journey tests.
+
+Run individual Schwab evals with:
 
 ```bash
 adk eval examples/google_adk_agent tests/evals/1_acc_schwab_account_numbers_test.json --config_file_path tests/evals/test_config.json
-SCHWAB_EVAL_FILE=<schwab-market-eval-json>
+# Replace the filename with any schwab eval listed above
+SCHWAB_EVAL_FILE=2_mkt_schwab_quote_test.json
 adk eval examples/google_adk_agent "tests/evals/${SCHWAB_EVAL_FILE}" --config_file_path tests/evals/test_config.json
-adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_chain_test.json --config_file_path tests/evals/test_config.json
-adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_expirations_test.json --config_file_path tests/evals/test_config.json
-adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
 ```
 
 ### 4. Watchlist Read-Only Evaluations (`3_wth_*`)

--- a/tests/unit/test_schwab_eval_coverage.py
+++ b/tests/unit/test_schwab_eval_coverage.py
@@ -1,0 +1,115 @@
+"""Regression test: every registered schwab_* MCP tool must have an ADK eval fixture
+or appear in the explicit omission list with justification.
+
+Run with: pytest tests/unit/test_schwab_eval_coverage.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+EVAL_DIR = Path(__file__).parent.parent / "evals"
+
+# Tools excluded from eval coverage with documented justification.
+# Streaming tools: real-time WebSocket subscriptions don't fit the ADK
+#   request/response eval model — there is no stable final_response to assert.
+# Trading mutation tools: require live credentials AND execute real market orders
+#   or destructive cancellations; covered by integration journey tests instead.
+EVAL_OMISSION_ALLOWLIST: frozenset[str] = frozenset(
+    [
+        # --- Streaming (real-time subscriptions, no request/response eval model) ---
+        "schwab_stream_account_activity",
+        "schwab_stream_level2",
+        "schwab_stream_option_quotes",
+        "schwab_stream_quotes",
+        # --- Trading mutations (execute real orders or destructive cancellations) ---
+        "schwab_buy_stock_market",
+        "schwab_sell_stock_market",
+        "schwab_buy_stock_limit",
+        "schwab_sell_stock_limit",
+        "schwab_place_order",
+        "schwab_cancel_order",
+        "schwab_cancel_all_stock_orders",
+        "schwab_cancel_all_option_orders",
+        "schwab_cancel_option_order",
+        "schwab_replace_order",
+        "schwab_order_sell_stop",
+        "schwab_order_buy_option_limit",
+        "schwab_order_sell_option_limit",
+        "schwab_order_option_credit_spread",
+        "schwab_order_option_debit_spread",
+        "schwab_option_buy_to_open",
+        "schwab_option_sell_to_close",
+    ]
+)
+
+
+def _collect_eval_tool_names() -> set[str]:
+    """Return all MCP tool names referenced inside tests/evals/*schwab*_test.json."""
+    covered: set[str] = set()
+    for path in EVAL_DIR.glob("*schwab*_test.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for case in data.get("eval_cases", []):
+            for turn in case.get("conversation", []):
+                for tool_use in turn.get("intermediate_data", {}).get("tool_uses", []):
+                    covered.add(tool_use["name"])
+    return covered
+
+
+def _collect_registered_schwab_tools() -> list[str]:
+    """Return all MCP tool names that start with 'schwab_' from the live server."""
+    from open_stocks_mcp.server.app import mcp
+
+    tools = asyncio.run(mcp.list_tools())
+    return sorted(t.name for t in tools if t.name.startswith("schwab_"))
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_every_schwab_tool_has_eval_or_omission_justification() -> None:
+    """Fail if a registered schwab_* tool has no eval fixture and no omission entry.
+
+    This test acts as a coverage gate: adding a new Schwab tool to the server
+    requires either adding a corresponding eval fixture in tests/evals/ or
+    adding the tool name to EVAL_OMISSION_ALLOWLIST with a comment explaining why.
+    """
+    eval_covered = _collect_eval_tool_names()
+    registered = _collect_registered_schwab_tools()
+
+    uncovered = [
+        name
+        for name in registered
+        if name not in eval_covered and name not in EVAL_OMISSION_ALLOWLIST
+    ]
+
+    assert uncovered == [], (
+        "The following registered schwab_* tools have no ADK eval fixture and are "
+        "not in EVAL_OMISSION_ALLOWLIST:\n"
+        + "\n".join(f"  - {name}" for name in uncovered)
+        + "\n\nFix by adding tests/evals/*schwab*_test.json fixtures that exercise "
+        "these tools, or add them to EVAL_OMISSION_ALLOWLIST in this file with a "
+        "comment justifying the omission."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_omission_allowlist_has_no_phantom_entries() -> None:
+    """Warn if an omission allowlist entry no longer corresponds to a registered tool.
+
+    Phantom entries indicate a tool was renamed or removed without updating the list.
+    """
+    registered = set(_collect_registered_schwab_tools())
+    phantoms = [name for name in EVAL_OMISSION_ALLOWLIST if name not in registered]
+
+    assert phantoms == [], (
+        "EVAL_OMISSION_ALLOWLIST contains entries that are no longer registered "
+        "schwab_* MCP tools:\n"
+        + "\n".join(f"  - {name}" for name in sorted(phantoms))
+        + "\n\nRemove stale entries from EVAL_OMISSION_ALLOWLIST in "
+        "tests/unit/test_schwab_eval_coverage.py."
+    )


### PR DESCRIPTION
Closes #962

## Changes

- **36 new ADK eval fixtures** covering all read-only `schwab_*` MCP tools organized into 6 categories:
  - `1_acc_schwab_*` — 11 account evals (account, accounts, portfolio, balances, margin, preferences, aggregate positions, holdings, day trades)
  - `2_mkt_schwab_*` — 6 market evals (quotes, instrument, market hours, movers, movers SP500, instrument by CUSIP)
  - `5_ord_schwab_*` — 5 order/transaction evals (open orders, get order, transactions, transactions by date, get transaction)
  - `7_pmt_schwab_*` — 5 payment evals (dividends, dividends by symbol, stock loan payments, interest payments, total dividends)
  - `8_opt_schwab_*` — 8 options evals (chain by expiration, positions, orders, open orders, all positions, open positions, find tradable, option quote)
  - `9_adv_schwab_*` — 1 advanced eval (build user profile)
- **Regression test** `tests/unit/test_schwab_eval_coverage.py` with two checks:
  - Fails if a registered `schwab_*` MCP tool has no eval fixture and no omission entry
  - Fails if an omission allowlist entry no longer corresponds to a registered tool
- **Updated `tests/evals/ADK-testing-evals.md`** with full per-category Schwab eval manifest, coverage gate note, and explicit omission list with rationale
- **Coverage summary**: 43 of 64 `schwab_*` tools now have eval fixtures; 21 explicitly omitted (4 streaming tools — no request/response model; 17 trading mutations — require live credentials and execute real orders)

## Test plan

- `pytest tests/unit/test_schwab_eval_coverage.py -v` — both coverage gate tests pass
- `pytest tests/unit/ -q` — all unit tests pass (exit code 0)
- Authoring does not require live Schwab credentials; eval execution requires `SCHWAB_API_KEY` etc. per `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)