### PR TITLE
fix: wire journey_advanced_data and journey_market_intelligence markers

### DIFF
--- a/tests/unit/test_market_research_tools.py
+++ b/tests/unit/test_market_research_tools.py
@@ -20,10 +20,12 @@ class TestTopMoversSP500:
     """Test top S&P 500 movers functionality."""
 
     @pytest.mark.journey_research
+    @pytest.mark.journey_market_intelligence
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.movers.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.movers.get_session_manager")
     @pytest.mark.journey_research
+    @pytest.mark.journey_market_intelligence
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_top_movers_sp500_up_success(
@@ -71,10 +73,12 @@ class TestTopMoversSP500:
         assert result["result"]["status"] == "success"
 
     @pytest.mark.journey_research
+    @pytest.mark.journey_market_intelligence
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.movers.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.movers.get_session_manager")
     @pytest.mark.journey_research
+    @pytest.mark.journey_market_intelligence
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_top_movers_sp500_down_success(
@@ -637,6 +641,7 @@ class TestStockLevel2Data:
     @patch("open_stocks_mcp.tools.market.level2.execute_with_retry")
     @patch("open_stocks_mcp.tools.market.level2.get_session_manager")
     @pytest.mark.journey_research
+    @pytest.mark.journey_advanced_data
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_stock_level2_data_success(

--- a/tests/unit/test_market_tools.py
+++ b/tests/unit/test_market_tools.py
@@ -16,6 +16,7 @@ class TestMarketTools:
     """Test market data tools with mocked responses."""
 
     @pytest.mark.journey_market_data
+    @pytest.mark.journey_market_intelligence
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.movers.rh.get_top_movers")
     @pytest.mark.asyncio
@@ -32,6 +33,7 @@ class TestMarketTools:
         # The actual structure depends on how the tool processes the data
 
     @pytest.mark.journey_market_data
+    @pytest.mark.journey_market_intelligence
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.market.movers.rh.get_top_100")
     @pytest.mark.asyncio

--- a/tests/unit/test_schwab_streaming_tools.py
+++ b/tests/unit/test_schwab_streaming_tools.py
@@ -212,6 +212,7 @@ async def test_schwab_stream_account_activity_unavailable(
 
 
 @pytest.mark.journey_market_data
+@pytest.mark.journey_advanced_data
 @pytest.mark.asyncio
 async def test_schwab_stream_level2_success() -> None:
     mock_broker = MagicMock()
@@ -246,6 +247,7 @@ async def test_schwab_stream_level2_success() -> None:
 
 
 @pytest.mark.journey_market_data
+@pytest.mark.journey_advanced_data
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "symbol,venue,capability,manager_exists,is_running,sub_success,snapshot,expected_reason",

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -762,6 +762,7 @@ class TestAdvancedInstrumentTools:
         assert "empty" in result["result"]["error"].lower()
 
     @pytest.mark.journey_market_data
+    @pytest.mark.journey_advanced_data
     @pytest.mark.unit
     @patch("open_stocks_mcp.tools.stocks.quote.rh.get_pricebook_by_symbol")
     @pytest.mark.asyncio
@@ -795,6 +796,7 @@ class TestAdvancedInstrumentTools:
         assert result["result"]["bids"][0]["price"] == 150.20
 
     @pytest.mark.journey_market_data
+    @pytest.mark.journey_advanced_data
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_pricebook_by_symbol_invalid_symbol(self) -> None:


### PR DESCRIPTION
Closes #967

## Changes
- Added `@pytest.mark.journey_advanced_data` to `test_get_pricebook_by_symbol_success` and `test_get_pricebook_by_symbol_invalid_symbol` in `tests/unit/test_stock_market_tools.py`
- Added `@pytest.mark.journey_advanced_data` to `test_schwab_stream_level2_success` and `test_schwab_stream_level2_unavailable` in `tests/unit/test_schwab_streaming_tools.py`
- Added `@pytest.mark.journey_advanced_data` to `test_get_stock_level2_data_success` in `tests/unit/test_market_research_tools.py`
- Added `@pytest.mark.journey_market_intelligence` to `test_get_top_movers_success` and `test_get_top_100_success` in `tests/unit/test_market_tools.py`
- Added `@pytest.mark.journey_market_intelligence` to `test_get_top_movers_sp500_up_success` and `test_get_top_movers_sp500_down_success` in `tests/unit/test_market_research_tools.py`

## Test plan
- `pytest -m journey_advanced_data --collect-only` → 10 tests collected ✅
- `pytest -m journey_market_intelligence --collect-only` → 4 tests collected ✅
- `pytest -m "journey_advanced_data or journey_market_intelligence"` → 14 passed ✅
- `ruff check` on modified files → All checks passed ✅