### PR TITLE
docs: remove stale broker doc markers

### DIFF
--- a/docs/GRACEFUL_AUTH_IMPLEMENTATION.md
+++ b/docs/GRACEFUL_AUTH_IMPLEMENTATION.md
@@ -134,7 +134,7 @@ class RobinhoodBroker(BaseBroker):
 2. Create MCP server
 3. Call setup_brokers(username, password)
    ├─ Register RobinhoodBroker (if credentials provided)
-   ├─ Register SchwabBroker (TODO: when implemented)
+   ├─ Register SchwabBroker (if enabled and configured)
    └─ attempt_broker_logins() - NON-BLOCKING
        ├─ Logs detailed authentication results
        └─ Returns success/failure counts

--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -4,11 +4,11 @@ This directory contains a complete example of how to run the Open Stocks MCP ser
 
 ## Architecture
 
-This setup uses a production-ready approach:
-1. **Dockerfile**: Creates a secure base image with the `open-stocks-mcp` library installed and verified
-2. **docker-compose.yml**: Orchestrates the server deployment with HTTP transport and proper configuration
-3. **Enhanced Authentication**: Automatic device verification and MFA support for seamless Robinhood integration
-4. **HTTP Transport**: Uses HTTP transport (port 3001) for better reliability and session management
+This setup includes concrete deployment safeguards:
+1. **Dockerfile**: Creates a non-root container image with the `open-stocks-mcp` library installed and verified
+2. **docker-compose.yml**: Orchestrates the server with HTTP transport, resource limits, health checks, and persistent volumes
+3. **Authentication Requirements**: Uses `.env` credentials plus an `MCP_API_KEY` requirement when binding HTTP transport to `0.0.0.0`
+4. **HTTP Transport**: Uses HTTP transport (port 3001) with session and log storage that persist across container restarts
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes #987

## Changes
- Update the graceful-auth startup flow to show Schwab registration as implemented when enabled and configured.
- Replace the Docker README production-ready claim with concrete deployment safeguards: non-root user, resource limits, health checks, persistent storage, and MCP API key requirements.

## Test plan
- Verified stale documentation markers are absent with an inverted rg check.
- Verified replacement text for Schwab registration and Docker deployment safeguards with rg.
- Ran git diff --check.