### PR TITLE
refactor: replace shared global rate limiter with per-broker instances

### DIFF
--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -55,7 +55,6 @@ from open_stocks_mcp.tools.options.market_data import (
     get_option_historicals,
     get_option_market_data,
 )
-from open_stocks_mcp.tools.rate_limiter import configure_global_rate_limiter
 from open_stocks_mcp.tools.robinhood_account_feature_summary_tools import (
     get_account_features,
 )
@@ -2034,11 +2033,6 @@ def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:
         config = load_config()
 
     setup_logging(config)
-    configure_global_rate_limiter(
-        config.rate_limits.calls_per_minute,
-        config.rate_limits.calls_per_hour,
-        config.rate_limits.burst_size,
-    )
     setup_tracing(config)
     instrument_mcp_tool_calls(mcp)
     if config.timeout is not None:

--- a/src/open_stocks_mcp/server/http_transport.py
+++ b/src/open_stocks_mcp/server/http_transport.py
@@ -16,6 +16,7 @@ from mcp.server.fastmcp import FastMCP
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from open_stocks_mcp import __version__
+from open_stocks_mcp.brokers.registry import get_broker_registry_sync
 from open_stocks_mcp.brokers.session_state import get_session_manager
 from open_stocks_mcp.config import load_config
 from open_stocks_mcp.health import get_health_service
@@ -27,7 +28,6 @@ from open_stocks_mcp.server.tool_docs import (
     build_tool_openapi_paths,
 )
 from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 
 MAX_MCP_REQUEST_BODY_SIZE = 1024 * 1024  # 1 MiB
 
@@ -334,8 +334,7 @@ def create_http_server(
         """Lifespan context manager for startup/shutdown"""
         logger.info("Starting HTTP MCP server")
 
-        # Initialize rate limiter and session manager
-        get_rate_limiter()
+        # Initialize session manager
         get_session_manager()
         app.state.tool_docs_payload = await build_tool_docs_payload(mcp_server)
 
@@ -437,8 +436,14 @@ def create_http_server(
             metrics_collector = _require_metrics_collector()
             metrics = await metrics_collector.get_metrics()
 
-            rate_limiter = get_rate_limiter()
-            rate_stats = rate_limiter.get_stats()
+            try:
+                registry = get_broker_registry_sync()
+                rate_stats = {
+                    broker: registry.get_rate_limiter(broker).get_stats()
+                    for broker in ("robinhood", "schwab")
+                }
+            except Exception:
+                rate_stats = {}
 
             session_manager = _require_session_manager()
             session_info = session_manager.get_session_info()

--- a/src/open_stocks_mcp/server/tool_helpers.py
+++ b/src/open_stocks_mcp/server/tool_helpers.py
@@ -12,13 +12,13 @@ from mcp.server.fastmcp import FastMCP
 from open_stocks_mcp.brokers.registry import (
     RegistryNotInitializedError,
     get_broker_registry,
+    get_broker_registry_sync,
 )
 from open_stocks_mcp.brokers.session_state import get_session_manager
 from open_stocks_mcp.health import get_health_service
 from open_stocks_mcp.logging_config import logger
 from open_stocks_mcp.monitoring import get_metrics_collector
 from open_stocks_mcp.tools.circuit_breaker import get_broker_circuit_breaker
-from open_stocks_mcp.tools.rate_limiter import get_rate_limiter
 from open_stocks_mcp.tools.robinhood_tools import list_available_tools
 
 
@@ -119,21 +119,35 @@ async def get_list_brokers_data() -> dict[str, Any]:
 
 
 async def get_rate_limit_status_data() -> dict[str, Any]:
-    """Return current rate limit usage and statistics."""
+    """Return current rate limit usage and statistics, per broker."""
+    _known_brokers = ("robinhood", "schwab")
     fallback_note: str | None = None
+    broker_stats: dict[str, Any] = {}
+
     try:
-        rate_limiter = get_rate_limiter("robinhood")
+        registry = get_broker_registry_sync()
+        for broker_name in _known_brokers:
+            broker_stats[broker_name] = registry.get_rate_limiter(
+                broker_name
+            ).get_stats()
     except RegistryNotInitializedError:
         # Early startup can hit this before broker registry lifespan init.
-        rate_limiter = get_rate_limiter()
-        fallback_note = (
-            "broker registry not initialized; using global rate limiter fallback"
+        from open_stocks_mcp.tools.rate_limiter import (
+            RateLimiter,
+            get_broker_rate_limit_defaults,
         )
-    stats = rate_limiter.get_stats()
+
+        for broker_name in _known_brokers:
+            cpm, cph, burst = get_broker_rate_limit_defaults(broker_name)
+            broker_stats[broker_name] = RateLimiter(
+                calls_per_minute=cpm, calls_per_hour=cph, burst_size=burst
+            ).get_stats()
+        fallback_note = (
+            "broker registry not initialized; showing default limits without live stats"
+        )
 
     result: dict[str, Any] = {
-        **stats,
-        "endpoint_usage": stats.get("endpoint_usage", {}),
+        "brokers": broker_stats,
         "circuit_breaker": get_broker_circuit_breaker().snapshot(),
         "status": "success",
     }

--- a/tests/http_transport/test_http_auth.py
+++ b/tests/http_transport/test_http_auth.py
@@ -170,12 +170,12 @@ class TestHTTPSessionStatus:
     """Test session status reporting"""
 
     @patch("open_stocks_mcp.server.http_transport.get_session_manager")
-    @patch("open_stocks_mcp.server.http_transport.get_rate_limiter")
+    @patch("open_stocks_mcp.server.http_transport.get_broker_registry_sync")
     @patch("open_stocks_mcp.server.http_transport.get_metrics_collector")
     async def test_server_status_comprehensive(
         self,
         mock_get_metrics_collector: Mock,
-        mock_get_rate_limiter: Mock,
+        mock_get_broker_registry_sync: Mock,
         mock_get_session_manager: Mock,
         http_client: httpx.AsyncClient,
     ) -> None:
@@ -189,13 +189,21 @@ class TestHTTPSessionStatus:
         }
         mock_get_session_manager.return_value = mock_session_manager
 
-        mock_rate_limiter = Mock()
-        mock_rate_limiter.get_stats.return_value = {
-            "total_requests": 100,
-            "rate_limited_requests": 5,
-            "current_tokens": 95,
+        mock_registry = Mock()
+        mock_rh_limiter = Mock()
+        mock_rh_limiter.get_stats.return_value = {
+            "calls_last_minute": 10,
+            "limit_per_minute": 30,
         }
-        mock_get_rate_limiter.return_value = mock_rate_limiter
+        mock_schwab_limiter = Mock()
+        mock_schwab_limiter.get_stats.return_value = {
+            "calls_last_minute": 2,
+            "limit_per_minute": 120,
+        }
+        mock_registry.get_rate_limiter.side_effect = lambda name: (
+            mock_rh_limiter if name == "robinhood" else mock_schwab_limiter
+        )
+        mock_get_broker_registry_sync.return_value = mock_registry
 
         mock_metrics_collector = AsyncMock()
         mock_metrics_collector.get_metrics.return_value = {
@@ -213,7 +221,8 @@ class TestHTTPSessionStatus:
         assert data["server"]["version"] == __version__
         assert data["server"]["transport"] == "http"
         assert data["session"]["authenticated"] is True
-        assert data["rate_limiting"]["total_requests"] == 100
+        assert data["rate_limiting"]["robinhood"]["calls_last_minute"] == 10
+        assert data["rate_limiting"]["schwab"]["calls_last_minute"] == 2
         assert data["metrics"]["tool_calls"] == 50
 
     @patch("open_stocks_mcp.tools.robinhood_tools.list_available_tools")

--- a/tests/http_transport/test_http_integration.py
+++ b/tests/http_transport/test_http_integration.py
@@ -75,12 +75,12 @@ class TestHTTPIntegration:
     """Integration tests for HTTP transport functionality"""
 
     @patch("open_stocks_mcp.server.http_transport.get_session_manager")
-    @patch("open_stocks_mcp.server.http_transport.get_rate_limiter")
+    @patch("open_stocks_mcp.server.http_transport.get_broker_registry_sync")
     @patch("open_stocks_mcp.server.http_transport.get_metrics_collector")
     async def test_full_server_startup_sequence(
         self,
         mock_get_metrics_collector: Mock,
-        mock_get_rate_limiter: Mock,
+        mock_get_broker_registry_sync: Mock,
         mock_get_session_manager: Mock,
         mock_http_client: httpx.AsyncClient,
     ) -> None:
@@ -93,12 +93,14 @@ class TestHTTPIntegration:
         }
         mock_get_session_manager.return_value = mock_session_manager
 
-        mock_rate_limiter = Mock()
-        mock_rate_limiter.get_stats.return_value = {
-            "total_requests": 0,
-            "rate_limited_requests": 0,
+        mock_registry = Mock()
+        mock_limiter = Mock()
+        mock_limiter.get_stats.return_value = {
+            "calls_last_minute": 0,
+            "limit_per_minute": 30,
         }
-        mock_get_rate_limiter.return_value = mock_rate_limiter
+        mock_registry.get_rate_limiter.return_value = mock_limiter
+        mock_get_broker_registry_sync.return_value = mock_registry
 
         mock_metrics_collector = AsyncMock()
         mock_metrics_collector.get_health_status.return_value = {

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -36,7 +36,6 @@ class TestServerApp:
         with (
             patch("open_stocks_mcp.server.app.load_config") as mock_config,
             patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
-            patch("open_stocks_mcp.server.app.configure_global_rate_limiter"),
         ):
             mock_cfg = MagicMock()
             mock_cfg.otel.enabled = False
@@ -52,10 +51,7 @@ class TestServerApp:
         mock_config = MagicMock()
         mock_config.otel.enabled = False
 
-        with (
-            patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
-            patch("open_stocks_mcp.server.app.configure_global_rate_limiter"),
-        ):
+        with patch("open_stocks_mcp.server.app.setup_logging") as mock_logging:
             result = create_mcp_server(mock_config)
 
             assert result is mcp
@@ -366,7 +362,9 @@ class TestToolRegistration:
         assert "broker_health" in broker["result"]
         assert "broker_health" in metrics["result"]
         assert "account_health" in metrics["result"]
-        assert "endpoint_usage" in rate["result"]
+        assert "brokers" in rate["result"]
+        assert "robinhood" in rate["result"]["brokers"]
+        assert "endpoint_usage" in rate["result"]["brokers"]["robinhood"]
 
 
 def test_create_mcp_server_propagates_config_error() -> None:
@@ -384,22 +382,22 @@ def test_create_mcp_server_propagates_config_error() -> None:
         mock_logging.assert_not_called()
 
 
-def test_create_mcp_server_applies_rate_limiter_from_config() -> None:
+def test_create_mcp_server_does_not_configure_global_rate_limiter() -> None:
+    """Per-broker design: create_mcp_server must not set up a shared global rate limiter."""
     mock_config = MagicMock()
     mock_config.otel.enabled = False
-    mock_config.rate_limits.calls_per_minute = 77
-    mock_config.rate_limits.calls_per_hour = 1700
-    mock_config.rate_limits.burst_size = 13
 
-    with (
-        patch("open_stocks_mcp.server.app.setup_logging") as mock_logging,
-        patch("open_stocks_mcp.server.app.configure_global_rate_limiter") as mock_rl,
-    ):
+    with patch("open_stocks_mcp.server.app.setup_logging"):
         result = create_mcp_server(mock_config)
 
     assert result is mcp
-    mock_logging.assert_called_once_with(mock_config)
-    mock_rl.assert_called_once_with(77, 1700, 13)
+    # Verify the old global rate-limiter path is gone — import should fail.
+    import importlib
+
+    app_mod = importlib.import_module("open_stocks_mcp.server.app")
+    assert not hasattr(app_mod, "configure_global_rate_limiter"), (
+        "configure_global_rate_limiter should not be re-exported from app"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_tool_helpers.py
+++ b/tests/server/test_tool_helpers.py
@@ -136,44 +136,45 @@ class TestRateLimitStatusHelper:
 
     @pytest.mark.asyncio
     async def test_returns_rate_limiter_stats(self) -> None:
-        with patch(
-            "open_stocks_mcp.server.tool_helpers.get_rate_limiter"
-        ) as mock_get_rl:
-            rl = MagicMock()
-            rl.get_stats.return_value = {"requests_made": 5, "limit": 100}
-            mock_get_rl.return_value = rl
+        rh_stats = {"calls_last_minute": 5, "limit_per_minute": 30}
+        schwab_stats = {"calls_last_minute": 2, "limit_per_minute": 120}
 
+        mock_registry = MagicMock()
+        mock_rh = MagicMock()
+        mock_rh.get_stats.return_value = rh_stats
+        mock_schwab = MagicMock()
+        mock_schwab.get_stats.return_value = schwab_stats
+        mock_registry.get_rate_limiter.side_effect = lambda name: (
+            mock_rh if name == "robinhood" else mock_schwab
+        )
+
+        with patch(
+            "open_stocks_mcp.server.tool_helpers.get_broker_registry_sync",
+            return_value=mock_registry,
+        ):
             response = await get_rate_limit_status_data()
 
-        mock_get_rl.assert_called_once_with("robinhood")
-
         assert response["result"]["status"] == "success"
-        assert response["result"]["requests_made"] == 5
-        assert response["result"]["limit"] == 100
+        assert "brokers" in response["result"]
+        assert response["result"]["brokers"]["robinhood"]["calls_last_minute"] == 5
+        assert response["result"]["brokers"]["schwab"]["calls_last_minute"] == 2
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_global_limiter_when_registry_uninitialized(
+    async def test_falls_back_to_default_limits_when_registry_uninitialized(
         self,
     ) -> None:
-        global_limiter = MagicMock()
-        global_limiter.get_stats.return_value = {"requests_made": 7, "limit": 99}
-
         with patch(
-            "open_stocks_mcp.server.tool_helpers.get_rate_limiter"
-        ) as mock_get_rl:
-            mock_get_rl.side_effect = [
-                RegistryNotInitializedError("not initialized"),
-                global_limiter,
-            ]
-
+            "open_stocks_mcp.server.tool_helpers.get_broker_registry_sync",
+            side_effect=RegistryNotInitializedError("not initialized"),
+        ):
             response = await get_rate_limit_status_data()
 
-        assert mock_get_rl.call_args_list[0].args == ("robinhood",)
-        assert mock_get_rl.call_args_list[1].args == ()
         assert response["result"]["status"] == "success"
-        assert response["result"]["requests_made"] == 7
-        assert response["result"]["limit"] == 99
-        assert "global rate limiter fallback" in response["result"]["note"]
+        assert "brokers" in response["result"]
+        assert "robinhood" in response["result"]["brokers"]
+        assert "schwab" in response["result"]["brokers"]
+        assert "note" in response["result"]
+        assert "not initialized" in response["result"]["note"]
 
 
 @pytest.mark.journey_system

--- a/tests/unit/test_stock_market_tools.py
+++ b/tests/unit/test_stock_market_tools.py
@@ -531,14 +531,15 @@ class TestServerTools:
 
     @pytest.mark.journey_system
     @pytest.mark.unit
-    @patch("open_stocks_mcp.server.tool_helpers.get_rate_limiter")
+    @patch("open_stocks_mcp.server.tool_helpers.get_broker_registry_sync")
     @pytest.mark.asyncio
-    async def test_rate_limit_status_success(self, mock_get_rate_limiter: Any) -> None:
-        """Test successful rate limit status retrieval."""
+    async def test_rate_limit_status_success(
+        self, mock_get_broker_registry_sync: Any
+    ) -> None:
+        """Test successful rate limit status retrieval returns per-broker stats."""
         from open_stocks_mcp.server.app import rate_limit_status
 
-        mock_rate_limiter = MagicMock()
-        mock_rate_limiter.get_stats.return_value = {
+        rh_stats = {
             "calls_last_minute": 5,
             "calls_last_hour": 150,
             "limit_per_minute": 30,
@@ -546,16 +547,34 @@ class TestServerTools:
             "minute_usage_percent": 16.67,
             "hour_usage_percent": 15.0,
         }
-        mock_get_rate_limiter.return_value = mock_rate_limiter
+        schwab_stats = {
+            "calls_last_minute": 2,
+            "calls_last_hour": 40,
+            "limit_per_minute": 120,
+            "limit_per_hour": 3600,
+            "minute_usage_percent": 1.67,
+            "hour_usage_percent": 1.11,
+        }
+
+        mock_registry = MagicMock()
+        mock_rh_limiter = MagicMock()
+        mock_rh_limiter.get_stats.return_value = rh_stats
+        mock_schwab_limiter = MagicMock()
+        mock_schwab_limiter.get_stats.return_value = schwab_stats
+        mock_registry.get_rate_limiter.side_effect = lambda name: (
+            mock_rh_limiter if name == "robinhood" else mock_schwab_limiter
+        )
+        mock_get_broker_registry_sync.return_value = mock_registry
 
         result = await rate_limit_status()
 
         assert "result" in result
-        assert result["result"]["calls_last_minute"] == 5
-        assert result["result"]["calls_last_hour"] == 150
-        assert result["result"]["limit_per_minute"] == 30
-        assert result["result"]["minute_usage_percent"] == 16.67
         assert result["result"]["status"] == "success"
+        assert "brokers" in result["result"]
+        assert result["result"]["brokers"]["robinhood"]["calls_last_minute"] == 5
+        assert result["result"]["brokers"]["robinhood"]["limit_per_minute"] == 30
+        assert result["result"]["brokers"]["schwab"]["calls_last_minute"] == 2
+        assert result["result"]["brokers"]["schwab"]["limit_per_minute"] == 120
 
     @pytest.mark.journey_system
     @pytest.mark.unit


### PR DESCRIPTION
Closes #990

## Changes
- Removed `configure_global_rate_limiter()` call from `create_mcp_server()` in `server/app.py` — the per-broker registry already creates instances on demand with correct defaults; the global was never used for actual API calls
- Removed global `get_rate_limiter()` warmup from HTTP transport lifespan (no-op for real throttling)
- Updated `GET /status` endpoint to report per-broker rate limiter stats (`rate_limiting.robinhood.*` and `rate_limiting.schwab.*`) instead of the shared global counter
- Updated `rate_limit_status` MCP tool (`get_rate_limit_status_data`) to collect stats from `BrokerRegistry.get_rate_limiter(broker_name)` for both brokers, with a fallback that shows default limits when the registry hasn't initialized yet
- Updated all affected tests to reflect the new per-broker response shape

## Why
The old `configure_global_rate_limiter()` path wired up a single `RateLimiter` initialized with Robinhood's config. The `/status` endpoint and `rate_limit_status` MCP tool read from this global — so Schwab call stats were invisible, and operators had no per-broker visibility. Actual API calls already went through the correct per-broker path (`BrokerRegistry.get_rate_limiter`); this change removes the misleading parallel global path and surfaces real per-broker data.

## Test plan
- `pytest tests/unit/test_config.py tests/unit/test_simple_rate_limiter.py tests/unit/test_rate_limiter_isolation.py tests/server/test_server_app.py` — all pass
- `pytest -m "not slow and not exception_test and not rate_limited and not performance and not live_market"` — 1592 passed, 0 failed