### PR TITLE
chore: cleanup (ruff)

### DIFF
--- a/scripts/schwab_coverage.py
+++ b/scripts/schwab_coverage.py
@@ -64,7 +64,9 @@ def render_coverage_markdown(
         else:
             lines.append(f"- [ ] `{tool}` — *no eval*")
     total = len(schwab_tools)
-    header = f"**Coverage: {covered}/{total} schwab_* tools have ADK eval fixtures**\n\n"
+    header = (
+        f"**Coverage: {covered}/{total} schwab_* tools have ADK eval fixtures**\n\n"
+    )
     return header + "\n".join(lines) + "\n"
 
 

--- a/tests/unit/test_api_docs_generator.py
+++ b/tests/unit/test_api_docs_generator.py
@@ -62,22 +62,24 @@ def test_committed_api_tools_doc_matches_live_registry(tmp_path):
 def test_tools_from_eval_file(tmp_path):
     eval_file = tmp_path / "test_schwab_eval.json"
     eval_file.write_text(
-        json.dumps({
-            "eval_cases": [
-                {
-                    "conversation": [
-                        {
-                            "intermediate_data": {
-                                "tool_uses": [
-                                    {"name": "schwab_account_numbers"},
-                                    {"name": "schwab_quote"},
-                                ]
+        json.dumps(
+            {
+                "eval_cases": [
+                    {
+                        "conversation": [
+                            {
+                                "intermediate_data": {
+                                    "tool_uses": [
+                                        {"name": "schwab_account_numbers"},
+                                        {"name": "schwab_quote"},
+                                    ]
+                                }
                             }
-                        }
-                    ]
-                }
-            ]
-        })
+                        ]
+                    }
+                ]
+            }
+        )
     )
 
     result = schwab_coverage.tools_from_eval_file(eval_file)
@@ -90,19 +92,21 @@ def test_tools_from_eval_file(tmp_path):
 def test_build_coverage_maps_tool_to_filename(tmp_path):
     eval_file = tmp_path / "test_schwab_account_test.json"
     eval_file.write_text(
-        json.dumps({
-            "eval_cases": [
-                {
-                    "conversation": [
-                        {
-                            "intermediate_data": {
-                                "tool_uses": [{"name": "schwab_account_numbers"}]
+        json.dumps(
+            {
+                "eval_cases": [
+                    {
+                        "conversation": [
+                            {
+                                "intermediate_data": {
+                                    "tool_uses": [{"name": "schwab_account_numbers"}]
+                                }
                             }
-                        }
-                    ]
-                }
-            ]
-        })
+                        ]
+                    }
+                ]
+            }
+        )
     )
 
     coverage = schwab_coverage.build_coverage(tmp_path)


### PR DESCRIPTION
Automated code-quality cleanup using ruff formatter.

**Files changed:** 2
- scripts/schwab_coverage.py: 4 insertions, 1 deletion
- tests/unit/test_api_docs_generator.py: 30 insertions, 27 deletions

**Tools applied:** ruff (format)