### PR TITLE
test: handle local pre-commit repo without rev

### DIFF
--- a/tests/unit/test_dev_tooling.py
+++ b/tests/unit/test_dev_tooling.py
@@ -127,7 +127,11 @@ def test_dependency_floors_and_pre_commit_revisions() -> None:
         assert dep in group_dev_dependencies
     assert "pytest-cov>=7.1.0" in group_dev_dependencies
 
-    repo_revs = {repo["repo"]: repo["rev"] for repo in pre_commit["repos"] if "rev" in repo}
+    repo_revs = {
+        repo["repo"]: repo["rev"]
+        for repo in pre_commit["repos"]
+        if "rev" in repo
+    }
     assert repo_revs["https://github.com/astral-sh/ruff-pre-commit"] == "v0.15.14"
     assert repo_revs["https://github.com/pre-commit/pre-commit-hooks"] == "v6.0.0"
 


### PR DESCRIPTION
Closes #974

## Changes
- update `test_dependency_floors_and_pre_commit_revisions` to ignore repos without a `rev` key when building the revision map
- keep explicit revision assertions for pinned third-party pre-commit repos

## Test plan
- uv run pytest tests/unit/test_dev_tooling.py::test_dependency_floors_and_pre_commit_revisions -v
- uv run pytest tests/unit/test_dev_tooling.py -q
