### PR TITLE
test: fix ruff format check in test_dev_tooling

### DIFF
--- a/tests/unit/test_dev_tooling.py
+++ b/tests/unit/test_dev_tooling.py
@@ -128,9 +128,7 @@ def test_dependency_floors_and_pre_commit_revisions() -> None:
     assert "pytest-cov>=7.1.0" in group_dev_dependencies
 
     repo_revs = {
-        repo["repo"]: repo["rev"]
-        for repo in pre_commit["repos"]
-        if "rev" in repo
+        repo["repo"]: repo["rev"] for repo in pre_commit["repos"] if "rev" in repo
     }
     assert repo_revs["https://github.com/astral-sh/ruff-pre-commit"] == "v0.15.14"
     assert repo_revs["https://github.com/pre-commit/pre-commit-hooks"] == "v6.0.0"


### PR DESCRIPTION
Closes #978

## Changes
- Reformat `tests/unit/test_dev_tooling.py` with Ruff
- Keep behavior unchanged while aligning line wrapping with formatter output

## Test plan
- uv run ruff format --check tests/unit/test_dev_tooling.py
- uv run ruff format --check .