### PR TITLE
fix: skip repos without rev field in pre-commit test

### DIFF
--- a/tests/unit/test_dev_tooling.py
+++ b/tests/unit/test_dev_tooling.py
@@ -127,7 +127,7 @@ def test_dependency_floors_and_pre_commit_revisions() -> None:
         assert dep in group_dev_dependencies
     assert "pytest-cov>=7.1.0" in group_dev_dependencies
 
-    repo_revs = {repo["repo"]: repo["rev"] for repo in pre_commit["repos"]}
+    repo_revs = {repo["repo"]: repo["rev"] for repo in pre_commit["repos"] if "rev" in repo}
     assert repo_revs["https://github.com/astral-sh/ruff-pre-commit"] == "v0.15.14"
     assert repo_revs["https://github.com/pre-commit/pre-commit-hooks"] == "v6.0.0"
 


### PR DESCRIPTION
Closes #974

## Changes
- Filter out repos without a `rev` field in `test_dependency_floors_and_pre_commit_revisions`
- The `local` repo type in `.pre-commit-config.yaml` does not have a `rev` field per pre-commit spec
- Changed dict comprehension to only include repos that have a `rev` key

## Test plan
- `pytest tests/unit/test_dev_tooling.py` — all 7 tests pass