### PR TITLE
docs: remove praise wording from docker example

### DIFF
--- a/examples/open-stocks-mcp-docker/README.md
+++ b/examples/open-stocks-mcp-docker/README.md
@@ -4,7 +4,7 @@ This directory contains a complete example of how to run the Open Stocks MCP ser
 
 ## Architecture
 
-This setup uses a production-ready approach:
+This setup provides:
 1. **Dockerfile**: Creates a secure base image with the `open-stocks-mcp` library installed and verified
 2. **docker-compose.yml**: Orchestrates the server deployment with HTTP transport and proper configuration
 3. **Enhanced Authentication**: Automatic device verification and MFA support for seamless Robinhood integration


### PR DESCRIPTION
Closes #1002

## Changes
- Replaced `production-ready` wording in the Docker example architecture section with neutral, concrete phrasing.
- Kept the change scoped to the single slop-scan finding in the issue.

## Test plan
- rg -n "production-ready" examples/open-stocks-mcp-docker/README.md (expect no matches)
- Review the architecture section in examples/open-stocks-mcp-docker/README.md