### PR TITLE
docs: add per-fixture adk eval run commands for Schwab order/options

### DIFF
--- a/tests/evals/ADK-testing-evals.md
+++ b/tests/evals/ADK-testing-evals.md
@@ -307,6 +307,32 @@ Evaluations for Schwab-specific tools. These typically require live Schwab OAuth
 - `tests/evals/5_ord_schwab_order_option_debit_spread_test.json` — exercises `schwab_order_option_debit_spread`.
 - `tests/evals/5_ord_schwab_replace_order_test.json` — exercises `schwab_replace_order`.
 
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_orders_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_get_open_stock_orders_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_get_order_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_transactions_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_transactions_by_date_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_get_transaction_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_buy_stock_market_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_sell_stock_market_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_buy_stock_limit_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_sell_stock_limit_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_place_order_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_cancel_order_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_order_sell_stop_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_cancel_all_stock_orders_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_order_buy_option_limit_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_order_sell_option_limit_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_cancel_option_order_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_cancel_all_option_orders_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_order_option_credit_spread_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_order_option_debit_spread_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/5_ord_schwab_replace_order_test.json --config_file_path tests/evals/test_config.json
+```
+
 #### Payment Evals (`7_pmt_schwab_*`)
 
 - `tests/evals/7_pmt_schwab_get_dividends_test.json` — multi-step: `schwab_account_numbers` then `schwab_get_dividends`.
@@ -329,6 +355,23 @@ Evaluations for Schwab-specific tools. These typically require live Schwab OAuth
 - `tests/evals/8_opt_schwab_option_quote_test.json` — exercises `schwab_option_quote`.
 - `tests/evals/8_opt_schwab_option_buy_to_open_test.json` — exercises `schwab_option_buy_to_open`.
 - `tests/evals/8_opt_schwab_option_sell_to_close_test.json` — exercises `schwab_option_sell_to_close`.
+
+Run with:
+
+```bash
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_chain_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_chain_by_expiration_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_expirations_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_options_positions_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_orders_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_open_option_orders_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_get_all_option_positions_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_get_open_option_positions_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_find_tradable_options_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_quote_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_buy_to_open_test.json --config_file_path tests/evals/test_config.json
+adk eval examples/google_adk_agent tests/evals/8_opt_schwab_option_sell_to_close_test.json --config_file_path tests/evals/test_config.json
+```
 
 #### Advanced/Profile Evals (`9_adv_schwab_*`)
 


### PR DESCRIPTION
Closes #976

## Changes
- Added explicit `Run with:` code block to the Order/Transaction Evals (`5_ord_schwab_*`) subsection with one `adk eval` line per fixture (21 fixtures total, including 15 added in #971)
- Added explicit `Run with:` code block to the Options Evals (`8_opt_schwab_*`) subsection with one `adk eval` line per fixture (12 fixtures total, including 2 added in #971)
- Follows the same pattern used by other sections (`4_ntf_*`, `6_prf_*`, `3_wth_*`, etc.)

## Test plan
- Verify both new `Run with:` blocks appear in `tests/evals/ADK-testing-evals.md` under their respective subsections
- Verify each fixture file referenced in the run commands exists in `tests/evals/`
- Confirm all 21 `5_ord_schwab_*` and 12 `8_opt_schwab_*` fixture filenames match the actual files on disk