### PR TITLE
docs: replace credential placeholders with angle-bracket style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,14 @@ and `RUN_RATE_LIMITED=1 --run-live-market` were explicitly provided.
 
 ### Required for Robinhood Live Testing
 ```bash
-ROBINHOOD_USERNAME="email@example.com"
-ROBINHOOD_PASSWORD="password"
+ROBINHOOD_USERNAME="<robinhood-email>"
+ROBINHOOD_PASSWORD="<robinhood-password>"
 ```
 
 ### Required for Schwab Live Testing
 ```bash
-SCHWAB_API_KEY="your-api-key"
-SCHWAB_APP_SECRET="your-app-secret"
+SCHWAB_API_KEY="<schwab-api-key>"
+SCHWAB_APP_SECRET="<schwab-app-secret>"
 SCHWAB_CALLBACK_URL="https://127.0.0.1:8182/"
 SCHWAB_TOKEN_PATH="~/.tokens/schwab_token.json"
 ENABLED_BROKERS="robinhood,schwab"
@@ -175,9 +175,9 @@ Docker or CI runs should mount a token that was created interactively first.
 
 ### Required for ADK Evaluation  
 ```bash
-GOOGLE_API_KEY="your-google-api-key"
-ROBINHOOD_USERNAME="email@example.com" 
-ROBINHOOD_PASSWORD="password"
+GOOGLE_API_KEY="<google-api-key>"
+ROBINHOOD_USERNAME="<robinhood-email>"
+ROBINHOOD_PASSWORD="<robinhood-password>"
 # Include Schwab variables above when evaluating Schwab tools.
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Create a `.env` file:
 
 **For Robinhood:**
 ```bash
-ROBINHOOD_USERNAME=your_email@example.com
-ROBINHOOD_PASSWORD=your_password
+ROBINHOOD_USERNAME=<robinhood-email>
+ROBINHOOD_PASSWORD=<robinhood-password>
 ```
 
 **For Schwab (optional):**
@@ -320,9 +320,9 @@ See `config.yaml.example` for the supported schema.
 ### Google ADK Evaluation
 ```bash
 # Set environment variables
-export GOOGLE_API_KEY="your-google-api-key"
-export ROBINHOOD_USERNAME="email@example.com"
-export ROBINHOOD_PASSWORD="password"
+export GOOGLE_API_KEY="<google-api-key>"
+export ROBINHOOD_USERNAME="<robinhood-email>"
+export ROBINHOOD_PASSWORD="<robinhood-password>"
 
 # Start Docker server
 cd examples/open-stocks-mcp-docker && docker-compose up -d

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -107,8 +107,8 @@ tests/
 ### Environment Variables
 For integration tests, set:
 ```bash
-ROBINHOOD_USERNAME="email@example.com"
-ROBINHOOD_PASSWORD="password"
+ROBINHOOD_USERNAME="<robinhood-email>"
+ROBINHOOD_PASSWORD="<robinhood-password>"
 ```
 
 ### Test Commands

--- a/examples/google_adk_agent/README.md
+++ b/examples/google_adk_agent/README.md
@@ -10,16 +10,16 @@ A comprehensive stock trading agent that uses Google ADK to connect with our ope
 2. **Install open-stocks-mcp**: This package should be available in your environment
 3. **Set up environment variables**:
    ```bash
-   export GOOGLE_API_KEY="your-google-api-key"
+   export GOOGLE_API_KEY="<google-api-key>"
    export GOOGLE_MODEL="gemini-2.0-flash"  # Optional, defaults to gemini-2.0-flash
    
    # For Robinhood authentication (optional - enables environment-based login)
-   export ROBINHOOD_USERNAME="your_email@example.com"
-   export ROBINHOOD_PASSWORD="your_robinhood_password"
+   export ROBINHOOD_USERNAME="<robinhood-email>"
+   export ROBINHOOD_PASSWORD="<robinhood-password>"
    
    # For Schwab authentication (optional - enables Schwab tools)
-   export SCHWAB_API_KEY="your-schwab-api-key"
-   export SCHWAB_APP_SECRET="your-schwab-app-secret"
+   export SCHWAB_API_KEY="<schwab-api-key>"
+   export SCHWAB_APP_SECRET="<schwab-app-secret>"
    export SCHWAB_CALLBACK_URL="https://127.0.0.1"
    export SCHWAB_TOKEN_PATH="schwab_token.json"
    export ENABLED_BROKERS="robinhood,schwab"
@@ -30,11 +30,11 @@ A comprehensive stock trading agent that uses Google ADK to connect with our ope
 
    Or create a `.env` file in the project root:
    ```
-   GOOGLE_API_KEY=your-google-api-key
-   ROBINHOOD_USERNAME=your_email@example.com
-   ROBINHOOD_PASSWORD=your_robinhood_password
-   SCHWAB_API_KEY=your-schwab-api-key
-   SCHWAB_APP_SECRET=your-schwab-app-secret
+   GOOGLE_API_KEY=<google-api-key>
+   ROBINHOOD_USERNAME=<robinhood-email>
+   ROBINHOOD_PASSWORD=<robinhood-password>
+   SCHWAB_API_KEY=<schwab-api-key>
+   SCHWAB_APP_SECRET=<schwab-app-secret>
    SCHWAB_CALLBACK_URL=https://127.0.0.1
    SCHWAB_TOKEN_PATH=schwab_token.json
    ENABLED_BROKERS=robinhood,schwab

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -47,20 +47,20 @@ The Secret is intentionally excluded from `kustomization.yaml` to prevent placeh
 
 ```bash
 kubectl create secret generic open-stocks-mcp-secrets \
-  --from-literal=ROBINHOOD_USERNAME='your-email@example.com' \
-  --from-literal=ROBINHOOD_PASSWORD='your-password' \
-  --from-literal=MCP_API_KEY='a-long-random-secret'
+  --from-literal=ROBINHOOD_USERNAME='<robinhood-email>' \
+  --from-literal=ROBINHOOD_PASSWORD='<robinhood-password>' \
+  --from-literal=MCP_API_KEY='<generate-a-long-random-secret>'
 ```
 
 For Schwab credentials, add them to the same secret:
 
 ```bash
 kubectl create secret generic open-stocks-mcp-secrets \
-  --from-literal=ROBINHOOD_USERNAME='your-email@example.com' \
-  --from-literal=ROBINHOOD_PASSWORD='your-password' \
-  --from-literal=MCP_API_KEY='a-long-random-secret' \
-  --from-literal=SCHWAB_API_KEY='your-api-key' \
-  --from-literal=SCHWAB_APP_SECRET='your-app-secret' \
+  --from-literal=ROBINHOOD_USERNAME='<robinhood-email>' \
+  --from-literal=ROBINHOOD_PASSWORD='<robinhood-password>' \
+  --from-literal=MCP_API_KEY='<generate-a-long-random-secret>' \
+  --from-literal=SCHWAB_API_KEY='<schwab-api-key>' \
+  --from-literal=SCHWAB_APP_SECRET='<schwab-app-secret>' \
   --from-literal=SCHWAB_CALLBACK_URL='https://127.0.0.1:8182/' \
   --from-literal=SCHWAB_TOKEN_PATH='/home/mcp/.tokens/schwab_token.json'
 ```


### PR DESCRIPTION
Closes #1001

## Changes
- Convert `"password"` → `"<robinhood-password>"` for `ROBINHOOD_PASSWORD` across all docs
- Convert `"your-api-key"` → `"<schwab-api-key>"` for `SCHWAB_API_KEY`
- Convert `"your-app-secret"` → `"<schwab-app-secret>"` for `SCHWAB_APP_SECRET`
- Convert `"your-google-api-key"` → `"<google-api-key>"` for `GOOGLE_API_KEY`
- Convert `'a-long-random-secret'` → `'<generate-a-long-random-secret>'` for `MCP_API_KEY`
- Applied consistently across: `CLAUDE.md`, `README.md`, `contributing/README.md`, `examples/google_adk_agent/README.md`, `examples/kubernetes/README.md`

## Test plan
- No code changes — documentation only
- Verified no old-style placeholder patterns remain in affected files
- Angle-bracket style is clearly non-literal and won't trigger secret-scanner false positives