### PR TITLE
perf: batch broker enrichment lookups concurrently (#986)

### DIFF
--- a/src/open_stocks_mcp/tools/batch_fetch.py
+++ b/src/open_stocks_mcp/tools/batch_fetch.py
@@ -1,0 +1,66 @@
+"""Bounded concurrent fan-out helpers for broker enrichment lookups.
+
+Per-row instrument and quote lookups are common N+1 traps in this codebase
+(see issue #986). These helpers let call sites:
+
+- Deduplicate identical lookup keys (instrument URLs, option IDs, symbols)
+  so duplicates within a single request hit the broker only once.
+- Issue the remaining unique lookups concurrently with a bounded semaphore
+  instead of serially.
+- Surface per-key failures via ``return_exceptions=True`` so a single bad
+  lookup does not abort the whole batch.
+
+The helpers intentionally do not call ``execute_with_retry`` themselves —
+that keeps each call site in control of its retry/error contract and lets
+existing module-level mocks (which patch ``execute_with_retry``) keep
+working.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Iterable
+from typing import TypeVar
+
+DEFAULT_BATCH_CONCURRENCY = 8
+
+T = TypeVar("T")
+
+
+async def gather_bounded(
+    coros: Iterable[Awaitable[T]],
+    *,
+    limit: int = DEFAULT_BATCH_CONCURRENCY,
+) -> list[T | BaseException]:
+    """Run ``coros`` concurrently, capping in-flight tasks at ``limit``.
+
+    Mirrors ``asyncio.gather(..., return_exceptions=True)`` — results are
+    returned in submission order, and per-coroutine exceptions appear in
+    place of values rather than aborting the batch.
+    """
+    coros_list = list(coros)
+    if not coros_list:
+        return []
+
+    effective_limit = max(1, limit)
+    semaphore = asyncio.Semaphore(effective_limit)
+
+    async def _bounded(coro: Awaitable[T]) -> T:
+        async with semaphore:
+            return await coro
+
+    return await asyncio.gather(
+        *(_bounded(c) for c in coros_list), return_exceptions=True
+    )
+
+
+def dedupe_preserving_order(keys: Iterable[str | None]) -> list[str]:
+    """Return the unique non-empty keys from ``keys`` in first-seen order."""
+    seen: set[str] = set()
+    unique: list[str] = []
+    for key in keys:
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        unique.append(key)
+    return unique

--- a/src/open_stocks_mcp/tools/broker_comparison_tools.py
+++ b/src/open_stocks_mcp/tools/broker_comparison_tools.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from open_stocks_mcp.brokers.registry import get_broker_registry
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.batch_fetch import gather_bounded
 from open_stocks_mcp.tools.responses import create_success_response
 from open_stocks_mcp.tools.robinhood_account_tools import get_portfolio, get_positions
 from open_stocks_mcp.tools.robinhood_order_tools import get_stock_orders
@@ -46,10 +47,17 @@ async def _collect_robinhood_comparison(
         },
     }
 
-    # 1. Pricing
+    # 1. Pricing — fan out per-symbol lookups concurrently
     if symbols:
-        for symbol in symbols:
-            price_result = await get_stock_price(symbol)
+        price_results = await gather_bounded(
+            [get_stock_price(symbol) for symbol in symbols]
+        )
+        for symbol, price_result in zip(symbols, price_results, strict=True):
+            if isinstance(price_result, BaseException):
+                logger.warning(
+                    f"Failed to get Robinhood price for {symbol}: {price_result}"
+                )
+                continue
             price_data = price_result.get("result", {})
             if "error" not in price_data:
                 data["pricing"][symbol] = {
@@ -132,10 +140,17 @@ async def _collect_schwab_comparison(
 
     account_hash = accounts_data["accounts"][0]["hash_value"]
 
-    # 1. Pricing
+    # 1. Pricing — fan out per-symbol Schwab quotes concurrently
     if symbols:
-        for symbol in symbols:
-            quote_result = await get_schwab_quote(symbol)
+        quote_results = await gather_bounded(
+            [get_schwab_quote(symbol) for symbol in symbols]
+        )
+        for symbol, quote_result in zip(symbols, quote_results, strict=True):
+            if isinstance(quote_result, BaseException):
+                logger.warning(
+                    f"Failed to get Schwab quote for {symbol}: {quote_result}"
+                )
+                continue
             quote_data = quote_result.get("result", {})
             if "error" not in quote_data:
                 data["pricing"][symbol] = {

--- a/src/open_stocks_mcp/tools/options/positions.py
+++ b/src/open_stocks_mcp/tools/options/positions.py
@@ -6,10 +6,56 @@ from typing import Any
 import robin_stocks.robinhood as rh
 
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.batch_fetch import dedupe_preserving_order, gather_bounded
 from open_stocks_mcp.tools.error_handling import (
     execute_with_retry,
     handle_robin_stocks_errors,
 )
+
+
+def _extract_option_id(position: Any) -> str | None:
+    """Return the option_id for ``position`` if present, otherwise None.
+
+    Accepts both ``option_id`` directly and a trailing-segment ID parsed from
+    the ``option`` URL field (matching the prior inline extraction).
+    """
+    if not isinstance(position, dict):
+        return None
+    option_id = position.get("option_id")
+    if option_id:
+        return str(option_id)
+    option_url = position.get("option")
+    if option_url and isinstance(option_url, str):
+        url_parts = option_url.rstrip("/").split("/")
+        return url_parts[-1] if url_parts else None
+    return None
+
+
+async def _resolve_option_instruments(
+    option_ids: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Look up option-instrument metadata for each ``option_id`` concurrently."""
+    if not option_ids:
+        return {}
+
+    results = await gather_bounded(
+        [
+            execute_with_retry(
+                rh.options.get_option_instrument_data_by_id,
+                option_id,
+                max_retries=2,
+            )
+            for option_id in option_ids
+        ]
+    )
+    resolved: dict[str, dict[str, Any]] = {}
+    for option_id, value in zip(option_ids, results, strict=True):
+        if isinstance(value, BaseException):
+            logger.warning(f"Failed to fetch option details for {option_id}: {value}")
+            continue
+        if isinstance(value, dict):
+            resolved[option_id] = value
+    return resolved
 
 
 @handle_robin_stocks_errors
@@ -398,69 +444,51 @@ async def get_open_option_positions_with_details() -> dict[str, Any]:
     total_positions = len(positions_data) if isinstance(positions_data, list) else 0
 
     if isinstance(positions_data, list):
-        for position in positions_data:
+        # Pre-resolve every distinct option_id concurrently so large option
+        # books don't fan out into N+1 serial broker calls.
+        option_id_for_position = [
+            _extract_option_id(position) for position in positions_data
+        ]
+        unique_option_ids = dedupe_preserving_order(option_id_for_position)
+        option_details_by_id = await _resolve_option_instruments(unique_option_ids)
+
+        for position, option_id in zip(
+            positions_data, option_id_for_position, strict=True
+        ):
             if not isinstance(position, dict):
                 enriched_positions.append(position)
                 continue
-
-            # Extract option_id from position
-            option_id = position.get("option_id")
-            if not option_id:
-                # Try to extract from option URL
-                option_url = position.get("option")
-                if option_url and isinstance(option_url, str):
-                    # Extract ID from URL like "https://api.robinhood.com/options/instruments/845df489.../""
-                    url_parts = option_url.rstrip("/").split("/")
-                    option_id = url_parts[-1] if url_parts else None
 
             # Create enriched position starting with original data
             enriched_position = position.copy()
 
             if option_id:
-                try:
-                    # Step 3: Fetch option instrument details
-                    logger.debug(f"Fetching option details for ID: {option_id}")
-                    option_details = await execute_with_retry(
-                        rh.options.get_option_instrument_data_by_id,
-                        option_id,
-                        max_retries=2,
+                option_details = option_details_by_id.get(option_id)
+                if option_details:
+                    # Step 4: Add enriched fields to position
+                    enriched_position.update(
+                        {
+                            "option_type": option_details.get("type", "unknown"),
+                            "strike_price": option_details.get(
+                                "strike_price", "0.0000"
+                            ),
+                            "option_symbol": option_details.get("occ_symbol", ""),
+                            "tradability": option_details.get("tradability", "unknown"),
+                            "state": option_details.get("state", "unknown"),
+                            "underlying_symbol": option_details.get("chain_symbol", ""),
+                            "expiration_date": option_details.get(
+                                "expiration_date", ""
+                            ),
+                            "rhs_tradability": option_details.get(
+                                "rhs_tradability", "unknown"
+                            ),
+                        }
                     )
-
-                    if option_details and isinstance(option_details, dict):
-                        # Step 4: Add enriched fields to position
-                        enriched_position.update(
-                            {
-                                "option_type": option_details.get("type", "unknown"),
-                                "strike_price": option_details.get(
-                                    "strike_price", "0.0000"
-                                ),
-                                "option_symbol": option_details.get("occ_symbol", ""),
-                                "tradability": option_details.get(
-                                    "tradability", "unknown"
-                                ),
-                                "state": option_details.get("state", "unknown"),
-                                "underlying_symbol": option_details.get(
-                                    "chain_symbol", ""
-                                ),
-                                "expiration_date": option_details.get(
-                                    "expiration_date", ""
-                                ),
-                                "rhs_tradability": option_details.get(
-                                    "rhs_tradability", "unknown"
-                                ),
-                            }
-                        )
-                        enrichment_successes += 1
-                        logger.debug(f"Successfully enriched position for {option_id}")
-                    else:
-                        logger.warning(
-                            f"No option details found for option_id: {option_id}"
-                        )
-                        enriched_position["option_type"] = "unknown"
-
-                except Exception as e:
+                    enrichment_successes += 1
+                    logger.debug(f"Successfully enriched position for {option_id}")
+                else:
                     logger.warning(
-                        f"Failed to fetch option details for {option_id}: {e}"
+                        f"No option details found for option_id: {option_id}"
                     )
                     enriched_position["option_type"] = "unknown"
             else:

--- a/src/open_stocks_mcp/tools/robinhood_account_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_account_tools.py
@@ -6,6 +6,7 @@ import robin_stocks.robinhood as rh
 
 from open_stocks_mcp.config import load_config
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.batch_fetch import dedupe_preserving_order, gather_bounded
 from open_stocks_mcp.tools.cache import cached_async
 from open_stocks_mcp.tools.error_handling import (
     create_no_data_response,
@@ -213,18 +214,27 @@ async def get_positions() -> dict[str, Any]:
             {"positions": [], "count": 0, "message": "No open stock positions found."}
         )
 
+    # Resolve all unique instrument URLs concurrently so large portfolios
+    # don't pay N round-trips serially.
+    instrument_urls = dedupe_preserving_order(
+        position.get("instrument") for position in positions
+    )
+    url_to_symbol: dict[str, str] = {}
+    if instrument_urls:
+        symbol_results = await gather_bounded(
+            [execute_with_retry(rh.get_symbol_by_url, url) for url in instrument_urls]
+        )
+        for url, value in zip(instrument_urls, symbol_results, strict=True):
+            if isinstance(value, BaseException):
+                logger.warning(f"Failed to get symbol for instrument {url}: {value}")
+                continue
+            if isinstance(value, str) and value:
+                url_to_symbol[url] = value
+
     position_list = []
     for position in positions:
-        # Get symbol from instrument URL with retry logic
         instrument_url = position.get("instrument")
-        symbol = "N/A"
-        if instrument_url:
-            try:
-                symbol = await execute_with_retry(rh.get_symbol_by_url, instrument_url)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to get symbol for instrument {instrument_url}: {e}"
-                )
+        symbol = url_to_symbol.get(instrument_url, "N/A") if instrument_url else "N/A"
 
         quantity = position.get("quantity", "0")
 

--- a/src/open_stocks_mcp/tools/robinhood_dividend_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_dividend_tools.py
@@ -7,10 +7,39 @@ import robin_stocks.robinhood as rh
 
 from open_stocks_mcp.brokers.session_state import get_session_manager
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.batch_fetch import dedupe_preserving_order, gather_bounded
 from open_stocks_mcp.tools.error_handling import (
     execute_with_retry,
     handle_robin_stocks_errors,
 )
+
+
+async def _resolve_instruments(
+    instrument_urls: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Look up Robinhood instrument metadata for ``instrument_urls`` concurrently.
+
+    Returns a ``{url: instrument_dict}`` map; URLs that fail or return
+    non-dict responses are silently dropped after a warning log. Empty input
+    returns an empty dict.
+    """
+    if not instrument_urls:
+        return {}
+
+    results = await gather_bounded(
+        [
+            execute_with_retry(rh.stocks.get_instrument_by_url, url)
+            for url in instrument_urls
+        ]
+    )
+    resolved: dict[str, dict[str, Any]] = {}
+    for url, value in zip(instrument_urls, results, strict=True):
+        if isinstance(value, BaseException):
+            logger.warning(f"Failed to get instrument data for {url}: {value}")
+            continue
+        if isinstance(value, dict):
+            resolved[url] = value
+    return resolved
 
 
 @handle_robin_stocks_errors
@@ -56,6 +85,13 @@ async def get_dividends() -> dict[str, Any]:
         if not dividends or not isinstance(dividends, list):
             dividends = []
 
+        # Resolve all unique instrument URLs concurrently. Large dividend
+        # histories share many of the same instruments, so dedupe first.
+        instrument_urls = dedupe_preserving_order(
+            d.get("instrument") for d in dividends
+        )
+        url_to_instrument = await _resolve_instruments(instrument_urls)
+
         # Process dividend data
         processed_dividends = []
         total_amount = 0.0
@@ -76,18 +112,13 @@ async def get_dividends() -> dict[str, Any]:
                 "payable_date": dividend.get("payable_date"),
             }
 
-            # Get symbol from instrument URL if available
             instrument_url = dividend.get("instrument")
-            if instrument_url:
-                try:
-                    instrument_data = await execute_with_retry(
-                        rh.stocks.get_instrument_by_url, instrument_url
-                    )
-                    if instrument_data and isinstance(instrument_data, dict):
-                        processed["symbol"] = instrument_data.get("symbol")
-                        processed["name"] = instrument_data.get("simple_name")
-                except Exception as e:
-                    logger.warning(f"Failed to get instrument data: {e}")
+            instrument_data = (
+                url_to_instrument.get(instrument_url) if instrument_url else None
+            )
+            if instrument_data:
+                processed["symbol"] = instrument_data.get("symbol")
+                processed["name"] = instrument_data.get("simple_name")
 
             # Calculate total for paid dividends
             if dividend.get("state") == "paid" and dividend.get("amount"):
@@ -385,6 +416,11 @@ async def get_stock_loan_payments() -> dict[str, Any]:
         total_amount = 0.0
 
         if loan_payments and isinstance(loan_payments, list):
+            instrument_urls = dedupe_preserving_order(
+                p.get("instrument") for p in loan_payments
+            )
+            url_to_instrument = await _resolve_instruments(instrument_urls)
+
             for payment in loan_payments:
                 processed = {
                     "id": payment.get("id"),
@@ -397,18 +433,13 @@ async def get_stock_loan_payments() -> dict[str, Any]:
                     "created_at": payment.get("created_at"),
                 }
 
-                # Get symbol from instrument URL if available
                 instrument_url = payment.get("instrument")
-                if instrument_url:
-                    try:
-                        instrument_data = await execute_with_retry(
-                            rh.stocks.get_instrument_by_url, instrument_url
-                        )
-                        if instrument_data and isinstance(instrument_data, dict):
-                            processed["symbol"] = instrument_data.get("symbol")
-                            processed["name"] = instrument_data.get("simple_name")
-                    except Exception as e:
-                        logger.warning(f"Failed to get instrument data: {e}")
+                instrument_data = (
+                    url_to_instrument.get(instrument_url) if instrument_url else None
+                )
+                if instrument_data:
+                    processed["symbol"] = instrument_data.get("symbol")
+                    processed["name"] = instrument_data.get("simple_name")
 
                 # Calculate total for paid loans
                 if payment.get("state") == "paid" and payment.get("amount"):

--- a/src/open_stocks_mcp/tools/robinhood_trading_tools.py
+++ b/src/open_stocks_mcp/tools/robinhood_trading_tools.py
@@ -5,6 +5,7 @@ from typing import Any
 import robin_stocks.robinhood as rh
 
 from open_stocks_mcp.logging_config import logger
+from open_stocks_mcp.tools.batch_fetch import dedupe_preserving_order, gather_bounded
 from open_stocks_mcp.tools.error_handling import (
     create_success_response,
     execute_with_retry,
@@ -763,20 +764,29 @@ async def get_all_open_stock_orders() -> dict[str, Any]:
             {"orders": [], "count": 0, "message": "No open stock orders found"}
         )
 
-    order_list = []
-    for order in orders:
-        order = sanitize_api_response(order)
+    sanitized_orders = [sanitize_api_response(order) for order in orders]
 
-        # Get symbol from instrument URL
+    # Resolve every distinct instrument URL once, concurrently — multiple open
+    # orders for the same ticker would otherwise repeat the same lookup.
+    instrument_urls = dedupe_preserving_order(
+        order.get("instrument") for order in sanitized_orders
+    )
+    url_to_symbol: dict[str, str] = {}
+    if instrument_urls:
+        symbol_results = await gather_bounded(
+            [execute_with_retry(rh.get_symbol_by_url, url) for url in instrument_urls]
+        )
+        for url, value in zip(instrument_urls, symbol_results, strict=True):
+            if isinstance(value, BaseException):
+                logger.warning(f"Failed to get symbol for instrument {url}: {value}")
+                continue
+            if isinstance(value, str) and value:
+                url_to_symbol[url] = value
+
+    order_list = []
+    for order in sanitized_orders:
         instrument_url = order.get("instrument")
-        symbol = "N/A"
-        if instrument_url:
-            try:
-                symbol = await execute_with_retry(rh.get_symbol_by_url, instrument_url)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to get symbol for instrument {instrument_url}: {e}"
-                )
+        symbol = url_to_symbol.get(instrument_url, "N/A") if instrument_url else "N/A"
 
         order_data = {
             "order_id": order.get("id"),

--- a/tests/unit/test_account_tools.py
+++ b/tests/unit/test_account_tools.py
@@ -151,8 +151,13 @@ class TestAccountTools:
         """Test successful positions retrieval."""
         mock_positions.return_value = robinhood_positions_payload
 
-        # Mock symbol lookup for each instrument URL
-        mock_symbol.side_effect = ["AAPL", "GOOGL"]
+        # Concurrent gather may invoke the underlying mock in any thread
+        # order, so map URL → symbol explicitly.
+        symbol_by_url = {
+            "https://robinhood.com/instruments/aapl123/": "AAPL",
+            "https://robinhood.com/instruments/googl456/": "GOOGL",
+        }
+        mock_symbol.side_effect = lambda url: symbol_by_url[url]
 
         result = await get_positions()
 

--- a/tests/unit/test_analytics_tools.py
+++ b/tests/unit/test_analytics_tools.py
@@ -399,10 +399,19 @@ class TestStockLoanPayments:
             },
         ]
 
-        mock_instrument.side_effect = [
-            {"symbol": "AMC", "simple_name": "AMC Entertainment"},
-            {"symbol": "GME", "simple_name": "GameStop Corp"},
-        ]
+        # Concurrent gather may invoke this mock in any thread order, so map
+        # URL → instrument data explicitly to avoid relying on call sequence.
+        instrument_by_url = {
+            "https://robinhood.com/instruments/abc123/": {
+                "symbol": "AMC",
+                "simple_name": "AMC Entertainment",
+            },
+            "https://robinhood.com/instruments/def456/": {
+                "symbol": "GME",
+                "simple_name": "GameStop Corp",
+            },
+        }
+        mock_instrument.side_effect = lambda url: instrument_by_url[url]
 
         # Mock session manager
         mock_session_instance = AsyncMock()

--- a/tests/unit/test_batch_fetch.py
+++ b/tests/unit/test_batch_fetch.py
@@ -1,0 +1,498 @@
+"""Unit tests for the batch_fetch helpers and the N+1 regressions they cover.
+
+Covers:
+- ``gather_bounded`` honours the concurrency cap and surfaces exceptions
+  in place rather than aborting the batch.
+- ``dedupe_preserving_order`` removes duplicates and skips falsy keys.
+- The 6 enrichment call sites flagged in issue #986 only issue ONE broker
+  lookup per distinct key, even when the same URL/option ID appears across
+  many rows, and they handle large input lists without leaking serial
+  awaits.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from open_stocks_mcp.tools.batch_fetch import (
+    DEFAULT_BATCH_CONCURRENCY,
+    dedupe_preserving_order,
+    gather_bounded,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_gather_bounded_empty() -> None:
+    assert await gather_bounded([]) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_gather_bounded_preserves_order_and_returns_exceptions() -> None:
+    async def ok(value: int) -> int:
+        await asyncio.sleep(0)
+        return value
+
+    async def boom() -> int:
+        raise RuntimeError("nope")
+
+    results = await gather_bounded([ok(1), boom(), ok(3)])
+
+    assert results[0] == 1
+    assert isinstance(results[1], RuntimeError)
+    assert results[2] == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_gather_bounded_caps_concurrent_tasks() -> None:
+    """At most `limit` coroutines should be in flight at any one time."""
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def tracked() -> int:
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        await asyncio.sleep(0.005)
+        async with lock:
+            in_flight -= 1
+        return 1
+
+    await gather_bounded([tracked() for _ in range(50)], limit=4)
+    assert peak <= 4
+
+
+@pytest.mark.unit
+def test_dedupe_preserving_order_strips_falsy_and_dedupes() -> None:
+    assert dedupe_preserving_order(["a", None, "b", "", "a", "c", "b", None]) == [
+        "a",
+        "b",
+        "c",
+    ]
+
+
+@pytest.mark.unit
+def test_dedupe_preserving_order_empty() -> None:
+    assert dedupe_preserving_order([]) == []
+    assert dedupe_preserving_order([None, "", None]) == []
+
+
+@pytest.mark.unit
+def test_default_concurrency_is_sane() -> None:
+    assert 1 < DEFAULT_BATCH_CONCURRENCY <= 32
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the 6 N+1 sites flagged in issue #986
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.journey_portfolio
+async def test_get_positions_dedupes_repeated_instrument_urls() -> None:
+    """Duplicate instrument URLs across positions hit the broker once each."""
+    from open_stocks_mcp.tools.robinhood_account_tools import get_positions
+
+    aapl = "https://robinhood.com/instruments/aapl123/"
+    googl = "https://robinhood.com/instruments/googl456/"
+    positions_payload = [
+        {
+            "instrument": aapl,
+            "quantity": "10.0000",
+            "average_buy_price": "150.00",
+            "updated_at": "t",
+        },
+        {
+            "instrument": aapl,  # duplicate — same instrument as the first row
+            "quantity": "1.0000",
+            "average_buy_price": "151.00",
+            "updated_at": "t",
+        },
+        {
+            "instrument": googl,
+            "quantity": "5.0000",
+            "average_buy_price": "2500.00",
+            "updated_at": "t",
+        },
+    ]
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.robinhood_account_tools.rh.get_open_stock_positions",
+            return_value=positions_payload,
+        ),
+        patch(
+            "open_stocks_mcp.tools.robinhood_account_tools.rh.get_symbol_by_url",
+            side_effect=lambda url: {aapl: "AAPL", googl: "GOOGL"}[url],
+        ) as mock_symbol,
+    ):
+        result = await get_positions()
+
+    # Two unique URLs => exactly two lookups, regardless of position count.
+    assert mock_symbol.call_count == 2
+    assert sorted(call.args[0] for call in mock_symbol.call_args_list) == sorted(
+        [aapl, googl]
+    )
+    symbols = [p["symbol"] for p in result["result"]["positions"]]
+    assert symbols == ["AAPL", "AAPL", "GOOGL"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.journey_portfolio
+async def test_get_positions_handles_large_list_with_bounded_concurrency() -> None:
+    """A 50-position payload completes and stays within the concurrency cap."""
+    from open_stocks_mcp.tools.robinhood_account_tools import get_positions
+
+    n = 50
+    positions_payload = [
+        {
+            "instrument": f"https://robinhood.com/instruments/sym{i}/",
+            "quantity": "1.0000",
+            "average_buy_price": "10.00",
+            "updated_at": "t",
+        }
+        for i in range(n)
+    ]
+
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    from open_stocks_mcp.tools import robinhood_account_tools as mod
+
+    async def fake_symbol_lookup(url: str) -> str:
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        # Yield twice so concurrent tasks have a chance to ramp up to the cap.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        async with lock:
+            in_flight -= 1
+        return url.rstrip("/").rsplit("/", 1)[-1].upper()
+
+    async def fake_execute_with_retry(func: Any, *args: Any, **kwargs: Any) -> Any:
+        if func is mod.rh.get_open_stock_positions:
+            return positions_payload
+        if func is mod.rh.get_symbol_by_url:
+            return await fake_symbol_lookup(args[0])
+        raise AssertionError(f"unexpected fn: {func}")
+
+    with patch.object(
+        mod, "execute_with_retry", new=AsyncMock(side_effect=fake_execute_with_retry)
+    ):
+        result = await get_positions()
+
+    assert result["result"]["count"] == n
+    assert peak <= DEFAULT_BATCH_CONCURRENCY
+    assert {p["symbol"] for p in result["result"]["positions"]} == {
+        f"SYM{i}" for i in range(n)
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.journey_research
+async def test_get_dividends_dedupes_repeated_instrument_urls() -> None:
+    """get_dividends: same instrument URL across rows hits broker once."""
+    from open_stocks_mcp.tools import robinhood_dividend_tools as mod
+
+    aapl_url = "https://robinhood.com/instruments/aapl/"
+    dividends_payload = [
+        {"instrument": aapl_url, "amount": "1.00", "state": "paid"},
+        {"instrument": aapl_url, "amount": "1.00", "state": "paid"},
+        {"instrument": aapl_url, "amount": "1.00", "state": "paid"},
+    ]
+
+    call_count = 0
+
+    async def fake_execute(func: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        if func is mod.rh.account.get_dividends:
+            return dividends_payload
+        if func is mod.rh.stocks.get_instrument_by_url:
+            call_count += 1
+            return {"symbol": "AAPL", "simple_name": "Apple"}
+        raise AssertionError(f"unexpected fn: {func}")
+
+    session = MagicMock()
+    session.ensure_authenticated = AsyncMock(return_value=True)
+    with (
+        patch.object(
+            mod, "execute_with_retry", new=AsyncMock(side_effect=fake_execute)
+        ),
+        patch.object(mod, "get_session_manager", return_value=session),
+    ):
+        result = await mod.get_dividends()
+
+    # 3 dividends sharing one URL → exactly ONE instrument lookup.
+    assert call_count == 1
+    assert all(d["symbol"] == "AAPL" for d in result["result"]["dividends"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.journey_research
+async def test_get_stock_loan_payments_dedupes_repeated_instrument_urls() -> None:
+    """get_stock_loan_payments: shared instrument URL → one broker lookup."""
+    from open_stocks_mcp.tools import robinhood_dividend_tools as mod
+
+    amc_url = "https://robinhood.com/instruments/amc/"
+    payments_payload = [
+        {"instrument": amc_url, "amount": "0.10", "state": "paid"},
+        {"instrument": amc_url, "amount": "0.20", "state": "paid"},
+    ]
+
+    call_count = 0
+
+    async def fake_execute(func: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        if func is mod.rh.account.get_stock_loan_payments:
+            return payments_payload
+        if func is mod.rh.stocks.get_instrument_by_url:
+            call_count += 1
+            return {"symbol": "AMC", "simple_name": "AMC Entertainment"}
+        raise AssertionError(f"unexpected fn: {func}")
+
+    session = MagicMock()
+    session.ensure_authenticated = AsyncMock(return_value=True)
+    with (
+        patch.object(
+            mod, "execute_with_retry", new=AsyncMock(side_effect=fake_execute)
+        ),
+        patch.object(mod, "get_session_manager", return_value=session),
+    ):
+        result = await mod.get_stock_loan_payments()
+
+    assert call_count == 1
+    assert all(p["symbol"] == "AMC" for p in result["result"]["loan_payments"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.journey_options
+async def test_get_open_option_positions_with_details_dedupes_option_ids() -> None:
+    """Option positions sharing the same option_id only fetch instrument once."""
+    from open_stocks_mcp.tools.options.positions import (
+        get_open_option_positions_with_details,
+    )
+
+    positions_payload = [
+        {
+            "id": "p1",
+            "chain_symbol": "AAPL",
+            "option_id": "opt-1",
+            "total_equity": "10.00",
+            "unrealized_pnl": "1.00",
+        },
+        {
+            "id": "p2",
+            "chain_symbol": "AAPL",
+            "option_id": "opt-1",  # duplicate option_id (e.g. multi-leg)
+            "total_equity": "10.00",
+            "unrealized_pnl": "1.00",
+        },
+        {
+            "id": "p3",
+            "chain_symbol": "MSFT",
+            "option_id": "opt-2",
+            "total_equity": "10.00",
+            "unrealized_pnl": "1.00",
+        },
+    ]
+
+    instrument_payloads = {
+        "opt-1": {
+            "type": "call",
+            "strike_price": "150.0000",
+            "occ_symbol": "AAPL_C",
+            "tradability": "tradable",
+            "state": "active",
+            "chain_symbol": "AAPL",
+            "expiration_date": "2025-01-17",
+            "rhs_tradability": "tradable",
+        },
+        "opt-2": {
+            "type": "put",
+            "strike_price": "300.0000",
+            "occ_symbol": "MSFT_P",
+            "tradability": "tradable",
+            "state": "active",
+            "chain_symbol": "MSFT",
+            "expiration_date": "2025-01-17",
+            "rhs_tradability": "tradable",
+        },
+    }
+
+    with (
+        patch(
+            "open_stocks_mcp.tools.options.positions.rh.options.get_open_option_positions",
+            return_value=positions_payload,
+        ),
+        patch(
+            "open_stocks_mcp.tools.options.positions.rh.options.get_option_instrument_data_by_id",
+            side_effect=lambda option_id: instrument_payloads[option_id],
+        ) as mock_instrument,
+    ):
+        result = await get_open_option_positions_with_details()
+
+    # 3 positions, 2 unique option ids → exactly 2 instrument lookups.
+    assert mock_instrument.call_count == 2
+    types = [p["option_type"] for p in result["result"]["positions"]]
+    assert types == ["call", "call", "put"]
+    assert result["result"]["enrichment_success_rate"] == "100%"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.journey_trading
+async def test_get_all_open_stock_orders_dedupes_repeated_instrument_urls() -> None:
+    """Many open orders sharing one instrument URL → one symbol lookup."""
+    from open_stocks_mcp.tools import robinhood_trading_tools as mod
+
+    aapl_url = "https://robinhood.com/instruments/aapl/"
+    orders_payload = [
+        {
+            "id": f"o{i}",
+            "instrument": aapl_url,
+            "side": "buy",
+            "state": "queued",
+        }
+        for i in range(5)
+    ]
+
+    call_count = 0
+
+    async def fake_execute(func: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        if func is mod.rh.get_all_open_stock_orders:
+            return orders_payload
+        if func is mod.rh.get_symbol_by_url:
+            call_count += 1
+            return "AAPL"
+        raise AssertionError(f"unexpected fn: {func}")
+
+    with patch.object(
+        mod, "execute_with_retry", new=AsyncMock(side_effect=fake_execute)
+    ):
+        result = await mod.get_all_open_stock_orders()
+
+    assert call_count == 1
+    assert result["result"]["count"] == 5
+    assert all(o["symbol"] == "AAPL" for o in result["result"]["orders"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_broker_comparison_fans_out_robinhood_quotes_concurrently() -> None:
+    """The Robinhood comparison collector should not await quotes serially."""
+    from open_stocks_mcp.tools import broker_comparison_tools as mod
+
+    symbols = ["AAPL", "MSFT", "GOOGL"]
+
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def fake_get_stock_price(symbol: str) -> dict[str, Any]:
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        await asyncio.sleep(0.01)
+        async with lock:
+            in_flight -= 1
+        return {"result": {"price": 100.0, "change": 1.0, "change_percent": 0.5}}
+
+    with (
+        patch.object(
+            mod, "get_stock_price", new=AsyncMock(side_effect=fake_get_stock_price)
+        ),
+        patch.object(
+            mod,
+            "get_portfolio",
+            new=AsyncMock(return_value={"result": {"equity": 0, "buying_power": 0}}),
+        ),
+        patch.object(
+            mod,
+            "get_positions",
+            new=AsyncMock(return_value={"result": {"positions": []}}),
+        ),
+        patch.object(
+            mod,
+            "get_stock_orders",
+            new=AsyncMock(return_value={"result": {"orders": []}}),
+        ),
+    ):
+        data = await mod._collect_robinhood_comparison(
+            symbols=symbols, include_orders=False, max_orders=5
+        )
+
+    # All three symbols ran with overlapping in-flight tasks (>1 peak),
+    # proving the gather is concurrent rather than serial.
+    assert peak >= 2
+    assert set(data["pricing"].keys()) == set(symbols)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_broker_comparison_fans_out_schwab_quotes_concurrently() -> None:
+    """The Schwab comparison collector should not await quotes serially."""
+    from open_stocks_mcp.tools import broker_comparison_tools as mod
+
+    symbols = ["AAPL", "MSFT", "GOOGL"]
+
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def fake_get_schwab_quote(symbol: str) -> dict[str, Any]:
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        await asyncio.sleep(0.01)
+        async with lock:
+            in_flight -= 1
+        return {"result": {"last_price": 100.0, "change": 1.0, "change_percent": 0.5}}
+
+    with (
+        patch.object(
+            mod,
+            "get_schwab_account_numbers",
+            new=AsyncMock(return_value={"result": {"accounts": [{"hash_value": "h"}]}}),
+        ),
+        patch.object(
+            mod, "get_schwab_quote", new=AsyncMock(side_effect=fake_get_schwab_quote)
+        ),
+        patch.object(
+            mod,
+            "get_schwab_account_balances",
+            new=AsyncMock(return_value={"result": {"current_balances": {}}}),
+        ),
+        patch.object(
+            mod,
+            "get_schwab_portfolio",
+            new=AsyncMock(return_value={"result": {"positions": []}}),
+        ),
+        patch.object(
+            mod,
+            "get_schwab_orders",
+            new=AsyncMock(return_value={"result": {"orders": []}}),
+        ),
+    ):
+        data = await mod._collect_schwab_comparison(
+            symbols=symbols, include_orders=False, max_orders=5
+        )
+
+    assert peak >= 2
+    assert set(data["pricing"].keys()) == set(symbols)


### PR DESCRIPTION
Closes #986

## Changes
- New `tools/batch_fetch.py` helper: `gather_bounded` (bounded concurrent gather with `return_exceptions=True`) and `dedupe_preserving_order`. Helpers do not call `execute_with_retry` themselves so existing module-level mocks keep working.
- `broker_comparison_tools`: Robinhood and Schwab per-symbol quote loops now fan out via `gather_bounded`.
- `robinhood_account_tools.get_positions`: dedupes instrument URLs, resolves symbols concurrently, builds a URL→symbol map.
- `robinhood_dividend_tools.get_dividends` / `get_stock_loan_payments`: shared module-local `_resolve_instruments` helper deduplicates and fans out instrument lookups; both functions now share the same URL→instrument map within a request.
- `options/positions.get_open_option_positions_with_details`: `_extract_option_id` + `_resolve_option_instruments` dedupes by `option_id` and gathers fetches.
- `robinhood_trading_tools.get_all_open_stock_orders`: dedupes instrument URLs and gathers symbol lookups.
- New `tests/unit/test_batch_fetch.py`: helper unit tests + one regression per flagged call site for duplicate keys, plus a 50-row payload that exercises the concurrency cap.
- Tightened two existing tests (`test_get_positions_success`, `test_stock_loan_payments_success`) to map URL → symbol via callable `side_effect`, since concurrent gather no longer guarantees serial call order.

## Test plan
- [x] `uv run pytest tests/unit/test_batch_fetch.py -q --tb=short` — 14 passed
- [x] `uv run pytest tests/unit/ -q --tb=line` — 1386 passed, 69 skipped
- [x] `uv run ruff check src/open_stocks_mcp/tools/ tests/unit/test_batch_fetch.py tests/unit/test_account_tools.py tests/unit/test_analytics_tools.py` — clean
- [x] `uv run ruff format --check src/open_stocks_mcp/tools/ tests/unit/test_batch_fetch.py tests/unit/test_account_tools.py tests/unit/test_analytics_tools.py` — clean
- [x] `uv run mypy src/` — no issues found in 88 source files