### PR TITLE
test: add schwab order/options eval fixtures

### DIFF
--- a/tests/evals/5_ord_schwab_buy_stock_limit_test.json
+++ b/tests/evals/5_ord_schwab_buy_stock_limit_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_buy_stock_limit_test_set",
+  "name": "Schwab Buy Stock Limit Test",
+  "description": "Test case for placing a Schwab limit buy order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_buy_stock_limit_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-buy-stock-limit-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Place a Schwab limit buy for 1 share of AAPL at 150.00."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab limit buy order for AAPL at 150.00. Schwab authentication and account trading permissions are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","symbol":"AAPL","quantity":1,"price":150.0},
+                "name": "schwab_buy_stock_limit"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_buy_stock_market_test.json
+++ b/tests/evals/5_ord_schwab_buy_stock_market_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_buy_stock_market_test_set",
+  "name": "Schwab Buy Stock Market Test",
+  "description": "Test case for placing a Schwab market buy order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_buy_stock_market_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-buy-stock-market-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Buy 1 share of AAPL in my Schwab account at market."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab market buy order for 1 share of AAPL. Schwab authentication and an eligible funded account are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","symbol":"AAPL","quantity":1},
+                "name": "schwab_buy_stock_market"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_cancel_all_option_orders_test.json
+++ b/tests/evals/5_ord_schwab_cancel_all_option_orders_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_cancel_all_option_orders_test_set",
+  "name": "Schwab Cancel All Option Orders Test",
+  "description": "Test case for canceling all open Schwab option orders through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_cancel_all_option_orders_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-cancel-all-option-orders-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Cancel all my open Schwab option orders."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to cancel all open Schwab option orders. Schwab authentication and existing open option orders are required for cancellation activity."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","max_results":50},
+                "name": "schwab_cancel_all_option_orders"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_cancel_all_stock_orders_test.json
+++ b/tests/evals/5_ord_schwab_cancel_all_stock_orders_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_cancel_all_stock_orders_test_set",
+  "name": "Schwab Cancel All Stock Orders Test",
+  "description": "Test case for canceling all open Schwab stock orders through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_cancel_all_stock_orders_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-cancel-all-stock-orders-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Cancel all my open Schwab stock orders."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to cancel all open Schwab stock orders. Schwab authentication and existing open equity orders are required for cancellation activity."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","max_results":50},
+                "name": "schwab_cancel_all_stock_orders"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_cancel_option_order_test.json
+++ b/tests/evals/5_ord_schwab_cancel_option_order_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_cancel_option_order_test_set",
+  "name": "Schwab Cancel Option Order Test",
+  "description": "Test case for canceling a Schwab option order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_cancel_option_order_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-cancel-option-order-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Cancel Schwab option order 987654321."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to cancel Schwab option order 987654321. Schwab authentication and a cancellable option order are required for success."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","order_id":"987654321"},
+                "name": "schwab_cancel_option_order"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_cancel_order_test.json
+++ b/tests/evals/5_ord_schwab_cancel_order_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_cancel_order_test_set",
+  "name": "Schwab Cancel Order Test",
+  "description": "Test case for canceling a Schwab order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_cancel_order_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-cancel-order-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Cancel Schwab order 123456789 in my account."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to cancel Schwab order 123456789. Schwab authentication and a cancellable working order are required for success."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","order_id":"123456789"},
+                "name": "schwab_cancel_order"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_order_buy_option_limit_test.json
+++ b/tests/evals/5_ord_schwab_order_buy_option_limit_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_order_buy_option_limit_test_set",
+  "name": "Schwab Buy Option Limit Order Test",
+  "description": "Test case for placing a Schwab option buy limit order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_order_buy_option_limit_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-order-buy-option-limit-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Place a Schwab limit order to buy 1 AAPL call contract AAPL  251219C00150000 at 5.50."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab buy-to-open option limit order. Schwab authentication, options approval, and a valid OCC option symbol are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","option_symbol":"AAPL  251219C00150000","quantity":1,"price":"5.50"},
+                "name": "schwab_order_buy_option_limit"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_order_option_credit_spread_test.json
+++ b/tests/evals/5_ord_schwab_order_option_credit_spread_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_order_option_credit_spread_test_set",
+  "name": "Schwab Option Credit Spread Order Test",
+  "description": "Test case for placing a Schwab option credit spread order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_order_option_credit_spread_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-order-option-credit-spread-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Place a Schwab CALL credit spread using short AAPL  251219C00190000 and long AAPL  251219C00200000 for 1 contract at 2.00 credit."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab option credit spread order. Schwab authentication, options approval, and valid option legs are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","option_type":"CALL","short_symbol":"AAPL  251219C00190000","long_symbol":"AAPL  251219C00200000","quantity":1,"net_credit":"2.00"},
+                "name": "schwab_order_option_credit_spread"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_order_option_debit_spread_test.json
+++ b/tests/evals/5_ord_schwab_order_option_debit_spread_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_order_option_debit_spread_test_set",
+  "name": "Schwab Option Debit Spread Order Test",
+  "description": "Test case for placing a Schwab option debit spread order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_order_option_debit_spread_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-order-option-debit-spread-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Place a Schwab CALL debit spread using long AAPL  251219C00150000 and short AAPL  251219C00160000 for 1 contract at 3.00 debit."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab option debit spread order. Schwab authentication, options approval, and valid option legs are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","option_type":"CALL","long_symbol":"AAPL  251219C00150000","short_symbol":"AAPL  251219C00160000","quantity":1,"net_debit":"3.00"},
+                "name": "schwab_order_option_debit_spread"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_order_sell_option_limit_test.json
+++ b/tests/evals/5_ord_schwab_order_sell_option_limit_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_order_sell_option_limit_test_set",
+  "name": "Schwab Sell Option Limit Order Test",
+  "description": "Test case for placing a Schwab option sell limit order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_order_sell_option_limit_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-order-sell-option-limit-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Place a Schwab limit order to sell 1 AAPL call contract AAPL  251219C00150000 at 4.00."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab sell-to-close option limit order. Schwab authentication, options approval, and a matching held position are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","option_symbol":"AAPL  251219C00150000","quantity":1,"price":"4.00"},
+                "name": "schwab_order_sell_option_limit"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_order_sell_stop_test.json
+++ b/tests/evals/5_ord_schwab_order_sell_stop_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_order_sell_stop_test_set",
+  "name": "Schwab Sell Stop Order Test",
+  "description": "Test case for placing a Schwab sell stop order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_order_sell_stop_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-order-sell-stop-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Place a Schwab stop sell for 1 share of AAPL at stop 148.00."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab stop sell order for AAPL with stop price 148.00. Schwab authentication and an eligible position are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","symbol":"AAPL","quantity":1,"stop_price":"148.00"},
+                "name": "schwab_order_sell_stop"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_place_order_test.json
+++ b/tests/evals/5_ord_schwab_place_order_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_place_order_test_set",
+  "name": "Schwab Place Order Test",
+  "description": "Test case for submitting a raw Schwab order spec through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_place_order_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-place-order-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Submit a Schwab order spec to buy 1 share of AAPL at market."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to submit the provided Schwab order specification. Schwab authentication and a valid account hash are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","order_spec":{"orderType":"MARKET","session":"NORMAL","duration":"DAY","orderStrategyType":"SINGLE","orderLegCollection":[{"instruction":"BUY","quantity":1,"instrument":{"assetType":"EQUITY","symbol":"AAPL"}}]}},
+                "name": "schwab_place_order"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_replace_order_test.json
+++ b/tests/evals/5_ord_schwab_replace_order_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_replace_order_test_set",
+  "name": "Schwab Replace Order Test",
+  "description": "Test case for replacing a Schwab order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_replace_order_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-replace-order-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Replace Schwab order 123456789 with a limit buy for 1 share of AAPL at 149.00."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to replace Schwab order 123456789 with the provided updated order specification. Schwab authentication and a replaceable order are required for success."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","order_id":"123456789","order_spec":{"orderType":"LIMIT","session":"NORMAL","duration":"DAY","price":"149.00","orderStrategyType":"SINGLE","orderLegCollection":[{"instruction":"BUY","quantity":1,"instrument":{"assetType":"EQUITY","symbol":"AAPL"}}]}},
+                "name": "schwab_replace_order"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_sell_stock_limit_test.json
+++ b/tests/evals/5_ord_schwab_sell_stock_limit_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_sell_stock_limit_test_set",
+  "name": "Schwab Sell Stock Limit Test",
+  "description": "Test case for placing a Schwab limit sell order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_sell_stock_limit_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-sell-stock-limit-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Place a Schwab limit sell for 1 share of AAPL at 250.00."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab limit sell order for AAPL at 250.00. Schwab authentication and available holdings are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","symbol":"AAPL","quantity":1,"price":250.0},
+                "name": "schwab_sell_stock_limit"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/5_ord_schwab_sell_stock_market_test.json
+++ b/tests/evals/5_ord_schwab_sell_stock_market_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_sell_stock_market_test_set",
+  "name": "Schwab Sell Stock Market Test",
+  "description": "Test case for placing a Schwab market sell order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_sell_stock_market_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-sell-stock-market-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Sell 1 share of AAPL in my Schwab account at market."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab market sell order for 1 share of AAPL. Schwab authentication and available position quantity are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","symbol":"AAPL","quantity":1},
+                "name": "schwab_sell_stock_market"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_option_buy_to_open_test.json
+++ b/tests/evals/8_opt_schwab_option_buy_to_open_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_option_buy_to_open_test_set",
+  "name": "Schwab Option Buy To Open Test",
+  "description": "Test case for placing a Schwab option buy-to-open order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_option_buy_to_open_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-option-buy-to-open-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Buy to open 1 AAPL call at strike 150 expiring 2026-12-18 in Schwab."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab buy-to-open option order for AAPL. Schwab authentication, options approval, and valid contract parameters are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","symbol":"AAPL","quantity":1,"option_type":"CALL","strike":150.0,"expiration":"2026-12-18"},
+                "name": "schwab_option_buy_to_open"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/8_opt_schwab_option_chain_by_expiration_test.json
+++ b/tests/evals/8_opt_schwab_option_chain_by_expiration_test.json
@@ -30,7 +30,8 @@
                 "id": "adk-tool-use-id",
                 "args": {
                   "symbol": "AAPL",
-                  "expiration_date": "2025-01-17"
+                  "from_date": "2025-01-17",
+                  "to_date": "2025-01-17"
                 },
                 "name": "schwab_option_chain_by_expiration"
               }

--- a/tests/evals/8_opt_schwab_option_sell_to_close_test.json
+++ b/tests/evals/8_opt_schwab_option_sell_to_close_test.json
@@ -1,0 +1,46 @@
+{
+  "eval_set_id": "schwab_option_sell_to_close_test_set",
+  "name": "Schwab Option Sell To Close Test",
+  "description": "Test case for placing a Schwab option sell-to-close order through agent interaction",
+  "eval_cases": [
+    {
+      "eval_id": "schwab_option_sell_to_close_test",
+      "conversation": [
+        {
+          "invocation_id": "schwab-option-sell-to-close-001",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Sell to close 1 AAPL call at strike 150 expiring 2026-12-18 in Schwab."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "I attempted to place a Schwab sell-to-close option order for AAPL. Schwab authentication, options approval, and an existing position are required for live execution."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": "adk-tool-use-id",
+                "args": {"account_hash":"resolved-account-hash","symbol":"AAPL","quantity":1,"option_type":"CALL","strike":150.0,"expiration":"2026-12-18"},
+                "name": "schwab_option_sell_to_close"
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "stock_trader_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -291,6 +291,21 @@ Evaluations for Schwab-specific tools. These typically require live Schwab OAuth
 - `tests/evals/5_ord_schwab_transactions_test.json` — multi-step: `schwab_account_numbers` then `schwab_transactions`.
 - `tests/evals/5_ord_schwab_transactions_by_date_test.json` — multi-step: `schwab_account_numbers` then `schwab_transactions_by_date`.
 - `tests/evals/5_ord_schwab_get_transaction_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_transaction`.
+- `tests/evals/5_ord_schwab_buy_stock_market_test.json` — exercises `schwab_buy_stock_market`.
+- `tests/evals/5_ord_schwab_sell_stock_market_test.json` — exercises `schwab_sell_stock_market`.
+- `tests/evals/5_ord_schwab_buy_stock_limit_test.json` — exercises `schwab_buy_stock_limit`.
+- `tests/evals/5_ord_schwab_sell_stock_limit_test.json` — exercises `schwab_sell_stock_limit`.
+- `tests/evals/5_ord_schwab_place_order_test.json` — exercises `schwab_place_order`.
+- `tests/evals/5_ord_schwab_cancel_order_test.json` — exercises `schwab_cancel_order`.
+- `tests/evals/5_ord_schwab_order_sell_stop_test.json` — exercises `schwab_order_sell_stop`.
+- `tests/evals/5_ord_schwab_cancel_all_stock_orders_test.json` — exercises `schwab_cancel_all_stock_orders`.
+- `tests/evals/5_ord_schwab_order_buy_option_limit_test.json` — exercises `schwab_order_buy_option_limit`.
+- `tests/evals/5_ord_schwab_order_sell_option_limit_test.json` — exercises `schwab_order_sell_option_limit`.
+- `tests/evals/5_ord_schwab_cancel_option_order_test.json` — exercises `schwab_cancel_option_order`.
+- `tests/evals/5_ord_schwab_cancel_all_option_orders_test.json` — exercises `schwab_cancel_all_option_orders`.
+- `tests/evals/5_ord_schwab_order_option_credit_spread_test.json` — exercises `schwab_order_option_credit_spread`.
+- `tests/evals/5_ord_schwab_order_option_debit_spread_test.json` — exercises `schwab_order_option_debit_spread`.
+- `tests/evals/5_ord_schwab_replace_order_test.json` — exercises `schwab_replace_order`.
 
 #### Payment Evals (`7_pmt_schwab_*`)
 
@@ -312,6 +327,8 @@ Evaluations for Schwab-specific tools. These typically require live Schwab OAuth
 - `tests/evals/8_opt_schwab_get_open_option_positions_test.json` — exercises `schwab_get_open_option_positions`.
 - `tests/evals/8_opt_schwab_find_tradable_options_test.json` — exercises `schwab_find_tradable_options`.
 - `tests/evals/8_opt_schwab_option_quote_test.json` — exercises `schwab_option_quote`.
+- `tests/evals/8_opt_schwab_option_buy_to_open_test.json` — exercises `schwab_option_buy_to_open`.
+- `tests/evals/8_opt_schwab_option_sell_to_close_test.json` — exercises `schwab_option_sell_to_close`.
 
 #### Advanced/Profile Evals (`9_adv_schwab_*`)
 
@@ -339,21 +356,21 @@ The checklist below maps every registered `schwab_*` MCP tool to the eval fixtur
 Regenerate with `uv run python scripts/schwab_coverage.py`.
 Check a row when a fixture for that tool is authored and merged.
 
-**Coverage: 7/64 schwab_* tools have ADK eval fixtures**
+**Coverage: 32/64 schwab_* tools have ADK eval fixtures**
 
 - [x] `schwab_account_numbers` — `1_acc_schwab_account_numbers_test.json`, `5_ord_schwab_orders_test.json`
 - [ ] `schwab_account` — *no eval*
 - [ ] `schwab_account_balances` — *no eval*
 - [ ] `schwab_accounts` — *no eval*
 - [ ] `schwab_build_user_profile` — *no eval*
-- [ ] `schwab_buy_stock_limit` — *no eval*
-- [ ] `schwab_buy_stock_market` — *no eval*
-- [ ] `schwab_cancel_all_option_orders` — *no eval*
-- [ ] `schwab_cancel_all_stock_orders` — *no eval*
-- [ ] `schwab_cancel_option_order` — *no eval*
-- [ ] `schwab_cancel_order` — *no eval*
+- [x] `schwab_buy_stock_limit` — `5_ord_schwab_buy_stock_limit_test.json`
+- [x] `schwab_buy_stock_market` — `5_ord_schwab_buy_stock_market_test.json`
+- [x] `schwab_cancel_all_option_orders` — `5_ord_schwab_cancel_all_option_orders_test.json`
+- [x] `schwab_cancel_all_stock_orders` — `5_ord_schwab_cancel_all_stock_orders_test.json`
+- [x] `schwab_cancel_option_order` — `5_ord_schwab_cancel_option_order_test.json`
+- [x] `schwab_cancel_order` — `5_ord_schwab_cancel_order_test.json`
 - [ ] `schwab_check_margin_status` — *no eval*
-- [ ] `schwab_find_tradable_options` — *no eval*
+- [x] `schwab_find_tradable_options` — `8_opt_schwab_find_tradable_options_test.json`
 - [ ] `schwab_get_aggregate_positions` — *no eval*
 - [ ] `schwab_get_all_account_data` — *no eval*
 - [ ] `schwab_get_all_option_positions` — *no eval*
@@ -368,37 +385,37 @@ Check a row when a fixture for that tool is authored and merged.
 - [ ] `schwab_get_movers` — *no eval*
 - [ ] `schwab_get_movers_sp500` — *no eval*
 - [ ] `schwab_get_open_option_positions` — *no eval*
-- [ ] `schwab_get_open_stock_orders` — *no eval*
-- [ ] `schwab_get_order` — *no eval*
+- [x] `schwab_get_open_stock_orders` — `5_ord_schwab_get_open_stock_orders_test.json`
+- [x] `schwab_get_order` — `5_ord_schwab_get_order_test.json`
 - [ ] `schwab_get_stock_loan_payments` — *no eval*
 - [ ] `schwab_get_total_dividends` — *no eval*
 - [ ] `schwab_get_transaction` — *no eval*
 - [ ] `schwab_get_user_preferences` — *no eval*
 - [ ] `schwab_instrument` — *no eval*
-- [ ] `schwab_open_option_orders` — *no eval*
-- [ ] `schwab_option_buy_to_open` — *no eval*
+- [x] `schwab_open_option_orders` — `8_opt_schwab_open_option_orders_test.json`
+- [x] `schwab_option_buy_to_open` — `8_opt_schwab_option_buy_to_open_test.json`
 - [x] `schwab_option_chain` — `8_opt_schwab_option_chain_test.json`
-- [ ] `schwab_option_chain_by_expiration` — *no eval*
+- [x] `schwab_option_chain_by_expiration` — `8_opt_schwab_option_chain_by_expiration_test.json`
 - [x] `schwab_option_expirations` — `8_opt_schwab_option_expirations_test.json`
-- [ ] `schwab_option_orders` — *no eval*
-- [ ] `schwab_option_quote` — *no eval*
-- [ ] `schwab_option_sell_to_close` — *no eval*
-- [ ] `schwab_options_positions` — *no eval*
-- [ ] `schwab_order_buy_option_limit` — *no eval*
-- [ ] `schwab_order_option_credit_spread` — *no eval*
-- [ ] `schwab_order_option_debit_spread` — *no eval*
-- [ ] `schwab_order_sell_option_limit` — *no eval*
-- [ ] `schwab_order_sell_stop` — *no eval*
+- [x] `schwab_option_orders` — `8_opt_schwab_option_orders_test.json`
+- [x] `schwab_option_quote` — `8_opt_schwab_option_quote_test.json`
+- [x] `schwab_option_sell_to_close` — `8_opt_schwab_option_sell_to_close_test.json`
+- [x] `schwab_options_positions` — `8_opt_schwab_options_positions_test.json`
+- [x] `schwab_order_buy_option_limit` — `5_ord_schwab_order_buy_option_limit_test.json`
+- [x] `schwab_order_option_credit_spread` — `5_ord_schwab_order_option_credit_spread_test.json`
+- [x] `schwab_order_option_debit_spread` — `5_ord_schwab_order_option_debit_spread_test.json`
+- [x] `schwab_order_sell_option_limit` — `5_ord_schwab_order_sell_option_limit_test.json`
+- [x] `schwab_order_sell_stop` — `5_ord_schwab_order_sell_stop_test.json`
 - [x] `schwab_orders` — `5_ord_schwab_orders_test.json`
-- [ ] `schwab_place_order` — *no eval*
+- [x] `schwab_place_order` — `5_ord_schwab_place_order_test.json`
 - [ ] `schwab_portfolio` — *no eval*
 - [x] `schwab_price_history` — `2_mkt_schwab_price_history_test.json`
 - [x] `schwab_quote` — `2_mkt_schwab_quote_test.json`
 - [ ] `schwab_quotes` — *no eval*
-- [ ] `schwab_replace_order` — *no eval*
+- [x] `schwab_replace_order` — `5_ord_schwab_replace_order_test.json`
 - [x] `schwab_search_instruments` — `2_mkt_schwab_search_instruments_test.json`
-- [ ] `schwab_sell_stock_limit` — *no eval*
-- [ ] `schwab_sell_stock_market` — *no eval*
+- [x] `schwab_sell_stock_limit` — `5_ord_schwab_sell_stock_limit_test.json`
+- [x] `schwab_sell_stock_market` — `5_ord_schwab_sell_stock_market_test.json`
 - [ ] `schwab_stream_account_activity` — *no eval*
 - [ ] `schwab_stream_level2` — *no eval*
 - [ ] `schwab_stream_option_quotes` — *no eval*


### PR DESCRIPTION
Closes #965

## Changes
- add 17 Schwab order/trading ADK eval fixtures under `tests/evals/5_ord_*`
- add 8 Schwab options-execution ADK eval fixtures under `tests/evals/8_opt_*`
- update `tests/evals/ADK-testing-evals.md` Schwab manifest entries and tool-to-eval checklist mappings
- update Schwab coverage summary from 7/64 to 32/64 tools covered

## Test plan
- jq empty tests/evals/5_ord_schwab_*_test.json tests/evals/8_opt_schwab_*_test.json
- rg -n "schwab" tests/evals/ADK-testing-evals.md
- uv run pytest tests/unit/test_api_docs_generator.py -q