### PR TITLE
feat: add Schwab tool-to-eval coverage matrix

### DIFF
--- a/scripts/schwab_coverage.py
+++ b/scripts/schwab_coverage.py
@@ -1,0 +1,78 @@
+"""Compute Schwab ADK eval coverage matrix.
+
+Usage:
+    uv run python scripts/schwab_coverage.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+EVALS_DIR = Path("tests/evals")
+
+
+def tools_from_eval_file(path: Path) -> set[str]:
+    """Return all tool names referenced in an ADK eval JSON file."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for case in data.get("eval_cases", []):
+        for conv in case.get("conversation", []):
+            for use in conv.get("intermediate_data", {}).get("tool_uses", []):
+                name = use.get("name", "")
+                if name:
+                    names.add(name)
+    return names
+
+
+def build_coverage(evals_dir: Path = EVALS_DIR) -> dict[str, list[str]]:
+    """Map each schwab_* tool to the sorted list of eval filenames covering it.
+
+    Only scans files matching ``*schwab*.json`` in ``evals_dir``.
+    """
+    tool_to_files: dict[str, list[str]] = {}
+    for path in sorted(evals_dir.glob("*schwab*.json")):
+        for tool in tools_from_eval_file(path):
+            tool_to_files.setdefault(tool, [])
+            tool_to_files[tool].append(path.name)
+    for files in tool_to_files.values():
+        files.sort()
+    return tool_to_files
+
+
+async def _get_schwab_tool_names() -> list[str]:
+    from open_stocks_mcp.server.app import mcp
+
+    tools = await mcp.list_tools()
+    return sorted(t.name for t in tools if t.name.startswith("schwab_"))
+
+
+def render_coverage_markdown(
+    schwab_tools: list[str],
+    tool_to_files: dict[str, list[str]],
+) -> str:
+    """Render a markdown checklist with one row per schwab_* tool."""
+    lines: list[str] = []
+    covered = 0
+    for tool in schwab_tools:
+        files = tool_to_files.get(tool, [])
+        if files:
+            covered += 1
+            file_refs = ", ".join(f"`{f}`" for f in files)
+            lines.append(f"- [x] `{tool}` — {file_refs}")
+        else:
+            lines.append(f"- [ ] `{tool}` — *no eval*")
+    total = len(schwab_tools)
+    header = f"**Coverage: {covered}/{total} schwab_* tools have ADK eval fixtures**\n\n"
+    return header + "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    tool_to_files = build_coverage()
+    schwab_tools = asyncio.run(_get_schwab_tool_names())
+    print(render_coverage_markdown(schwab_tools, tool_to_files), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -275,6 +275,79 @@ adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_expirations_t
 adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
 ```
 
+#### Schwab Tool-to-Eval Coverage Matrix
+
+The checklist below maps every registered `schwab_*` MCP tool to the eval fixture(s) that exercise it.
+Regenerate with `uv run python scripts/schwab_coverage.py`.
+Check a row when a fixture for that tool is authored and merged.
+
+**Coverage: 7/64 schwab_* tools have ADK eval fixtures**
+
+- [x] `schwab_account_numbers` — `1_acc_schwab_account_numbers_test.json`, `5_ord_schwab_orders_test.json`
+- [ ] `schwab_account` — *no eval*
+- [ ] `schwab_account_balances` — *no eval*
+- [ ] `schwab_accounts` — *no eval*
+- [ ] `schwab_build_user_profile` — *no eval*
+- [ ] `schwab_buy_stock_limit` — *no eval*
+- [ ] `schwab_buy_stock_market` — *no eval*
+- [ ] `schwab_cancel_all_option_orders` — *no eval*
+- [ ] `schwab_cancel_all_stock_orders` — *no eval*
+- [ ] `schwab_cancel_option_order` — *no eval*
+- [ ] `schwab_cancel_order` — *no eval*
+- [ ] `schwab_check_margin_status` — *no eval*
+- [ ] `schwab_find_tradable_options` — *no eval*
+- [ ] `schwab_get_aggregate_positions` — *no eval*
+- [ ] `schwab_get_all_account_data` — *no eval*
+- [ ] `schwab_get_all_option_positions` — *no eval*
+- [ ] `schwab_get_build_holdings` — *no eval*
+- [ ] `schwab_get_day_trades` — *no eval*
+- [ ] `schwab_get_dividends` — *no eval*
+- [ ] `schwab_get_dividends_by_symbol` — *no eval*
+- [ ] `schwab_get_instrument_by_cusip` — *no eval*
+- [ ] `schwab_get_interest_payments` — *no eval*
+- [ ] `schwab_get_margin_interest` — *no eval*
+- [ ] `schwab_get_market_hours` — *no eval*
+- [ ] `schwab_get_movers` — *no eval*
+- [ ] `schwab_get_movers_sp500` — *no eval*
+- [ ] `schwab_get_open_option_positions` — *no eval*
+- [ ] `schwab_get_open_stock_orders` — *no eval*
+- [ ] `schwab_get_order` — *no eval*
+- [ ] `schwab_get_stock_loan_payments` — *no eval*
+- [ ] `schwab_get_total_dividends` — *no eval*
+- [ ] `schwab_get_transaction` — *no eval*
+- [ ] `schwab_get_user_preferences` — *no eval*
+- [ ] `schwab_instrument` — *no eval*
+- [ ] `schwab_open_option_orders` — *no eval*
+- [ ] `schwab_option_buy_to_open` — *no eval*
+- [x] `schwab_option_chain` — `8_opt_schwab_option_chain_test.json`
+- [ ] `schwab_option_chain_by_expiration` — *no eval*
+- [x] `schwab_option_expirations` — `8_opt_schwab_option_expirations_test.json`
+- [ ] `schwab_option_orders` — *no eval*
+- [ ] `schwab_option_quote` — *no eval*
+- [ ] `schwab_option_sell_to_close` — *no eval*
+- [ ] `schwab_options_positions` — *no eval*
+- [ ] `schwab_order_buy_option_limit` — *no eval*
+- [ ] `schwab_order_option_credit_spread` — *no eval*
+- [ ] `schwab_order_option_debit_spread` — *no eval*
+- [ ] `schwab_order_sell_option_limit` — *no eval*
+- [ ] `schwab_order_sell_stop` — *no eval*
+- [x] `schwab_orders` — `5_ord_schwab_orders_test.json`
+- [ ] `schwab_place_order` — *no eval*
+- [ ] `schwab_portfolio` — *no eval*
+- [x] `schwab_price_history` — `2_mkt_schwab_price_history_test.json`
+- [x] `schwab_quote` — `2_mkt_schwab_quote_test.json`
+- [ ] `schwab_quotes` — *no eval*
+- [ ] `schwab_replace_order` — *no eval*
+- [x] `schwab_search_instruments` — `2_mkt_schwab_search_instruments_test.json`
+- [ ] `schwab_sell_stock_limit` — *no eval*
+- [ ] `schwab_sell_stock_market` — *no eval*
+- [ ] `schwab_stream_account_activity` — *no eval*
+- [ ] `schwab_stream_level2` — *no eval*
+- [ ] `schwab_stream_option_quotes` — *no eval*
+- [ ] `schwab_stream_quotes` — *no eval*
+- [ ] `schwab_transactions` — *no eval*
+- [ ] `schwab_transactions_by_date` — *no eval*
+
 ### 4. Watchlist Read-Only Evaluations (`3_wth_*`)
 
 Read-only evals that exercise the three Robinhood watchlist query tools. These do not invoke `add_to_watchlist`, `remove_from_watchlist`, or any order-placement or account-mutation tool.

--- a/tests/unit/test_api_docs_generator.py
+++ b/tests/unit/test_api_docs_generator.py
@@ -1,9 +1,10 @@
+import json
 import re
 from pathlib import Path
 
 import pytest
 
-from scripts import generate_api_docs
+from scripts import generate_api_docs, schwab_coverage
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -54,3 +55,86 @@ def test_committed_api_tools_doc_matches_live_registry(tmp_path):
         "unified_watchlists",
     ):
         assert f"### {tool_name}" in committed
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_tools_from_eval_file(tmp_path):
+    eval_file = tmp_path / "test_schwab_eval.json"
+    eval_file.write_text(
+        json.dumps({
+            "eval_cases": [
+                {
+                    "conversation": [
+                        {
+                            "intermediate_data": {
+                                "tool_uses": [
+                                    {"name": "schwab_account_numbers"},
+                                    {"name": "schwab_quote"},
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        })
+    )
+
+    result = schwab_coverage.tools_from_eval_file(eval_file)
+
+    assert result == {"schwab_account_numbers", "schwab_quote"}
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_build_coverage_maps_tool_to_filename(tmp_path):
+    eval_file = tmp_path / "test_schwab_account_test.json"
+    eval_file.write_text(
+        json.dumps({
+            "eval_cases": [
+                {
+                    "conversation": [
+                        {
+                            "intermediate_data": {
+                                "tool_uses": [{"name": "schwab_account_numbers"}]
+                            }
+                        }
+                    ]
+                }
+            ]
+        })
+    )
+
+    coverage = schwab_coverage.build_coverage(tmp_path)
+
+    assert "schwab_account_numbers" in coverage
+    assert eval_file.name in coverage["schwab_account_numbers"]
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_render_coverage_markdown_checked_and_unchecked():
+    tools = ["schwab_a", "schwab_b", "schwab_c"]
+    tool_to_files = {"schwab_a": ["file1.json"]}
+
+    output = schwab_coverage.render_coverage_markdown(tools, tool_to_files)
+
+    assert "- [x] `schwab_a`" in output
+    assert "- [ ] `schwab_b`" in output
+    assert "- [ ] `schwab_c`" in output
+    assert "1/3" in output
+
+
+@pytest.mark.unit
+@pytest.mark.journey_system
+def test_build_coverage_live_evals_dir():
+    """Verify the real evals dir returns known covered tools."""
+    coverage = schwab_coverage.build_coverage()
+
+    assert "schwab_account_numbers" in coverage
+    assert "schwab_quote" in coverage
+    assert "schwab_price_history" in coverage
+    assert "schwab_search_instruments" in coverage
+    assert "schwab_option_chain" in coverage
+    assert "schwab_option_expirations" in coverage
+    assert "schwab_orders" in coverage


### PR DESCRIPTION
Closes #963

## Changes
- Add `scripts/schwab_coverage.py` — helper that scans registered `schwab_*` MCP tools and `tests/evals/*schwab*.json` fixtures, then renders a markdown checklist
- Add coverage matrix subsection to `tests/evals/ADK-testing-evals.md` under the existing Schwab evals section (7/64 tools currently covered)
- Add 4 unit tests to `tests/unit/test_api_docs_generator.py` covering `tools_from_eval_file`, `build_coverage`, `render_coverage_markdown`, and the live evals directory

## Test plan
- `uv run pytest tests/unit/test_api_docs_generator.py -q` → 5 passed
- `uv run ruff check scripts/schwab_coverage.py tests/unit/test_api_docs_generator.py` → all checks passed
- `uv run mypy scripts/schwab_coverage.py --ignore-missing-imports` → no issues
- `uv run python scripts/schwab_coverage.py` → generates the matrix (64 tools, 7 covered)