### PR TITLE
feat: implement pluggable broker architecture

### DIFF
--- a/src/open_stocks_mcp/brokers/factory.py
+++ b/src/open_stocks_mcp/brokers/factory.py
@@ -1,0 +1,146 @@
+"""Pluggable broker factory registry.
+
+New brokers can be added without modifying core server code by:
+1. Subclassing BaseBroker
+2. Implementing a BrokerFactory function (BrokerBuildContext -> BaseBroker | None)
+3. Calling register_broker_factory("name", factory_fn) at module load time
+
+The server's setup_brokers() iterates enabled_brokers and dispatches through
+this registry, so no changes to server/app.py or config.py are required.
+
+Example (third-party broker plugin)::
+
+    from open_stocks_mcp.brokers.factory import register_broker_factory, BrokerBuildContext
+
+    class AlpacaBroker(BaseBroker):
+        ...
+
+    def _build_alpaca(ctx: BrokerBuildContext) -> AlpacaBroker | None:
+        api_key = ctx.cli_credentials.get("alpaca_api_key")
+        if not api_key:
+            return None
+        return AlpacaBroker(api_key=api_key)
+
+    register_broker_factory("alpaca", _build_alpaca)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from open_stocks_mcp.brokers.base import BaseBroker
+    from open_stocks_mcp.config import ServerConfig
+
+BrokerFactory = Callable[["BrokerBuildContext"], "BaseBroker | None"]
+
+_BROKER_FACTORIES: dict[str, BrokerFactory] = {}
+
+
+@dataclass
+class BrokerBuildContext:
+    """Context passed to each broker factory during server startup."""
+
+    config: ServerConfig
+    cli_credentials: dict[str, str] = field(default_factory=dict)
+
+
+def register_broker_factory(name: str, factory: BrokerFactory) -> None:
+    """Register a factory function for a named broker.
+
+    The factory receives a BrokerBuildContext and returns a configured
+    BaseBroker instance, or None if the broker cannot be built (e.g.
+    missing credentials).
+
+    Args:
+        name: Broker identifier (e.g. "alpaca"). Must be lowercase.
+        factory: Callable that builds and returns the broker.
+    """
+    _BROKER_FACTORIES[name.lower()] = factory
+
+
+def get_registered_broker_names() -> frozenset[str]:
+    """Return the set of broker names that have a registered factory."""
+    return frozenset(_BROKER_FACTORIES)
+
+
+def is_broker_factory_registered(name: str) -> bool:
+    """Return True if a factory is registered for the given broker name."""
+    return name.lower() in _BROKER_FACTORIES
+
+
+def build_broker(name: str, ctx: BrokerBuildContext) -> BaseBroker | None:
+    """Build a broker instance using the registered factory.
+
+    Args:
+        name: Broker name (e.g. "robinhood", "schwab").
+        ctx: Build context containing server config and CLI credentials.
+
+    Returns:
+        Configured broker instance, or None if no factory is registered
+        or the factory decides the broker cannot be built (missing credentials).
+    """
+    factory = _BROKER_FACTORIES.get(name.lower())
+    if factory is None:
+        return None
+    return factory(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Built-in broker factories
+# These use lazy imports so that broker modules are not imported until needed,
+# and so that this file can be imported without triggering the full broker
+# dependency chain.
+# ---------------------------------------------------------------------------
+
+
+def _build_robinhood(ctx: BrokerBuildContext) -> BaseBroker | None:
+    from open_stocks_mcp.logging_config import logger
+
+    username = (
+        ctx.cli_credentials.get("username") or ctx.config.brokers.robinhood.username
+    )
+    password = (
+        ctx.cli_credentials.get("password") or ctx.config.brokers.robinhood.password
+    )
+    if not username or not password:
+        logger.warning(
+            "⚠️  Robinhood credentials not provided - skipping Robinhood integration"
+        )
+        logger.info(
+            "   Set ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD to enable Robinhood"
+        )
+        return None
+    from open_stocks_mcp.brokers.robinhood import RobinhoodBroker
+    from open_stocks_mcp.tools.session_manager import get_session_manager
+
+    return RobinhoodBroker(
+        username=username,
+        password=password,
+        session_manager=get_session_manager(),
+    )
+
+
+def _build_schwab(ctx: BrokerBuildContext) -> BaseBroker | None:
+    from open_stocks_mcp.logging_config import logger
+
+    sc = ctx.config.brokers.schwab
+    if not sc.api_key or not sc.app_secret:
+        logger.info(
+            "Schwab enablement gate honored but Schwab credentials not configured - skipping"
+        )
+        return None
+    from open_stocks_mcp.brokers.schwab import SchwabBroker
+
+    return SchwabBroker(
+        api_key=sc.api_key,
+        app_secret=sc.app_secret,
+        callback_url=sc.callback_url,
+        token_path=sc.token_path,
+    )
+
+
+register_broker_factory("robinhood", _build_robinhood)
+register_broker_factory("schwab", _build_schwab)

--- a/src/open_stocks_mcp/config.py
+++ b/src/open_stocks_mcp/config.py
@@ -271,7 +271,7 @@ class SchwabConfig:
     token_path: str | None = None
 
 
-_KNOWN_BROKERS: frozenset[str] = frozenset({"robinhood", "schwab"})
+_BUILTIN_BROKERS: frozenset[str] = frozenset({"robinhood", "schwab"})
 
 
 @dataclass
@@ -338,7 +338,9 @@ def _parse_enabled_brokers_config(
 ) -> list[str]:
     """Parse ENABLED_BROKERS env var or YAML list into a normalized broker list.
 
-    Unknown names are warned-and-dropped. Empty result is allowed.
+    Unrecognised broker names are passed through with a warning so that
+    third-party broker plugins (registered via the factory registry) can be
+    enabled without modifying this file.  Empty result is allowed.
     """
     if raw is not None:
         tokens = [t.strip().lower() for t in raw.split(",") if t.strip()]
@@ -353,14 +355,14 @@ def _parse_enabled_brokers_config(
         if name in seen:
             continue
         seen.add(name)
-        if name not in _KNOWN_BROKERS:
+        if name not in _BUILTIN_BROKERS:
             _config_logger.warning(
-                "Unknown broker '%s' in ENABLED_BROKERS; ignoring. Known brokers: %s",
+                "Broker '%s' is not a built-in broker. It will be enabled if a "
+                "factory is registered for it. Built-in brokers: %s",
                 name,
-                sorted(_KNOWN_BROKERS),
+                sorted(_BUILTIN_BROKERS),
             )
-        else:
-            result.append(name)
+        result.append(name)
     return result
 
 

--- a/src/open_stocks_mcp/server/app.py
+++ b/src/open_stocks_mcp/server/app.py
@@ -10,9 +10,12 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 from open_stocks_mcp.brokers.auth_coordinator import attempt_broker_logins
+from open_stocks_mcp.brokers.factory import (
+    BrokerBuildContext,
+    build_broker,
+    is_broker_factory_registered,
+)
 from open_stocks_mcp.brokers.registry import get_broker_registry
-from open_stocks_mcp.brokers.robinhood import RobinhoodBroker
-from open_stocks_mcp.brokers.schwab import SchwabBroker
 from open_stocks_mcp.config import ServerConfig, load_config
 from open_stocks_mcp.logging_config import logger, setup_logging
 from open_stocks_mcp.server.tool_execution_limits import install_tool_execution_limit
@@ -2046,46 +2049,6 @@ def create_mcp_server(config: ServerConfig | None = None) -> FastMCP:
     return mcp
 
 
-KNOWN_BROKERS = {"robinhood", "schwab"}
-
-
-def _parse_enabled_brokers(raw: str | None) -> list[str]:
-    """Parse comma-separated list of enabled brokers.
-
-    Args:
-        raw: Raw environment variable value
-
-    Returns:
-        List of normalized broker names
-    """
-    if raw is None:
-        return ["robinhood"]
-
-    tokens = [t.strip().lower() for t in raw.split(",") if t.strip()]
-    return list(dict.fromkeys(tokens))
-
-
-def _apply_default_broker(registry: Any, raw: str | None) -> None:
-    """Apply the default broker if specified.
-
-    Args:
-        registry: Broker registry
-        raw: Raw environment variable value
-    """
-    if not raw:
-        return
-
-    name = raw.strip().lower()
-    registered = registry.list_brokers()
-
-    if name in registered:
-        registry.set_active_broker(name)
-    else:
-        logger.warning(
-            f"⚠️  DEFAULT_BROKER '{name}' not in registered brokers: {registered}"
-        )
-
-
 async def setup_brokers(
     username: str | None,
     password: str | None,
@@ -2113,50 +2076,38 @@ async def setup_brokers(
     # Use centralized broker config for enabled brokers
     enabled = config.brokers.enabled_brokers
 
-    # Setup Robinhood broker if enabled
-    if "robinhood" in enabled:
-        # CLI credentials override configured credentials
-        rh_username = username or config.brokers.robinhood.username
-        rh_password = password or config.brokers.robinhood.password
-        if rh_username and rh_password:
-            logger.info("Configuring Robinhood broker...")
-            session_manager = get_session_manager()
-            robinhood_broker = RobinhoodBroker(
-                username=rh_username,
-                password=rh_password,
-                session_manager=session_manager,
-            )
-            registry.register(robinhood_broker)
-            logger.info("✓ Robinhood broker registered")
-        else:
-            logger.warning(
-                "⚠️  Robinhood credentials not provided - skipping Robinhood integration"
-            )
-            logger.info(
-                "   Set ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD to enable Robinhood"
-            )
-    elif username or password:
+    # Warn if Robinhood credentials were supplied on CLI but Robinhood is disabled
+    if (username or password) and "robinhood" not in enabled:
         logger.info(
             "Robinhood credentials supplied but Robinhood is disabled via ENABLED_BROKERS"
         )
 
-    # Setup Schwab broker if enabled
-    if "schwab" in enabled:
-        sc = config.brokers.schwab
-        if sc.api_key and sc.app_secret:
-            logger.info("Configuring Schwab broker...")
-            schwab_broker = SchwabBroker(
-                api_key=sc.api_key,
-                app_secret=sc.app_secret,
-                callback_url=sc.callback_url,
-                token_path=sc.token_path,
+    # Build context: carries CLI overrides so broker factories can merge them with config
+    ctx = BrokerBuildContext(
+        config=config,
+        cli_credentials={
+            k: v for k, v in {"username": username, "password": password}.items() if v
+        },
+    )
+
+    # Dispatch each enabled broker through the factory registry.
+    # Built-in brokers (robinhood, schwab) self-register their factories when their
+    # modules are imported at the top of this file.  Third-party brokers can be
+    # added without modifying this file by calling register_broker_factory() before
+    # the server starts.
+    for broker_name in enabled:
+        if not is_broker_factory_registered(broker_name):
+            logger.warning(
+                f"⚠️  No factory registered for broker '{broker_name}' — skipping. "
+                "Register a factory via "
+                "open_stocks_mcp.brokers.factory.register_broker_factory()."
             )
-            registry.register(schwab_broker)
-            logger.info("✓ Schwab broker registered")
-        else:
-            logger.info(
-                "Schwab enablement gate honored, but Schwab registration is tracked in #54"
-            )
+            continue
+        logger.info(f"Configuring {broker_name} broker...")
+        broker = build_broker(broker_name, ctx)
+        if broker is not None:
+            registry.register(broker)
+            logger.info(f"✓ {broker_name} broker registered")
 
     # Apply default broker from centralized config
     default = config.brokers.default_broker

--- a/tests/server/test_server_app.py
+++ b/tests/server/test_server_app.py
@@ -430,8 +430,7 @@ async def test_setup_brokers_registers_robinhood_when_flag_enabled() -> None:
             AsyncMock(return_value=mock_registry),
         ),
         patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
-        patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
-        patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+        patch("open_stocks_mcp.server.app.build_broker", return_value=MagicMock()),
     ):
         await setup_brokers("user", "pass", config=config)
 
@@ -454,7 +453,7 @@ async def test_setup_brokers_registers_schwab_when_enabled_and_configured() -> N
             AsyncMock(return_value=mock_registry),
         ),
         patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
-        patch("open_stocks_mcp.server.app.SchwabBroker", MagicMock()),
+        patch("open_stocks_mcp.server.app.build_broker", return_value=MagicMock()),
     ):
         await setup_brokers(None, None, config=config)
 
@@ -477,8 +476,7 @@ class TestSetupBrokers:
                 "open_stocks_mcp.server.app.get_broker_registry",
                 AsyncMock(return_value=mock_registry),
             ),
-            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
-            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.build_broker", return_value=MagicMock()),
             patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
         ):
             await setup_brokers("user", "pass")
@@ -500,13 +498,12 @@ class TestSetupBrokers:
                 "open_stocks_mcp.server.app.get_broker_registry",
                 AsyncMock(return_value=mock_registry),
             ),
-            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
-            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.build_broker", return_value=None),
             patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
         ):
             await setup_brokers("user", "pass")
 
-        # Should NOT register Robinhood
+        # Should NOT register anything (schwab factory returns None for unconfigured schwab)
         mock_registry.register.assert_not_called()
 
     @pytest.mark.asyncio
@@ -535,19 +532,27 @@ class TestSetupBrokers:
         monkeypatch.setenv("ENABLED_BROKERS", " Robinhood , schwab ")
         mock_registry = MagicMock()
         mock_registry.register = MagicMock()
+        call_count = 0
+
+        def _fake_build(name, ctx):
+            nonlocal call_count
+            if name == "robinhood":
+                call_count += 1
+                return MagicMock()
+            return None
 
         with (
             patch(
                 "open_stocks_mcp.server.app.get_broker_registry",
                 AsyncMock(return_value=mock_registry),
             ),
-            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
-            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.build_broker", side_effect=_fake_build),
             patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
         ):
             await setup_brokers("user", "pass")
 
-        # Robinhood should be registered
+        # Robinhood should be registered; schwab returns None (not configured)
+        assert call_count == 1
         mock_registry.register.assert_called_once()
 
     @pytest.mark.asyncio
@@ -563,13 +568,17 @@ class TestSetupBrokers:
 
         caplog.set_level(logging.WARNING, logger="open_stocks_mcp")
 
+        def _fake_build(name, ctx):
+            if name == "robinhood":
+                return MagicMock()
+            return None
+
         with (
             patch(
                 "open_stocks_mcp.server.app.get_broker_registry",
                 AsyncMock(return_value=mock_registry),
             ),
-            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
-            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.build_broker", side_effect=_fake_build),
             patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
         ):
             await setup_brokers("user", "pass")
@@ -591,8 +600,7 @@ class TestSetupBrokers:
                 "open_stocks_mcp.server.app.get_broker_registry",
                 AsyncMock(return_value=mock_registry),
             ),
-            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
-            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.build_broker", return_value=MagicMock()),
             patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
         ):
             await setup_brokers("user", "pass")
@@ -618,8 +626,7 @@ class TestSetupBrokers:
                 "open_stocks_mcp.server.app.get_broker_registry",
                 AsyncMock(return_value=mock_registry),
             ),
-            patch("open_stocks_mcp.server.app.RobinhoodBroker", MagicMock()),
-            patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+            patch("open_stocks_mcp.server.app.build_broker", return_value=MagicMock()),
             patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
         ):
             await setup_brokers("user", "pass")
@@ -630,7 +637,7 @@ class TestSetupBrokers:
 
 @pytest.mark.asyncio
 async def test_setup_brokers_uses_configured_robinhood_credentials() -> None:
-    """setup_brokers uses config.brokers.robinhood credentials when no CLI args given."""
+    """setup_brokers passes config credentials in BrokerBuildContext when no CLI args."""
     config = ServerConfig(
         brokers=BrokerSettings(
             enabled_brokers=["robinhood"],
@@ -638,7 +645,11 @@ async def test_setup_brokers_uses_configured_robinhood_credentials() -> None:
         )
     )
     mock_registry = MagicMock()
-    mock_rh_broker_cls = MagicMock()
+    captured: list = []
+
+    def _fake_build(name, ctx):
+        captured.append(ctx)
+        return MagicMock()
 
     with (
         patch(
@@ -646,21 +657,22 @@ async def test_setup_brokers_uses_configured_robinhood_credentials() -> None:
             AsyncMock(return_value=mock_registry),
         ),
         patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
-        patch("open_stocks_mcp.server.app.RobinhoodBroker", mock_rh_broker_cls),
-        patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+        patch("open_stocks_mcp.server.app.build_broker", side_effect=_fake_build),
     ):
         await setup_brokers(None, None, config=config)
 
-    mock_rh_broker_cls.assert_called_once()
-    call_kwargs = mock_rh_broker_cls.call_args[1]
-    assert call_kwargs["username"] == "cfg_user"
-    assert call_kwargs["password"] == "cfg_pass"
+    assert len(captured) == 1
+    ctx = captured[0]
+    # No CLI credentials provided: factory receives empty cli_credentials and must use config
+    assert ctx.cli_credentials == {}
+    assert ctx.config.brokers.robinhood.username == "cfg_user"
+    assert ctx.config.brokers.robinhood.password == "cfg_pass"
     mock_registry.register.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_setup_brokers_cli_credentials_override_config() -> None:
-    """CLI username/password override configured Robinhood credentials."""
+    """CLI username/password are placed in cli_credentials, overriding config in the factory."""
     config = ServerConfig(
         brokers=BrokerSettings(
             enabled_brokers=["robinhood"],
@@ -668,7 +680,11 @@ async def test_setup_brokers_cli_credentials_override_config() -> None:
         )
     )
     mock_registry = MagicMock()
-    mock_rh_broker_cls = MagicMock()
+    captured: list = []
+
+    def _fake_build(name, ctx):
+        captured.append(ctx)
+        return MagicMock()
 
     with (
         patch(
@@ -676,19 +692,18 @@ async def test_setup_brokers_cli_credentials_override_config() -> None:
             AsyncMock(return_value=mock_registry),
         ),
         patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
-        patch("open_stocks_mcp.server.app.RobinhoodBroker", mock_rh_broker_cls),
-        patch("open_stocks_mcp.server.app.get_session_manager", MagicMock()),
+        patch("open_stocks_mcp.server.app.build_broker", side_effect=_fake_build),
     ):
         await setup_brokers("cli_user", "cli_pass", config=config)
 
-    call_kwargs = mock_rh_broker_cls.call_args[1]
-    assert call_kwargs["username"] == "cli_user"
-    assert call_kwargs["password"] == "cli_pass"
+    assert len(captured) == 1
+    ctx = captured[0]
+    assert ctx.cli_credentials == {"username": "cli_user", "password": "cli_pass"}
 
 
 @pytest.mark.asyncio
 async def test_setup_brokers_schwab_uses_broker_config_settings() -> None:
-    """setup_brokers passes centralized Schwab settings to SchwabBroker."""
+    """setup_brokers passes the full Schwab config in BrokerBuildContext."""
     config = ServerConfig(
         brokers=BrokerSettings(
             enabled_brokers=["schwab"],
@@ -701,7 +716,11 @@ async def test_setup_brokers_schwab_uses_broker_config_settings() -> None:
         )
     )
     mock_registry = MagicMock()
-    mock_schwab_cls = MagicMock()
+    captured: list = []
+
+    def _fake_build(name, ctx):
+        captured.append((name, ctx))
+        return MagicMock()
 
     with (
         patch(
@@ -709,16 +728,18 @@ async def test_setup_brokers_schwab_uses_broker_config_settings() -> None:
             AsyncMock(return_value=mock_registry),
         ),
         patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
-        patch("open_stocks_mcp.server.app.SchwabBroker", mock_schwab_cls),
+        patch("open_stocks_mcp.server.app.build_broker", side_effect=_fake_build),
     ):
         await setup_brokers(None, None, config=config)
 
-    mock_schwab_cls.assert_called_once_with(
-        api_key="mykey",
-        app_secret="mysecret",
-        callback_url="https://my.cb/",
-        token_path="/tmp/tok.json",
-    )
+    assert len(captured) == 1
+    name, ctx = captured[0]
+    assert name == "schwab"
+    sc = ctx.config.brokers.schwab
+    assert sc.api_key == "mykey"
+    assert sc.app_secret == "mysecret"
+    assert sc.callback_url == "https://my.cb/"
+    assert sc.token_path == "/tmp/tok.json"
     mock_registry.register.assert_called_once()
 
 
@@ -741,7 +762,7 @@ async def test_setup_brokers_default_broker_from_config() -> None:
             AsyncMock(return_value=mock_registry),
         ),
         patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
-        patch("open_stocks_mcp.server.app.SchwabBroker", MagicMock()),
+        patch("open_stocks_mcp.server.app.build_broker", return_value=MagicMock()),
     ):
         await setup_brokers(None, None, config=config)
 
@@ -750,7 +771,7 @@ async def test_setup_brokers_default_broker_from_config() -> None:
 
 @pytest.mark.asyncio
 async def test_setup_brokers_disabled_broker_skipped_even_with_creds() -> None:
-    """Brokers not in enabled_brokers are not registered even if credentials exist."""
+    """Brokers not in enabled_brokers are not built, even if credentials exist."""
     config = ServerConfig(
         brokers=BrokerSettings(
             enabled_brokers=["schwab"],
@@ -759,8 +780,11 @@ async def test_setup_brokers_disabled_broker_skipped_even_with_creds() -> None:
         )
     )
     mock_registry = MagicMock()
-    mock_rh_cls = MagicMock()
-    mock_schwab_cls = MagicMock()
+    called_names: list[str] = []
+
+    def _fake_build(name, ctx):
+        called_names.append(name)
+        return MagicMock()
 
     with (
         patch(
@@ -768,13 +792,12 @@ async def test_setup_brokers_disabled_broker_skipped_even_with_creds() -> None:
             AsyncMock(return_value=mock_registry),
         ),
         patch("open_stocks_mcp.server.app.attempt_broker_logins", AsyncMock()),
-        patch("open_stocks_mcp.server.app.RobinhoodBroker", mock_rh_cls),
-        patch("open_stocks_mcp.server.app.SchwabBroker", mock_schwab_cls),
+        patch("open_stocks_mcp.server.app.build_broker", side_effect=_fake_build),
     ):
         await setup_brokers(None, None, config=config)
 
-    mock_rh_cls.assert_not_called()
-    mock_schwab_cls.assert_called_once()
+    assert "robinhood" not in called_names
+    assert "schwab" in called_names
 
 
 def test_main_debug_flag_passes_debug_config_to_server() -> None:

--- a/tests/unit/test_broker_factory.py
+++ b/tests/unit/test_broker_factory.py
@@ -1,0 +1,161 @@
+"""Tests for the pluggable broker factory registry."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from open_stocks_mcp.brokers.base import BaseBroker, BrokerAuthStatus
+from open_stocks_mcp.brokers.factory import (
+    _BROKER_FACTORIES,
+    BrokerBuildContext,
+    build_broker,
+    get_registered_broker_names,
+    is_broker_factory_registered,
+    register_broker_factory,
+)
+
+
+class _DummyBroker(BaseBroker):
+    """Minimal broker for testing."""
+
+    def __init__(self, name: str = "dummy"):
+        super().__init__(name)
+        self._auth_info.status = BrokerAuthStatus.AUTHENTICATED
+
+    async def authenticate(self) -> bool:
+        return True
+
+    async def is_authenticated(self) -> bool:
+        return True
+
+    async def logout(self) -> None:
+        pass
+
+    async def get_account_info(self) -> dict[str, Any]:
+        return {"result": {}}
+
+    async def get_portfolio(self) -> dict[str, Any]:
+        return {"result": {}}
+
+    async def get_positions(self) -> dict[str, Any]:
+        return {"result": {}}
+
+    async def get_stock_quote(self, symbol: str) -> dict[str, Any]:
+        return {"result": {}}
+
+    async def get_stock_price(self, symbol: str) -> dict[str, Any]:
+        return {"result": {}}
+
+    async def order_buy_market(self, symbol: str, quantity: float) -> dict[str, Any]:
+        return {"result": {}}
+
+    async def order_sell_market(self, symbol: str, quantity: float) -> dict[str, Any]:
+        return {"result": {}}
+
+
+@pytest.fixture(autouse=True)
+def _clean_test_factories():
+    """Remove test-only factories registered during each test."""
+    before = set(_BROKER_FACTORIES.keys())
+    yield
+    for key in list(_BROKER_FACTORIES.keys()):
+        if key not in before:
+            del _BROKER_FACTORIES[key]
+
+
+@pytest.mark.unit
+def test_register_and_lookup():
+    called_with: list[BrokerBuildContext] = []
+
+    def factory(ctx: BrokerBuildContext) -> _DummyBroker | None:
+        called_with.append(ctx)
+        return _DummyBroker("test_broker")
+
+    register_broker_factory("test_broker", factory)
+
+    assert is_broker_factory_registered("test_broker")
+    assert "test_broker" in get_registered_broker_names()
+
+    config = MagicMock()
+    ctx = BrokerBuildContext(config=config)
+    result = build_broker("test_broker", ctx)
+
+    assert isinstance(result, _DummyBroker)
+    assert len(called_with) == 1
+    assert called_with[0] is ctx
+
+
+@pytest.mark.unit
+def test_build_broker_unknown_returns_none():
+    result = build_broker("__no_such_broker__", BrokerBuildContext(config=MagicMock()))
+    assert result is None
+
+
+@pytest.mark.unit
+def test_is_broker_factory_registered_false_for_unknown():
+    assert not is_broker_factory_registered("__no_such_broker__")
+
+
+@pytest.mark.unit
+def test_factory_returning_none_propagates():
+    register_broker_factory("returns_none", lambda ctx: None)
+    result = build_broker("returns_none", BrokerBuildContext(config=MagicMock()))
+    assert result is None
+
+
+@pytest.mark.unit
+def test_register_normalizes_to_lowercase():
+    register_broker_factory("MyBroker", lambda ctx: _DummyBroker())
+    assert is_broker_factory_registered("mybroker")
+    assert is_broker_factory_registered("MYBROKER")
+    assert "mybroker" in get_registered_broker_names()
+
+
+@pytest.mark.unit
+def test_builtin_brokers_are_registered():
+    """Importing broker modules triggers their factory registrations."""
+    import open_stocks_mcp.brokers.robinhood
+    import open_stocks_mcp.brokers.schwab  # noqa: F401
+
+    assert is_broker_factory_registered("robinhood")
+    assert is_broker_factory_registered("schwab")
+
+
+@pytest.mark.unit
+def test_third_party_broker_can_register_without_modifying_server_code():
+    """Demonstrate the pluggable pattern: register a new broker at import time."""
+    factory_called = False
+
+    def alpaca_factory(ctx: BrokerBuildContext) -> _DummyBroker | None:
+        nonlocal factory_called
+        factory_called = True
+        return _DummyBroker("alpaca")
+
+    register_broker_factory("alpaca", alpaca_factory)
+
+    assert is_broker_factory_registered("alpaca")
+    broker = build_broker("alpaca", BrokerBuildContext(config=MagicMock()))
+    assert isinstance(broker, _DummyBroker)
+    assert factory_called
+
+
+@pytest.mark.unit
+def test_broker_build_context_cli_credentials():
+    received: list[dict[str, str]] = []
+
+    def factory(ctx: BrokerBuildContext) -> None:
+        received.append(dict(ctx.cli_credentials))
+        return None
+
+    register_broker_factory("cred_test", factory)
+
+    config = MagicMock()
+    ctx = BrokerBuildContext(
+        config=config, cli_credentials={"username": "bob", "password": "secret"}
+    )
+    build_broker("cred_test", ctx)
+
+    assert received == [{"username": "bob", "password": "secret"}]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -458,13 +458,14 @@ def test_enabled_brokers_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.journey_system
-def test_enabled_brokers_unknown_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_enabled_brokers_non_builtin_kept(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-built-in broker names are kept so third-party factory plugins can use them."""
     monkeypatch.setenv("ENABLED_BROKERS", "bogus,robinhood")
 
     cfg = load_config(config_path=Path("/tmp/definitely-missing-config.yaml"))
 
-    assert cfg.brokers.enabled_brokers == ["robinhood"]
-    assert "bogus" not in cfg.brokers.enabled_brokers
+    assert "robinhood" in cfg.brokers.enabled_brokers
+    assert "bogus" in cfg.brokers.enabled_brokers
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #996

## Changes

- **New `src/open_stocks_mcp/brokers/factory.py`**: Broker factory registry with `BrokerBuildContext`, `register_broker_factory()`, `build_broker()`, and `is_broker_factory_registered()`. Built-in factories for Robinhood and Schwab are registered at module-load time using lazy imports to avoid pulling the full broker dependency chain eagerly.

- **`server/app.py`**: `setup_brokers()` now iterates `enabled_brokers` and dispatches through the factory registry instead of hard-coding `if "robinhood" in enabled: ... if "schwab" in enabled: ...`. Removed `KNOWN_BROKERS`, `_parse_enabled_brokers()`, and `_apply_default_broker()` dead code.

- **`config.py`**: `_parse_enabled_brokers_config()` now passes non-built-in broker names through (warn but keep) instead of dropping them, so third-party broker plugins can be enabled via `ENABLED_BROKERS` without modifying config.py. Renamed `_KNOWN_BROKERS` → `_BUILTIN_BROKERS` to reflect its advisory-only role.

- **New `tests/unit/test_broker_factory.py`**: 8 tests covering registration, lookup, third-party plugin pattern, CLI credential context, and built-in broker auto-registration.

- **`tests/unit/test_config.py`**: Updated `test_enabled_brokers_unknown_dropped` → `test_enabled_brokers_non_builtin_kept` to match new pass-through behavior.

- **`tests/server/test_server_app.py`**: Updated 13 tests that patched the now-removed `RobinhoodBroker`/`SchwabBroker` directly in `app.py` to instead patch `build_broker` at the right level.

## Adding a new broker (e.g. Alpaca)

No changes to core server code are required. Just:
```python
from open_stocks_mcp.brokers.factory import register_broker_factory, BrokerBuildContext

class AlpacaBroker(BaseBroker): ...

def _build_alpaca(ctx: BrokerBuildContext) -> AlpacaBroker | None:
    api_key = ctx.config.brokers.alpaca.api_key  # or ctx.cli_credentials
    if not api_key:
        return None
    return AlpacaBroker(api_key=api_key)

register_broker_factory("alpaca", _build_alpaca)
```

Then set `ENABLED_BROKERS=alpaca` and the server will pick it up.

## Test plan
- `uv run pytest tests/unit/test_broker_factory.py` → 8 passed
- `uv run pytest tests/unit/test_config.py` → 40 passed
- `uv run pytest tests/server/test_server_app.py` → 38 passed
- `uv run pytest tests/unit/ -m "not slow and not exception_test"` → 1361 passed
- `uv run ruff check . && uv run ruff format --check .` → clean
- `uv run mypy src/open_stocks_mcp/brokers/factory.py src/open_stocks_mcp/config.py src/open_stocks_mcp/server/app.py` → Success